### PR TITLE
fix: replace hardcoded ~/.opencrabs/ paths with profile-aware opencrabs_home()

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/src/brain/prompt_builder.rs
+++ b/src/brain/prompt_builder.rs
@@ -635,17 +635,21 @@ fn push_skills_section(prompt: &mut String) {
 /// question stays out; the goal is "next time you're told 'check
 /// the logs' you don't grep .git/".
 pub(crate) fn push_known_paths(prompt: &mut String) {
-    prompt.push_str(
-        "\nKnown paths (under ~/.opencrabs/):\n\
-         - Logs: ~/.opencrabs/logs/opencrabs.YYYY-MM-DD (daily, today is the most relevant)\n\
-         - Config: ~/.opencrabs/config.toml\n\
-         - Keys: ~/.opencrabs/keys.toml\n\
-         - Brain files: ~/.opencrabs/{SOUL,USER,AGENTS,TOOLS,MEMORY,CODE}.md\n\
-         - Plans: ~/.opencrabs/agents/session/.opencrabs_plan_<session-id>.json\n\
+    let base = crate::config::profile::base_opencrabs_dir();
+    let home = crate::config::opencrabs_home();
+    prompt.push_str(&format!(
+        "\nKnown paths:\n\
+         - Logs: {base}/logs/opencrabs.YYYY-MM-DD (daily, today is the most relevant)\n\
+         - Config: {base}/config.toml\n\
+         - Keys: {base}/keys.toml\n\
+         - Brain files: {home}/{{SOUL,USER,AGENTS,TOOLS,MEMORY,CODE}}.md\n\
+         - Plans: {home}/agents/session/.opencrabs_plan_<session-id>.json\n\
          When the user asks to check logs, read today's file at \
-         ~/.opencrabs/logs/opencrabs.<today UTC date>. Do NOT grep the repo \
+         {base}/logs/opencrabs.<today UTC date>. Do NOT grep the repo \
          working directory for log files — opencrabs never writes logs there.\n",
-    );
+        base = base.display(),
+        home = home.display(),
+    ));
 }
 
 #[cfg(test)]

--- a/src/brain/provider/codex_oauth.rs
+++ b/src/brain/provider/codex_oauth.rs
@@ -53,8 +53,7 @@ const SCOPES: &str =
 
 /// Path to the token storage file.
 fn token_path() -> std::path::PathBuf {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    home.join(".opencrabs").join("auth").join("codex.json")
+    crate::config::opencrabs_home().join("auth").join("codex.json")
 }
 
 // ─── Token Storage ───────────────────────────────────────────────────────────

--- a/src/utils/file_extract.rs
+++ b/src/utils/file_extract.rs
@@ -191,8 +191,7 @@ fn is_video_vision_available(config: &Config) -> bool {
 
 /// Write file bytes to a temp path under `~/.opencrabs/tmp/files/` and return the path.
 fn save_to_temp(bytes: &[u8], filename: &str) -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("No home directory found")?;
-    let tmp_dir = home.join(".opencrabs").join("tmp").join("files");
+    let tmp_dir = crate::config::opencrabs_home().join("tmp").join("files");
     fs::create_dir_all(&tmp_dir).map_err(|e| format!("Failed to create temp dir: {e}"))?;
 
     let safe_name = filename


### PR DESCRIPTION
Fixes three hardcoded `~/.opencrabs/` paths that bypass named profile isolation:

### Changes

1. **`src/utils/file_extract.rs`** — `save_to_temp()` used `dirs::home_dir().join('.opencrabs')` instead of `opencrabs_home()`, so temp files bypassed profile isolation.

2. **`src/brain/provider/codex_oauth.rs`** — `token_path()` same pattern: OAuth tokens always went to `~/.opencrabs/auth/codex.json` regardless of active profile.

3. **`src/brain/prompt_builder.rs`** — `push_known_paths()` hardcoded `'~/.opencrabs/'` in the LLM prompt for ALL paths. Logs/config/keys are global (use `base_opencrabs_dir()`), brain files and plans are per-profile (use `opencrabs_home()`). LLM now sees correct paths for the active profile.

### Discussion needed (issue pending)

- `src/brain/tools/subagent/status.rs` — subagent status dir uses hardcoded global path (might need per-profile isolation)
- `src/brain/tools/dynamic/loader.rs` — tools.toml is loaded from global path, profile-specific tools.toml is ignored by runtime