### PR TITLE
fix(team): add missing mark_awaiting_input in team agent spawn loop

### DIFF
--- a/src/brain/tools/subagent/resume.rs
+++ b/src/brain/tools/subagent/resume.rs
@@ -235,6 +235,14 @@ impl Tool for ResumeAgentTool {
                 match result {
                     Ok(response) => {
                         manager.update_output(&agent_id_clone, response.content.clone());
+                        // Flip to AwaitingInput so wait_agent can observe
+                        // round-boundary progress — same pattern as
+                        // spawn.rs / team/create.rs. Without this the
+                        // resumed agent's task never terminates at a
+                        // round (only on input/cancel), so the old
+                        // `handle.await` in wait.rs always hit its
+                        // timeout_secs and the LLM gave up the turn.
+                        manager.mark_awaiting_input(&agent_id_clone);
                         tracing::info!(
                             "Sub-agent {} round complete, waiting for input",
                             agent_id_clone
@@ -242,7 +250,13 @@ impl Tool for ResumeAgentTool {
 
                         let next = tokio::select! {
                             msg = input_rx.recv() => msg,
-                            _ = cancel_clone.cancelled() => None,
+                            _ = cancel_clone.cancelled() => {
+                                tracing::info!(
+                                    "Sub-agent {} cancelled while waiting for input",
+                                    agent_id_clone
+                                );
+                                None
+                            }
                         };
 
                         match next {

--- a/src/brain/tools/subagent/team/create.rs
+++ b/src/brain/tools/subagent/team/create.rs
@@ -256,10 +256,20 @@ impl Tool for TeamCreateTool {
                     match result {
                         Ok(response) => {
                             manager.update_output(&agent_id_clone, response.content.clone());
+                            // Flip to AwaitingInput so wait_agent can observe
+                            // round-boundary progress (same pattern as spawn.rs).
+                            manager.mark_awaiting_input(&agent_id_clone);
+                            tracing::info!(
+                                "Team agent {} round complete, waiting for input",
+                                agent_id_clone
+                            );
 
                             let next = tokio::select! {
                                 msg = input_rx.recv() => msg,
-                                _ = cancel_clone.cancelled() => None,
+                                _ = cancel_clone.cancelled() => {
+                                    tracing::info!("Team agent {} cancelled while waiting for input", agent_id_clone);
+                                    None
+                                }
                             };
 
                             match next {


### PR DESCRIPTION
Team-created agents never called `mark_awaiting_input()` after completing a round, so `wait_agent` could never observe round-boundary progress — it kept polling until timeout, always reporting "still running" even though the agent had produced output and was waiting for follow-up input.

This mirrors the pattern in `spawn.rs` (spawn_agent): after `manager.update_output()`, flip to `AwaitingInput` state. This lets `wait_agent` return the round output immediately instead of blocking on task-join semantics (the agent task never terminates at a round — only on input/cancel).

Also added the same `tracing::info!` logs that `spawn.rs` has for consistency (round-complete and cancelled-while-waiting).

Fixes: team-created agents never completing from `wait_agent` perspective.