### PR TITLE
fix: escape single quotes in dynamic shell tool params

### DIFF
--- a/src/brain/rsi.rs
+++ b/src/brain/rsi.rs
@@ -281,7 +281,7 @@ Your job is to write improvements that PREVENT these from recurring:
 2. **Decide action**: After reading:
    - If the file has NO existing instruction covering your improvement → use action='apply' to append.
    - If the file ALREADY has an instruction that covers the same topic but needs refinement → use action='update' with the exact old_content copied from what you just read, and your improved content in 'content'.
-   - If the file already covers the topic AND the feedback shows a FRESH repeat violation (new incident since the rule was written) → use action='update' to reinforce: append the new date/incident as evidence, and tighten the wording if the model keeps slipping past it. Do NOT bump inline counters — see \"Reinforcing Repeat Violations\" below.
+   - If the file already covers the topic AND the feedback shows a FRESH repeat violation (new incident since the rule was written) → use action='update' to reinforce: append the new date/incident as evidence, and tighten the wording if the model keeps slipping past it. Do NOT bump inline counters — see \"Reinforcing Repeat Violations\" below. 
    Repeat violations of an existing rule are NOT a 'covered, skip' case — they signal the rule needs reinforcement.
    - If the file already says what you want to say AND there is no fresh evidence of new violations → SKIP. Do not duplicate.
 3. **Never rewrite the whole file**. The 'update' action replaces ONE specific section/paragraph. \

--- a/src/brain/tools/dynamic/tool.rs
+++ b/src/brain/tools/dynamic/tool.rs
@@ -188,6 +188,29 @@ impl DynamicToolDef {
         }
         result
     }
+
+    /// Escape string values in params for use in single-quoted shell
+    /// arguments. Replaces each `'` with `'\''` (end single-quote,
+    /// escaped single-quote, resume single-quote) — the standard POSIX
+    /// shell idiom for embedding a single quote inside a single-quoted
+    /// string.
+    ///
+    /// Non-string values (numbers, booleans, arrays, objects) pass
+    /// through unchanged — they are already safe for shell usage since
+    /// `render_template` converts them with `to_string()`.
+    pub fn shell_escape_params(params: &Value) -> Value {
+        match params {
+            Value::Object(map) => {
+                let mut out = serde_json::Map::new();
+                for (k, v) in map {
+                    out.insert(k.clone(), Self::shell_escape_params(v));
+                }
+                Value::Object(out)
+            }
+            Value::String(s) => Value::String(s.replace('\'', "'\\''")),
+            other => other.clone(),
+        }
+    }
 }
 
 /// Top-level tools.toml structure.
@@ -321,8 +344,12 @@ impl DynamicTool {
         params: &Value,
         context: &ToolExecutionContext,
     ) -> Result<ToolResult> {
+        // Shell-escape string parameter values so single quotes in
+        // values don't break single-quoted shell arguments like
+        // `--string 'message={{message}}'`.
+        let escaped_params = DynamicToolDef::shell_escape_params(params);
         let cmd = match &self.def.command {
-            Some(c) => DynamicToolDef::render_template(c, params),
+            Some(c) => DynamicToolDef::render_template(c, &escaped_params),
             None => {
                 return Ok(ToolResult::error(
                     "Shell tool missing 'command' field".into(),
@@ -603,5 +630,96 @@ url = "https://example.com/health"
         });
         let result = t.execute(serde_json::json!({}), &ctx()).await.unwrap();
         assert!(!result.success);
+    }
+
+    #[test]
+    fn test_shell_escape_params_noop() {
+        // No single quotes — values pass through unchanged
+        let params = serde_json::json!({"msg": "hello world"});
+        let escaped = DynamicToolDef::shell_escape_params(&params);
+        assert_eq!(escaped["msg"], "hello world");
+    }
+
+    #[test]
+    fn test_shell_escape_params_single_quote() {
+        // Single quote in value gets escaped
+        let params = serde_json::json!({"msg": "it's nice"});
+        let escaped = DynamicToolDef::shell_escape_params(&params);
+        assert_eq!(escaped["msg"], "it'\\''s nice");
+    }
+
+    #[test]
+    fn test_shell_escape_params_multiple_quotes() {
+        // Multiple single quotes
+        let params = serde_json::json!({"msg": "'a' 'b'"});
+        let escaped = DynamicToolDef::shell_escape_params(&params);
+        assert_eq!(escaped["msg"], "'\\''a'\\'' '\\''b'\\''");
+    }
+
+    #[test]
+    fn test_shell_escape_params_nested() {
+        // Nested object values are also escaped
+        let params = serde_json::json!({"outer": {"inner": "it's nested"}});
+        let escaped = DynamicToolDef::shell_escape_params(&params);
+        assert_eq!(escaped["outer"]["inner"], "it'\\''s nested");
+    }
+
+    #[test]
+    fn test_shell_escape_params_non_string() {
+        // Numbers, booleans, null pass through unchanged
+        let params = serde_json::json!({"n": 42, "b": true, "x": null});
+        let escaped = DynamicToolDef::shell_escape_params(&params);
+        assert_eq!(escaped["n"], 42);
+        assert_eq!(escaped["b"], true);
+        assert_eq!(escaped["x"], serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    async fn test_execute_shell_with_single_quote() {
+        // Message with single quote — escaped params prevent shell breakage
+        let result = make_shell(
+            "echo_test",
+            "echo 'msg={{msg}}'",
+            vec![ParamDef {
+                name: "msg".into(),
+                param_type: "string".into(),
+                description: "".into(),
+                required: true,
+                default: None,
+                coerce_empty_to: Default::default(),
+                coerce_null_to: Default::default(),
+            }],
+        )
+        .execute(serde_json::json!({"msg": "it's nice"}), &ctx())
+        .await
+        .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("msg=it's nice"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_shell_newlines() {
+        // Multi-line message — newlines survive single-quoted shell arg
+        let result = make_shell(
+            "echo_test",
+            "echo 'msg={{msg}}'",
+            vec![ParamDef {
+                name: "msg".into(),
+                param_type: "string".into(),
+                description: "".into(),
+                required: true,
+                default: None,
+                coerce_empty_to: Default::default(),
+                coerce_null_to: Default::default(),
+            }],
+        )
+        .execute(
+            serde_json::json!({"msg": "line1\nline2"}),
+            &ctx(),
+        )
+        .await
+        .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("line1\nline2") || result.output.contains("line1\nline2"));
     }
 }


### PR DESCRIPTION
## Problem

Parameter values containing single quotes (`'`) produce garbled output.

## Fix

Handle single quotes in parameter values to prevent output corruption.