### PR TITLE
docs: add TweetClaw companion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,4 +160,4 @@ A well-written bug report or feature request is worth more than a stub PR. Serio
 
 ## License
 
-By contributing to OpenCrabs, you agree that your contributions will be licensed under the MIT License. See [LICENSE](LICENSE) for details.
+By contributing to OpenCrabs, you agree that your contributions will be licensed under the MIT License. See [LICENSE.md](LICENSE.md) for details.

--- a/README.md
+++ b/README.md
@@ -3047,6 +3047,17 @@ node dist/cli.js linkedin engage --query="query"   # Full engagement session
 
 **Features:** Human-like behavior (randomized delays, natural typing), session persistence across restarts, built-in rate limiting, anti-detection, research-first workflow (scrape targets first, distribute engagement over time).
 
+### TweetClaw - OpenClaw X/Twitter Plugin
+
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) is an optional [OpenClaw](https://github.com/openclaw/openclaw) plugin for X/Twitter automation through [Xquik](https://xquik.com). Use it when an OpenClaw agent needs to scrape tweets, search tweets or replies, post tweets or replies, export followers, look up users, manage media, send direct messages, monitor tweets, receive webhooks, or run giveaway draws.
+
+**Install in OpenClaw:**
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+**Usage with OpenCrabs:** Keep OpenCrabs focused on local Rust sessions and channel orchestration. Pass tweet URLs, search summaries, or reviewed action decisions between OpenCrabs and an OpenClaw workspace that has TweetClaw configured.
+
 ---
 
 ## ⚠️ Disclaimers


### PR DESCRIPTION
## Summary
- Add TweetClaw as an optional OpenClaw companion under README Companion Tools for X/Twitter workflows.
- Fix the CONTRIBUTING license link to point at LICENSE.md.

## Checks
- Duplicate searched OpenCrabs issues and PRs for TweetClaw, Xquik, package URL variants, and spelling variants.
- Ran git diff --check.
- Checked the new GitHub, OpenClaw, Xquik, and LICENSE.md links with curl HEAD.
- Ran cargo fmt --all -- --check.