### PR TITLE
fix: bump llama-cpp-2 to 0.1.137 (Metal segfault on macOS 26)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ tiktoken-rs = "0.9.1"
 
 # Memory Search (FTS5 + vector search)
 qmd = "0.3"
-llama-cpp-2 = "0.1.134"
+llama-cpp-2 = "0.1.137"
 
 
 


### PR DESCRIPTION
## Summary

- Bump `llama-cpp-2` from `0.1.134` to `0.1.137` to fix a Metal backend segfault

## Details

`llama-cpp-2` v0.1.136 segfaults in `ggml_metal_buffer_is_shared` (null pointer dereference at address 0x10) during embedding model initialization on macOS 26.3 (Tahoe) / arm64. The crash occurs in `llama_context::llama_context` → `llama_init_from_model` on a tokio runtime worker thread.

v0.1.137 fixes this Metal backend issue.

## Test plan

- [x] Verified crash reproduces on macOS 26.3 arm64 with v0.1.134/0.1.136
- [x] Verified crash is fixed with v0.1.137
- [x] `cargo build --release` succeeds
- [x] `cargo test` passes (516/517, 1 pre-existing failure unrelated)