### PR TITLE
fix(evolve): check user-level systemd units when scheduling restart

### DIFF
--- a/src/brain/tools/evolve.rs
+++ b/src/brain/tools/evolve.rs
@@ -81,25 +81,44 @@ pub(crate) const SYSTEMD_UNIT_PATTERN: &str = "opencrabs*.service";
 /// these flags would re-introduce the "Evolved! but daemon didn't
 /// restart" symptom that issue #136 reported.
 ///
+/// Set `user` to `true` to target user-level units (`systemctl --user`),
+/// e.g. when OpenCrabs was installed via `install_systemd_service()` which
+/// writes to `~/.config/systemd/user/`.
+///
 /// The `pid` argument is used to derive a unique transient unit
 /// name (`opencrabs-evolve-<pid>`) so concurrent evolve calls don't
 /// collide on the transient unit registry.
-pub(crate) fn build_systemd_restart_command(pid: u32) -> std::process::Command {
+pub(crate) fn build_systemd_restart_command(pid: u32, user: bool) -> std::process::Command {
     let unit_name = format!("opencrabs-evolve-{pid}");
     let mut cmd = std::process::Command::new("systemd-run");
-    cmd.args([
-        "--on-active=3",
-        &format!("--unit={unit_name}"),
-        "systemctl",
-        "restart",
-        SYSTEMD_UNIT_PATTERN,
-    ])
-    .stdout(std::process::Stdio::null())
-    .stderr(std::process::Stdio::null());
+    let mut args = vec![];
+    // --user on systemd-run itself is required when the daemon runs as a
+    // user service: without it, systemd-run tries to talk to the system
+    // bus and either fails (no permission from within a --user service)
+    // or creates the transient timer in the system instance, where the
+    // spawned systemctl won't have DBUS_SESSION_BUS_ADDRESS available.
+    if user {
+        args.push("--user".to_string());
+    }
+    args.push("--on-active=3".to_string());
+    args.push(format!("--unit={unit_name}"));
+    args.push("systemctl".to_string());
+    // --user on systemctl is needed to target the user service manager.
+    if user {
+        args.push("--user".to_string());
+    }
+    args.push("restart".to_string());
+    args.push(SYSTEMD_UNIT_PATTERN.to_string());
+    cmd.args(&args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
     cmd
 }
 
-/// Count systemd service units matching the given glob pattern.
+/// Count systemd service units matching the given glob pattern, at either
+/// system or user level.
+///
+/// Set `user` to `true` to query user-level units (`systemctl --user`).
 ///
 /// Returns `Some(n)` on a successful query (n may be zero), or
 /// `None` if `systemctl` failed to spawn / returned a non-zero exit
@@ -110,12 +129,15 @@ pub(crate) fn build_systemd_restart_command(pid: u32) -> std::process::Command {
 /// Uses `--no-legend --no-pager` to keep stdout machine-parseable.
 /// Counts non-empty lines — `systemctl` prints one line per matched
 /// unit when `--no-legend` is set.
-pub(crate) fn count_matching_systemd_units(pattern: &str) -> Option<usize> {
-    let output = std::process::Command::new("systemctl")
-        .args(["list-units", "--no-legend", "--no-pager", pattern])
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
+pub(crate) fn count_matching_systemd_units(pattern: &str, user: bool) -> Option<usize> {
+    let mut cmd = std::process::Command::new("systemctl");
+    cmd.args(["list-units", "--no-legend", "--no-pager"]);
+    if user {
+        cmd.arg("--user");
+    }
+    cmd.arg(pattern);
+    cmd.stderr(std::process::Stdio::null());
+    let output = cmd.output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -996,16 +1018,43 @@ impl EvolveTool {
         // never restarts) but for a different reason (unit name
         // mismatch instead of missing restart). Skip the spawn and
         // tell the user honestly.
+        //
+        // OpenCrabs is commonly installed as a user-level systemd service
+        // (`systemctl --user`), so if system-level units return 0 we
+        // fall through and check user-level units too.
         let mut restart_status = RestartStatus::NotSystemd;
+        let mut use_user_units = false;
         if std::path::Path::new("/run/systemd/system").exists() {
-            let unit_count = count_matching_systemd_units(SYSTEMD_UNIT_PATTERN);
+            let mut unit_count = count_matching_systemd_units(SYSTEMD_UNIT_PATTERN, false);
+            if unit_count == Some(0) {
+                // No system-level units matched — try user-level.
+                // OpenCrabs's `install_systemd_service()` writes to
+                // ~/.config/systemd/user/ and uses `systemctl --user`.
+                let user_count = count_matching_systemd_units(SYSTEMD_UNIT_PATTERN, true);
+                match user_count {
+                    Some(n) if n > 0 => {
+                        use_user_units = true;
+                        unit_count = Some(n);
+                        tracing::info!(
+                            target: "evolve",
+                            pattern = SYSTEMD_UNIT_PATTERN,
+                            user_units = n,
+                            session_id = %sid,
+                            "evolve: no system-level units found, using {n} user-level units — scheduling restart with --user"
+                        );
+                    }
+                    _ => {
+                        // Still 0 or None — keep unit_count as Some(0)
+                    }
+                }
+            }
             match unit_count {
                 Some(0) => {
                     tracing::warn!(
                         target: "evolve",
                         pattern = SYSTEMD_UNIT_PATTERN,
                         session_id = %sid,
-                        "evolve: no systemd units matched the pattern — skipping scheduled restart"
+                        "evolve: no systemd units matched the pattern (checked system and user level) — skipping scheduled restart"
                     );
                     restart_status = RestartStatus::NoUnitsMatched;
                 }
@@ -1020,6 +1069,7 @@ impl EvolveTool {
                             target: "evolve",
                             pattern = SYSTEMD_UNIT_PATTERN,
                             matched_units = n,
+                            use_user_units,
                             session_id = %sid,
                             "evolve: pre-flight found matching systemd units, scheduling restart (+3s)"
                         );
@@ -1042,7 +1092,7 @@ impl EvolveTool {
                     // forensic evidence when "evolve said success but
                     // didn't restart" happens — exactly the symptom this
                     // whole code path was added to prevent (#136).
-                    match build_systemd_restart_command(pid).spawn() {
+                    match build_systemd_restart_command(pid, use_user_units).spawn() {
                         Ok(child) => {
                             tracing::info!(
                                 target: "evolve",
@@ -1060,7 +1110,8 @@ impl EvolveTool {
                                 error = %e,
                                 session_id = %sid,
                                 "evolve: failed to spawn systemd-run — daemon will NOT auto-restart, \
-                                 manual `systemctl restart opencrabs*.service` is required to load the new binary"
+                                 manual `systemctl restart opencrabs*.service` (or `systemctl --user restart` \
+                                 for user services) is required to load the new binary"
                             );
                             restart_status = RestartStatus::SpawnFailed(e.to_string());
                         }
@@ -1122,14 +1173,18 @@ impl RestartStatus {
             ),
             RestartStatus::NoUnitsMatched => format!(
                 "Evolved from v{current} to v{latest}. Binary updated on disk, but no \
-                 systemd units matched `{SYSTEMD_UNIT_PATTERN}` — your daemon (if any) was \
-                 not restarted. Restart it manually with `systemctl restart <your-unit>`, \
+                 systemd units matched `{SYSTEMD_UNIT_PATTERN}` at system or user level \
+                 — your daemon (if any) was not restarted. Restart it manually with \
+                 `systemctl --user restart {SYSTEMD_UNIT_PATTERN}` (if installed as a \
+                 user service) or `systemctl restart <your-unit>` (if a system service), \
                  or relaunch if running standalone."
             ),
             RestartStatus::SpawnFailed(err) => format!(
                 "Evolved from v{current} to v{latest}. Binary updated on disk, but \
                  scheduling the systemd restart failed ({err}). Restart your daemon \
-                 manually with `systemctl restart {SYSTEMD_UNIT_PATTERN}`."
+                 manually with `systemctl --user restart {SYSTEMD_UNIT_PATTERN}` \
+                 (if a user service) or `systemctl restart {SYSTEMD_UNIT_PATTERN}` \
+                 (if a system service)."
             ),
         }
     }

--- a/src/tests/evolve_systemd_restart_test.rs
+++ b/src/tests/evolve_systemd_restart_test.rs
@@ -38,7 +38,7 @@ fn unit_pattern_is_glob_so_multiple_profiles_match() {
 
 #[test]
 fn restart_command_uses_systemd_run_binary() {
-    let cmd = build_systemd_restart_command(12345);
+    let cmd = build_systemd_restart_command(12345, false);
     assert_eq!(
         cmd.get_program(),
         "systemd-run",
@@ -48,8 +48,8 @@ fn restart_command_uses_systemd_run_binary() {
 }
 
 #[test]
-fn restart_command_args_are_pinned() {
-    let cmd = build_systemd_restart_command(12345);
+fn restart_command_system_level_args_are_pinned() {
+    let cmd = build_systemd_restart_command(12345, false);
     let args: Vec<String> = cmd
         .get_args()
         .map(|a| a.to_string_lossy().to_string())
@@ -63,7 +63,7 @@ fn restart_command_args_are_pinned() {
             "restart",
             "opencrabs*.service",
         ],
-        "arg list must not drift — each flag's removal or rename re-introduces \
+        "system-level (user=false) arg list must not drift — each flag's removal or rename re-introduces \
          a known regression mode: --on-active=3 = the 3s delivery window, \
          --unit=... = the PID-derived name that avoids concurrent-evolve collisions, \
          opencrabs*.service = the multi-profile glob. \
@@ -74,13 +74,37 @@ fn restart_command_args_are_pinned() {
 }
 
 #[test]
+fn restart_command_user_level_includes_user_flag() {
+    let cmd = build_systemd_restart_command(12345, true);
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+    assert_eq!(
+        args,
+        vec![
+            "--user",
+            "--on-active=3",
+            "--unit=opencrabs-evolve-12345",
+            "systemctl",
+            "--user",
+            "restart",
+            "opencrabs*.service",
+        ],
+        "user-level (user=true) command must include --user on both systemd-run \
+         (to connect to the user bus and create the timer in the user instance) \
+         and systemctl (to target the user service manager)"
+    );
+}
+
+#[test]
 fn restart_command_unit_name_includes_pid() {
     // Concurrent evolve calls would collide on a fixed transient
     // unit name. The PID embedding makes the name unique per
     // process. Verify both that the PID appears verbatim AND that
     // different PIDs produce different names.
-    let cmd_a = build_systemd_restart_command(12345);
-    let cmd_b = build_systemd_restart_command(67890);
+    let cmd_a = build_systemd_restart_command(12345, false);
+    let cmd_b = build_systemd_restart_command(67890, false);
     let unit_a = cmd_a
         .get_args()
         .map(|a| a.to_string_lossy().to_string())
@@ -101,22 +125,9 @@ fn restart_command_unit_name_includes_pid() {
 }
 
 // ── User-message coverage for every RestartStatus branch ────────
-//
-// RestartStatus is private to evolve.rs by design (no external
-// consumer), so we exercise the message wording via the public
-// success/failure modes the tool can produce. The wording itself
-// is the contract these tests pin — drifting any branch toward the
-// generic "Restarting into the new version." string would let the
-// no-units / spawn-failed / non-systemd cases get mistaken for a
-// successful auto-restart, exactly the gap #136 was filed for.
 
 #[test]
 fn restart_status_messages_are_distinct_per_outcome() {
-    // We construct each user-message by inspecting the actual
-    // tool source rather than re-importing the private enum —
-    // these are sentinel strings, so the assertion below is a
-    // build-time anchor: if any wording is reworded to look like
-    // "Restarting…" we'll catch the regression at test time.
     let src = include_str!("../brain/tools/evolve.rs");
     assert!(
         src.contains("Restarting into the new version."),
@@ -136,5 +147,25 @@ fn restart_status_messages_are_distinct_per_outcome() {
         src.contains("scheduling the systemd restart failed"),
         "the SpawnFailed branch must quote the actual error so the user knows \
          systemd-run couldn't fire"
+    );
+}
+
+#[test]
+fn no_units_matched_message_mentions_user_flag() {
+    // The user-facing message should guide the user toward
+    // `systemctl --user restart` as well as the system variant.
+    let src = include_str!("../brain/tools/evolve.rs");
+    assert!(
+        src.contains("systemctl --user restart"),
+        "NoUnitsMatched user message must mention --user restart as an option"
+    );
+}
+
+#[test]
+fn spawn_failed_message_mentions_user_flag() {
+    let src = include_str!("../brain/tools/evolve.rs");
+    assert!(
+        src.contains("systemctl --user restart"),
+        "SpawnFailed user message must mention --user restart as an option"
     );
 }


### PR DESCRIPTION
## Problem

OpenCrabs is commonly installed as a **user-level** systemd service via `install_systemd_service()` (onboarding/config.rs), which writes to `~/.config/systemd/user/` and uses `systemctl --user enable/start`.

The evolve tool's pre-flight `count_matching_systemd_units()` only queried **system-level** systemd units (no `--user` flag), so when OpenCrabs runs as a user service the flow was:

1. `systemctl list-units --no-legend --no-pager opencrabs*.service` → 0 units (no system-level)
2. `RestartStatus::NoUnitsMatched` → no restart scheduled
3. New binary downloaded and swapped on disk ✓
4. Running daemons continue on the old deleted inode ✗

The user identifies this correctly: \"there is mismatch between how the daemons are installed by opencrabs cli and what evolve checks.\"

## Changes

- `build_systemd_restart_command(pid, user)` — new `user: bool` parameter; when `true`, injects `--user` between `systemctl` and `restart` in the `systemd-run` command
- `count_matching_systemd_units(pattern, user)` — new `user: bool` parameter; when `true`, adds `--user` to the `systemctl list-units` query
- In `evolve_via_binary_download()`: first checks system-level units; if 0, falls through to check user-level units; if user-level match found, schedules restart with `--user` flag
- User-facing messages (`NoUnitsMatched`, `SpawnFailed`) now mention both `systemctl --user restart` and system-level `systemctl restart` as manual recovery options
- Tracing log in spawn-failed handler also mentions `--user` restart option

## Testing

- Added `restart_command_user_level_includes_user_flag` — verifies `--user` appears in the arg list when `user=true`
- Added `no_units_matched_message_mentions_user_flag` and `spawn_failed_message_mentions_user_flag` — sentinel string checks for `--user restart` mentions
- Updated all existing test calls to pass explicit `user: false` (no behavioural change for system-level paths)

Closes #136 (residual: systemd user units were not covered by the original fix)