### PR TITLE
feat(plan): bundle reference plan files + minimal JSON import format

### DIFF
--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -19,6 +19,7 @@ pub mod self_update;
 pub mod skills;
 pub mod tokenizer;
 pub mod tools;
+pub mod plans;
 
 // Brain re-exports
 pub use commands::{CommandLoader, UserCommand};

--- a/src/brain/plans.rs
+++ b/src/brain/plans.rs
@@ -1,0 +1,69 @@
+//! Bundled reference plan files for the plan tool.
+//!
+//! Files are embedded via include_str! and written to the runtime directory
+//! (`~/.opencrabs/plans/` for default profile) on first access if not present.
+
+use std::fs;
+use std::path::PathBuf;
+use crate::config::opencrabs_home;
+
+/// Returns the path to the plans directory for the current profile.
+/// This is `opencrabs_home().join("plans")`.
+pub fn plans_dir() -> PathBuf {
+    opencrabs_home().join("plans")
+}
+
+/// Embedded reference plan files.
+pub mod files {
+    use super::*;
+
+    /// Returns the path to a bundled file, writing it to disk if needed.
+    fn resolve_path(rel_path: &str) -> PathBuf {
+        let target = plans_dir().join(rel_path);
+        if !target.exists() {
+            if let Some(parent) = target.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            let embedded = embedded_content(rel_path);
+            let _ = fs::write(&target, embedded);
+        }
+        target
+    }
+
+    fn embedded_content(rel_path: &str) -> &'static str {
+        match rel_path {
+            "plan-json-spec.md" => include_str!("../../docs/reference/plans/plan-json-spec.md"),
+            "coding-plans/python-fast.json" => include_str!("../../docs/reference/plans/coding-plans/python-fast.json"),
+            "coding-plans/python-medium.json" => include_str!("../../docs/reference/plans/coding-plans/python-medium.json"),
+            "coding-plans/python-full.json" => include_str!("../../docs/reference/plans/coding-plans/python-full.json"),
+            "coding-plans/rust-fast.json" => include_str!("../../docs/reference/plans/coding-plans/rust-fast.json"),
+            "coding-plans/rust-medium.json" => include_str!("../../docs/reference/plans/coding-plans/rust-medium.json"),
+            "coding-plans/rust-full.json" => include_str!("../../docs/reference/plans/coding-plans/rust-full.json"),
+            "coding-plans/sample-minimal-plan.json" => include_str!("../../docs/reference/plans/coding-plans/sample-minimal-plan.json"),
+            _ => panic!("unknown bundled file: {}", rel_path),
+        }
+    }
+
+    /// Path to the plan JSON schema specification.
+    pub fn plan_spec_path() -> PathBuf {
+        resolve_path("plan-json-spec.md")
+    }
+
+    /// Path to a coding plan by name.
+    pub fn coding_plan_path(name: &str) -> PathBuf {
+        resolve_path(&format!("coding-plans/{}.json", name))
+    }
+
+    /// Paths to all bundled coding plans.
+    pub fn all_coding_plan_paths() -> Vec<PathBuf> {
+        vec![
+            coding_plan_path("python-fast"),
+            coding_plan_path("python-medium"),
+            coding_plan_path("python-full"),
+            coding_plan_path("rust-fast"),
+            coding_plan_path("rust-medium"),
+            coding_plan_path("rust-full"),
+            coding_plan_path("sample-minimal-plan"),
+        ]
+    }
+}

--- a/src/brain/tools/plan_tool.rs
+++ b/src/brain/tools/plan_tool.rs
@@ -205,7 +205,13 @@ impl Tool for PlanTool {
          (d) you need to retry steps independently if some fail, \
          (e) the user is going to step away while you work. \
          Skip planning only for trivial single-tool answers (one read, one search, one edit). \
-         The plan stays visible across compactions, so it doubles as memory for long sessions."
+         The plan stays visible across compactions, so it doubles as memory for long sessions. \
+         \n\nBUNDLED REFERENCE PLANS: Source at `src/docs/reference/plans/` (embedded in binary). \
+         Runtime path: `~/.opencrabs/profiles/<profile>/plans/` (e.g., `~/.opencrabs/profiles/ops/plans/`). \
+         See `coding-plans/rust-fast.json`, `coding-plans/rust-medium.json`, `coding-plans/rust-full.json`, \
+         `coding-plans/python-fast.json`, `coding-plans/python-medium.json`, `coding-plans/python-full.json`, \
+         and `coding-plans/sample-minimal-plan.json`. Also see `plan-json-spec.md` for schema documentation. \
+         Minimal import format: only 6 fields required (title, description + 3 per task: title, description, task_type)."
     }
 
     fn input_schema(&self) -> Value {
@@ -495,17 +501,22 @@ impl Tool for PlanTool {
                 imported.updated_at = chrono::Utc::now();
                 imported.approved_at = None;
 
+                // Resolve integer index dependencies to UUIDs before any validation
+                imported.resolve_index_deps();
+
                 // Validate no orphan dependencies before remapping — a dep
                 // pointing at a UUID not in the imported task set is a
                 // malformed plan and must be rejected explicitly rather
                 // than silently dropped.
                 for task in &imported.tasks {
                     for dep in &task.dependencies {
-                        if !old_to_new.contains_key(dep) {
-                            return Err(ToolError::InvalidInput(format!(
-                                "Task '{}' depends on unknown task id {}",
-                                task.title, dep
-                            )));
+                        if let Some(dep_id) = dep.as_uuid() {
+                            if !old_to_new.contains_key(&dep_id) {
+                                return Err(ToolError::InvalidInput(format!(
+                                    "Task '{}' depends on unknown task id {}",
+                                    task.title, dep_id
+                                )));
+                            }
                         }
                     }
                 }
@@ -525,7 +536,11 @@ impl Tool for PlanTool {
                     task.dependencies = task
                         .dependencies
                         .iter()
-                        .filter_map(|old_dep_id| old_to_new.get(old_dep_id).copied())
+                        .filter_map(|dep| {
+                            dep.as_uuid()
+                                .and_then(|old_id| old_to_new.get(&old_id).copied())
+                                .map(TaskDep::Id)
+                        })
                         .collect();
                 }
 
@@ -610,7 +625,7 @@ impl Tool for PlanTool {
                         ))
                     })?;
 
-                    task.dependencies.push(dep_task.id);
+                task.dependencies.push(crate::tui::plan::TaskDep::Id(dep_task.id));
                 }
 
                 current_plan.add_task(task);

--- a/src/db/repository/plan.rs
+++ b/src/db/repository/plan.rs
@@ -5,7 +5,7 @@
 use crate::db::Pool;
 use crate::db::database::interact_err;
 use crate::db::models::{Plan, PlanTask};
-use crate::tui::plan::{PlanDocument, PlanStatus, TaskStatus, TaskType};
+use crate::tui::plan::{PlanDocument, PlanStatus, TaskDep, TaskStatus, TaskType};
 use anyhow::{Context, Result};
 use rusqlite::params;
 use uuid::Uuid;
@@ -281,7 +281,7 @@ impl PlanRepository {
 
     /// Convert database task to domain task
     fn task_from_db(&self, db_task: PlanTask) -> Result<crate::tui::plan::PlanTask> {
-        let dependencies: Vec<Uuid> = serde_json::from_str(&db_task.dependencies)
+        let dependencies: Vec<TaskDep> = serde_json::from_str(&db_task.dependencies)
             .context("Failed to parse dependencies JSON")?;
         let acceptance_criteria: Vec<String> =
             serde_json::from_str(&db_task.acceptance_criteria)
@@ -537,7 +537,7 @@ mod tests {
             title: "Task 2".to_string(),
             description: "Second task".to_string(),
             task_type: TaskType::Edit,
-            dependencies: vec![task1.id],
+            dependencies: vec![TaskDep::Id(task1.id)],
             complexity: 5,
             acceptance_criteria: vec![],
             status: TaskStatus::Pending,
@@ -875,7 +875,7 @@ mod tests {
 
         // Task 2 should depend on Task 1
         assert_eq!(found.tasks[1].dependencies.len(), 1);
-        assert_eq!(found.tasks[1].dependencies[0], task1_id);
+        assert_eq!(found.tasks[1].dependencies[0], TaskDep::Id(task1_id));
     }
 
     #[tokio::test]

--- a/src/docs/reference/plans/coding-plans/python-fast.json
+++ b/src/docs/reference/plans/coding-plans/python-fast.json
@@ -1,0 +1,46 @@
+{
+  "title": "Python Fast Path",
+  "description": "Trivial change (< 20 lines, single file). Lint, test, commit to main. No PR, no gates, no reviews.",
+  "tasks": [
+    {
+      "order": 1,
+      "title": "ruff check --fix",
+      "description": "Run ruff linting and auto-fix. Fix any remaining issues manually.",
+      "task_type": "Test",
+      "complexity": 1,
+      "acceptance_criteria": [
+        "ruff exits 0",
+        "no remaining lint errors"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "pytest",
+      "description": "Run full test suite. All tests must pass.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        1
+      ],
+      "acceptance_criteria": [
+        "all tests green",
+        "no regressions"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "Commit to main",
+      "description": "Commit the change with a descriptive message and push directly to main. No PR, no branch, no review. Link to issue if applicable.",
+      "task_type": "Edit",
+      "complexity": 1,
+      "dependencies": [
+        2
+      ],
+      "acceptance_criteria": [
+        "commit on main",
+        "pushed to origin/main",
+        "message follows convention: type(scope): description"
+      ]
+    }
+  ]
+}

--- a/src/docs/reference/plans/coding-plans/python-full.json
+++ b/src/docs/reference/plans/coding-plans/python-full.json
@@ -1,0 +1,161 @@
+{
+  "title": "Python Full Path",
+  "description": "Large change (> 100 lines, cross-file) or complex refactor. Full process with plan gate, Qwen3.7 subagent review, both Sourcery passes. Stops at PR — user handles CI, review, merge.",
+  "tasks": [
+    {
+      "order": 1,
+      "title": "Context Read",
+      "description": "Read relevant code, understand the problem space. Check logs, related files, existing tests. Research APIs/constraints if feature work.",
+      "task_type": "Research",
+      "complexity": 3,
+      "acceptance_criteria": [
+        "problem fully understood",
+        "all affected files identified",
+        "test strategy clear",
+        "architecture decisions documented"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "⏸ GATE: Approve Plan",
+      "description": "Human gate. Present the implementation plan to the user. Wait for explicit approval before proceeding.",
+      "task_type": "Research",
+      "complexity": 1,
+      "dependencies": [
+        1
+      ],
+      "acceptance_criteria": [
+        "user approves the plan"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "TDD: Write Failing Tests",
+      "description": "Write regression/behaviour tests that capture the expected change. Every new code path should have a test.",
+      "task_type": "Test",
+      "complexity": 3,
+      "dependencies": [
+        2
+      ],
+      "acceptance_criteria": [
+        "tests capture all expected behaviours",
+        "tests fail before implementation",
+        "edge cases covered"
+      ]
+    },
+    {
+      "order": 4,
+      "title": "Implement",
+      "description": "Write the actual code change. Keep it focused on the issue — no scope creep.",
+      "task_type": "Edit",
+      "complexity": 3,
+      "dependencies": [
+        3
+      ],
+      "acceptance_criteria": [
+        "all tests pass",
+        "implementation is minimal and correct",
+        "no unrelated changes"
+      ]
+    },
+    {
+      "order": 5,
+      "title": "ruff + pytest",
+      "description": "Run linter and test suite. Fix any issues before proceeding to review.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        4
+      ],
+      "acceptance_criteria": [
+        "ruff exits 0",
+        "all tests green"
+      ]
+    },
+    {
+      "order": 6,
+      "title": "Qwen3.7 Code Review",
+      "description": "Spawn a Qwen3.7 subagent to review the diff. Prompt: 'Review the PR diff critically. Find bugs, quality issues, edge cases, regressions. Be harsh.'",
+      "task_type": "Research",
+      "complexity": 2,
+      "dependencies": [
+        5
+      ],
+      "acceptance_criteria": [
+        "Qwen3.7 review complete",
+        "findings documented"
+      ]
+    },
+    {
+      "order": 7,
+      "title": "Fix Review Issues",
+      "description": "Address all findings from Qwen3.7 review. Fix bugs, edge cases, quality issues.",
+      "task_type": "Edit",
+      "complexity": 2,
+      "dependencies": [
+        6
+      ],
+      "acceptance_criteria": [
+        "all legitimate findings addressed",
+        "no new bugs introduced"
+      ]
+    },
+    {
+      "order": 8,
+      "title": "Re-run checks",
+      "description": "Run ruff + pytest again after fixing review issues.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        7
+      ],
+      "acceptance_criteria": [
+        "ruff exits 0",
+        "all tests green"
+      ]
+    },
+    {
+      "order": 9,
+      "title": "Self-Review",
+      "description": "Read through the entire diff line by line. Check logic errors, all callers updated, edge cases, message correctness, test coverage, consistency.",
+      "task_type": "Research",
+      "complexity": 2,
+      "dependencies": [
+        8
+      ],
+      "acceptance_criteria": [
+        "no logic errors",
+        "all callers updated",
+        "edge cases handled",
+        "messages correct",
+        "test coverage complete"
+      ]
+    },
+    {
+      "order": 10,
+      "title": "Sourcery CLI",
+      "description": "Run `sourcery review <files>` locally. Different ruleset from GH App.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        9
+      ],
+      "acceptance_criteria": [
+        "Sourcery CLI passes or findings addressed"
+      ]
+    },
+    {
+      "order": 11,
+      "title": "Sourcery GH App",
+      "description": "Comment @sourcery-ai review on the PR. Address findings.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        10
+      ],
+      "acceptance_criteria": [
+        "Sourcery GH App findings reviewed and addressed"
+      ]
+    }
+  ]
+}

--- a/src/docs/reference/plans/coding-plans/python-medium.json
+++ b/src/docs/reference/plans/coding-plans/python-medium.json
@@ -1,0 +1,103 @@
+{
+  "title": "Python Medium Path",
+  "description": "Moderate change (20–100 lines, possibly 2–3 files). Self-review + Sourcery (both CLI and GH App). Stops at PR — user handles CI, review, merge.",
+  "tasks": [
+    {
+      "order": 1,
+      "title": "Context Read",
+      "description": "Read relevant code, understand the problem space. Check logs, related files, existing tests.",
+      "task_type": "Research",
+      "complexity": 2,
+      "acceptance_criteria": [
+        "problem fully understood",
+        "affected files identified",
+        "test strategy clear"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "TDD: Write Failing Test",
+      "description": "Write a regression test (bug) or behaviour test (feature) that captures the expected change. Watch it fail first.",
+      "task_type": "Test",
+      "complexity": 2,
+      "dependencies": [
+        1
+      ],
+      "acceptance_criteria": [
+        "test captures the expected behaviour",
+        "test fails before implementation"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "Implement",
+      "description": "Write the actual code change to make the test pass. Keep it minimal and focused.",
+      "task_type": "Edit",
+      "complexity": 2,
+      "dependencies": [
+        2
+      ],
+      "acceptance_criteria": [
+        "test passes",
+        "implementation is minimal",
+        "no unrelated changes"
+      ]
+    },
+    {
+      "order": 4,
+      "title": "ruff + pytest",
+      "description": "Run linter and test suite. Fix any issues.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        3
+      ],
+      "acceptance_criteria": [
+        "ruff exits 0",
+        "all tests green"
+      ]
+    },
+    {
+      "order": 5,
+      "title": "Self-Review",
+      "description": "Read through the entire diff. Check logic, edge cases, unchanged call sites, message correctness, test coverage.",
+      "task_type": "Research",
+      "complexity": 1,
+      "dependencies": [
+        4
+      ],
+      "acceptance_criteria": [
+        "no logic errors",
+        "all callers updated",
+        "edge cases handled",
+        "messages correct"
+      ]
+    },
+    {
+      "order": 6,
+      "title": "Sourcery CLI",
+      "description": "Run `sourcery review <files>` locally. Review findings and fix if needed.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        5
+      ],
+      "acceptance_criteria": [
+        "Sourcery CLI passes or findings addressed"
+      ]
+    },
+    {
+      "order": 7,
+      "title": "Sourcery GH App",
+      "description": "Comment @sourcery-ai review on the PR. Different ruleset from CLI — review findings separately.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        6
+      ],
+      "acceptance_criteria": [
+        "Sourcery GH App findings reviewed and addressed"
+      ]
+    }
+  ]
+}

--- a/src/docs/reference/plans/coding-plans/rust-fast.json
+++ b/src/docs/reference/plans/coding-plans/rust-fast.json
@@ -1,0 +1,61 @@
+{
+  "title": "Rust Fast Path",
+  "description": "Trivial Rust change (< 20 lines). modum check, self-review, PR. Stops at PR — user handles CI, review, merge.",
+  "tasks": [
+    {
+      "order": 1,
+      "title": "Verify branch base",
+      "description": "Fetch origin/main. Create branch from origin/main (NOT upstream/main — the two remotes have diverged; upstream/main has commits not in origin/main). Verify with: `git diff origin/main --stat` should show ONLY the intended changed files. If it shows hundreds of files, you're based on the wrong branch — start fresh from origin/main.",
+      "task_type": "Configuration",
+      "complexity": 1,
+      "acceptance_criteria": [
+        "branch based on origin/main",
+        "git diff origin/main --stat shows only intended files"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "modum check",
+      "description": "Run `modum check --mode error` on the crate root. Fix any violations before proceeding. This is the preflight check since we can't compile on this machine.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        1
+      ],
+      "acceptance_criteria": [
+        "modum exits 0"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "Self-review diff",
+      "description": "Read through the ENTIRE diff (`git diff origin/main`) line by line. Check for:\n- Logic errors: Does the control flow handle all edge cases? (early returns, None/Err paths, fallthroughs, type conversions)\n- Unchanged call sites: Did you update ALL callers of a refactored function? Grep for old signatures — this is the most common failure pattern\n- Message correctness: Do user-facing strings reference the right flags, paths, and commands?\n- Consistency: Are variable names, function signatures, and arg ordering consistent across the change?\n- Edge cases: What happens when a dependency is missing, a subprocess fails, a config is empty?",
+      "task_type": "Research",
+      "complexity": 1,
+      "dependencies": [
+        2
+      ],
+      "acceptance_criteria": [
+        "no logic errors",
+        "no obvious compilation issues",
+        "messages correct",
+        "all callers updated"
+      ]
+    },
+    {
+      "order": 4,
+      "title": "Push + PR",
+      "description": "Verify branch is NEW: `git branch -r | grep <branch-name>`. If it already exists on any remote, pick a different name (e.g. `-v2`). Never push to an existing branch unless you specifically mean to update it.\n\nPush branch to upstream (NOT origin): `git push upstream <branch>`.\n\nCreate PR: `gh pr create --repo adolfousier/opencrabs --head leshchenko1979:<branch>`\n\nVerify PR diff: `gh pr diff --name-only` should match expected files. If it doesn't, close the PR and fix.",
+      "task_type": "Configuration",
+      "complexity": 1,
+      "dependencies": [
+        3
+      ],
+      "acceptance_criteria": [
+        "branch pushed to upstream",
+        "PR created against origin",
+        "gh pr diff --name-only matches expected"
+      ]
+    }
+  ]
+}

--- a/src/docs/reference/plans/coding-plans/rust-full.json
+++ b/src/docs/reference/plans/coding-plans/rust-full.json
@@ -1,0 +1,150 @@
+{
+  "title": "Rust Full Path",
+  "description": "Large Rust change (> 100 lines, cross-file) or complex refactor. Plan gate, full PR checklist, modum, deep self-review. Stops at PR — user handles CI, review, merge.",
+  "tasks": [
+    {
+      "order": 1,
+      "title": "Context Read",
+      "description": "Read relevant Rust source code. Understand the problem, affected modules, function signatures, and callers. Check related tests. Research architecture context.",
+      "task_type": "Research",
+      "complexity": 3,
+      "acceptance_criteria": [
+        "problem fully understood",
+        "all affected modules identified",
+        "architecture decisions clear",
+        "test strategy known"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "⏸ GATE: Approve Plan",
+      "description": "Human gate. Present the implementation plan to the user. Wait for explicit approval before proceeding.",
+      "task_type": "Research",
+      "complexity": 1,
+      "dependencies": [
+        1
+      ],
+      "acceptance_criteria": [
+        "user approves the plan"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "Verify branch + rebase to origin/main",
+      "description": "Verify branch is new: `git branch -r | grep <branch-name>` — if it exists on any remote, rename (add `-v2`).\n\nFetch and rebase onto origin/main (NOT upstream/main — they have diverged; upstream/main has commits not in origin/main):\n```\ngit fetch origin\ngit rebase origin/main\n```\nVerify: `git diff origin/main --stat` shows ONLY the files you intend to change.",
+      "task_type": "Configuration",
+      "complexity": 1,
+      "dependencies": [
+        2
+      ],
+      "acceptance_criteria": [
+        "branch name is unique across remotes",
+        "rebased onto origin/main",
+        "git diff origin/main --stat shows only intended files"
+      ]
+    },
+    {
+      "order": 4,
+      "title": "Write tests",
+      "description": "Add test cases for the new behaviour. Rust tests live in the same file (unit tests, `#[cfg(test)] mod tests`) or `tests/` directory (integration tests). Every new code path should have a test. Edge cases (empty, null, None, overflow) must be covered.",
+      "task_type": "Test",
+      "complexity": 3,
+      "dependencies": [
+        3
+      ],
+      "acceptance_criteria": [
+        "tests capture expected behaviour",
+        "edge cases covered",
+        "tests fail without implementation"
+      ]
+    },
+    {
+      "order": 5,
+      "title": "Implement",
+      "description": "Write the code change. Keep it scoped to one issue — one logical change per PR. Do NOT bundle unrelated fixes.",
+      "task_type": "Edit",
+      "complexity": 3,
+      "dependencies": [
+        4
+      ],
+      "acceptance_criteria": [
+        "change is minimal and focused",
+        "all callers updated",
+        "no scope creep"
+      ]
+    },
+    {
+      "order": 6,
+      "title": "modum check",
+      "description": "Run `modum check --mode error` on the crate root. Fix violations before proceeding.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        5
+      ],
+      "acceptance_criteria": [
+        "modum exits 0"
+      ]
+    },
+    {
+      "order": 7,
+      "title": "Deep self-review",
+      "description": "Read the ENTIRE diff (`git diff origin/main`) line by line. Check:\n- Logic errors: Does the control flow handle all edge cases? (early returns, None/Err paths, fallthroughs, type conversions)\n- **Unchanged call sites: Did you update ALL callers of a refactored function? Grep for old signatures everywhere — this is the most common failure pattern**\n- Message correctness: Do user-facing strings reference the right flags, paths, and commands?\n- Edge cases: What happens when a dependency is missing, a subprocess fails, a config is empty?\n- Consistency: Are variable names, function signatures, and arg ordering consistent across the change?\n- Test coverage: Do the tests actually test the new behaviour, or just the old one with renamed variables?",
+      "task_type": "Research",
+      "complexity": 3,
+      "dependencies": [
+        6
+      ],
+      "acceptance_criteria": [
+        "no logic errors",
+        "ALL callers of changed functions updated",
+        "edge cases documented and handled",
+        "messages reference correct flags/paths",
+        "test coverage adequate"
+      ]
+    },
+    {
+      "order": 8,
+      "title": "Fix self-review findings",
+      "description": "Address any issues found during self-review. Then re-run modum.",
+      "task_type": "Edit",
+      "complexity": 2,
+      "dependencies": [
+        7
+      ],
+      "acceptance_criteria": [
+        "all findings addressed",
+        "modum still passes"
+      ]
+    },
+    {
+      "order": 9,
+      "title": "Verify PR diff is clean",
+      "description": "`git diff origin/main --stat`. Must show ONLY the intended changed files. If it shows hundreds of files, the branch is based on the wrong branch — abort and start fresh:\n```\ngit checkout origin/main -b fix/your-fix-v2\n```\nDo not try to fix a dirty branch by rebasing. Start fresh from origin/main.",
+      "task_type": "Research",
+      "complexity": 1,
+      "dependencies": [
+        8
+      ],
+      "acceptance_criteria": [
+        "diff shows only intended files",
+        "base is origin/main"
+      ]
+    },
+    {
+      "order": 10,
+      "title": "Push + PR",
+      "description": "Push to upstream (NOT origin): `git push upstream <branch>`\n\nCreate PR: `gh pr create --repo adolfousier/opencrabs --head leshchenko1979:<branch>`\n\nImmediately verify PR diff: `gh pr diff --name-only` should match expected files. If it doesn't, close the PR and start over from origin/main.",
+      "task_type": "Configuration",
+      "complexity": 1,
+      "dependencies": [
+        9
+      ],
+      "acceptance_criteria": [
+        "branch pushed to upstream",
+        "PR created",
+        "PR diff matches expected"
+      ]
+    }
+  ]
+}

--- a/src/docs/reference/plans/coding-plans/rust-medium.json
+++ b/src/docs/reference/plans/coding-plans/rust-medium.json
@@ -1,0 +1,94 @@
+{
+  "title": "Rust Medium Path",
+  "description": "Moderate Rust change (20–100 lines, 1–3 files). modum, self-review, PR. Stops at PR — user handles CI, review, merge.",
+  "tasks": [
+    {
+      "order": 1,
+      "title": "Context Read",
+      "description": "Read relevant Rust source code. Understand the problem, affected modules, function signatures, and callers. Check for existing test patterns.",
+      "task_type": "Research",
+      "complexity": 2,
+      "acceptance_criteria": [
+        "problem understood",
+        "all affected modules identified",
+        "caller graph known"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "Verify branch + rebase to origin/main",
+      "description": "Verify branch is fresh: `git branch -r | grep <branch-name>` — if it exists on any remote, rename (add `-v2`).\n\nFetch and rebase onto origin/main (NOT upstream/main — they have diverged):\n```\ngit fetch origin\ngit rebase origin/main\n```\nVerify: `git diff origin/main --stat` shows ONLY the files you intend to change.",
+      "task_type": "Configuration",
+      "complexity": 1,
+      "dependencies": [
+        1
+      ],
+      "acceptance_criteria": [
+        "branch name is unique across all remotes",
+        "rebased onto origin/main",
+        "git diff origin/main --stat shows only intended files"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "Implement",
+      "description": "Write the code change. Keep it scoped to one issue — one logical change per PR. Do NOT bundle unrelated fixes. If you have multiple independent fixes, make separate branches and PRs.",
+      "task_type": "Edit",
+      "complexity": 2,
+      "dependencies": [
+        2
+      ],
+      "acceptance_criteria": [
+        "change is minimal and focused",
+        "all callers updated",
+        "no scope creep"
+      ]
+    },
+    {
+      "order": 4,
+      "title": "modum check",
+      "description": "Run `modum check --mode error`. Fix any violations before proceeding.",
+      "task_type": "Test",
+      "complexity": 1,
+      "dependencies": [
+        3
+      ],
+      "acceptance_criteria": [
+        "modum exits 0"
+      ]
+    },
+    {
+      "order": 5,
+      "title": "Self-review every changed line",
+      "description": "Read through the ENTIRE diff (`git diff origin/main`) line by line. Check:\n- Logic errors: Does the control flow handle all edge cases? (early returns, None/Err paths, fallthroughs, type conversions)\n- Unchanged call sites: Did you update ALL callers of a refactored function? Grep for old signatures — **this is the most common failure pattern**\n- Message correctness: Do user-facing strings reference the right flags, paths, and commands?\n- Test coverage: Do the tests actually test the new behavior, or just the old one with renamed variables? Does every new code path have a test?\n- Edge cases: What happens when a dependency is missing, a subprocess fails, a config is empty?\n- Consistency: Are variable names, function signatures, and arg ordering consistent across the change?",
+      "task_type": "Research",
+      "complexity": 2,
+      "dependencies": [
+        4
+      ],
+      "acceptance_criteria": [
+        "no logic errors",
+        "all callers of changed functions updated",
+        "edge cases handled",
+        "messages correct",
+        "test coverage adequate"
+      ]
+    },
+    {
+      "order": 6,
+      "title": "Push + PR",
+      "description": "Verify diff is clean BEFORE pushing: `git diff origin/main --stat`. If it shows hundreds of files, you're based on the wrong branch. Start over:\n```\ngit checkout origin/main -b fix/your-fix-v2\n```\nDo not try to fix a dirty branch by rebasing — start fresh.\n\nPush to upstream (NOT origin): `git push upstream <branch>`\n\nCreate PR: `gh pr create --repo adolfousier/opencrabs --head leshchenko1979:<branch>`\n\nImmediately verify PR diff: `gh pr diff --name-only` should match expected files. If it doesn't, close the PR and start over from origin/main.",
+      "task_type": "Configuration",
+      "complexity": 1,
+      "dependencies": [
+        5
+      ],
+      "acceptance_criteria": [
+        "branch pushed to upstream",
+        "PR created",
+        "PR diff matches expected files",
+        "no extraneous files"
+      ]
+    }
+  ]
+}

--- a/src/docs/reference/plans/coding-plans/sample-minimal-plan.json
+++ b/src/docs/reference/plans/coding-plans/sample-minimal-plan.json
@@ -1,0 +1,34 @@
+{
+  "title": "Sample: Minimal Plan (Import-Ready Format)",
+  "description": "This is the MINIMAL format the plan tool accepts. Only 6 fields are required. UUIDs, timestamps, and most fields are auto-generated on import. Use this as a template when composing plan JSON for import.",
+  "tasks": [
+    {
+      "title": "Research task",
+      "description": "Investigate and understand the problem space",
+      "task_type": "research",
+      "complexity": 2
+    },
+    {
+      "title": "Implementation task",
+      "description": "Build the actual solution",
+      "task_type": "create",
+      "complexity": 3
+    },
+    {
+      "title": "Test task",
+      "description": "Verify the solution works correctly",
+      "task_type": "test",
+      "acceptance_criteria": [
+        "Tests pass",
+        "Edge cases handled"
+      ],
+      "complexity": 2
+    },
+    {
+      "title": "Documentation task",
+      "description": "Document the changes for future maintainers",
+      "task_type": "documentation",
+      "complexity": 1
+    }
+  ]
+}

--- a/src/docs/reference/plans/plan-json-spec.md
+++ b/src/docs/reference/plans/plan-json-spec.md
@@ -1,0 +1,143 @@
+# Plan JSON Schema Reference
+
+## Minimal Import Format
+
+Only **3 fields required** at the root and **3 per task** for a valid import:
+
+### Root Level (3 fields)
+```json
+{
+  "title": "Plan name",
+  "description": "What this plan accomplishes",
+  "tasks": [...]
+}
+```
+
+### Task Level (3 fields per task)
+```json
+{
+  "title": "Task name",
+  "description": "What this task does",
+  "task_type": "research"
+}
+```
+
+## Optional Task Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dependencies` | `integer[]` or `string[]` | *(omitted)* | **Optional.** Omit when there are no dependencies — empty `[]` is redundant. When present, use 1-based integer indices (e.g. `[1, 2]`) for readability. UUID strings also accepted. |
+| `complexity` | `number` | `3` | 1-5 scale: 1=trivial, 2=simple, 3=moderate, 4=complex, 5=very complex |
+| `acceptance_criteria` | `string[]` | `[]` | List of conditions that mark this task complete |
+
+## Auto-Generated Fields (Do NOT Provide)
+
+These are always overwritten on import:
+
+### Root Level
+- `id` — UUID, regenerated
+- `session_id` — UUID, from session
+- `status` — always `"Draft"`
+- `created_at` — ISO timestamp
+- `updated_at` — ISO timestamp  
+- `approved_at` — always `null`
+- `context` — defaults to empty string
+- `risks` — defaults to `[]`
+- `technical_stack` — defaults to `[]`
+- `test_strategy` — defaults to empty string
+
+### Task Level
+- `id` — UUID, auto-minted (do not provide — see Optional Fields note above)
+- `order` — 1-based; auto-assigned from array position if omitted (recommended to omit)
+- `status` — always `"Pending"`
+- `notes` — always `null`
+- `completed_at` — always `null`
+- `execution_history` — always `[]`
+- `retry_count` — always `0`
+- `max_retries` — defaults to `3`
+- `artifacts` — always `[]`
+- `reflection` — always `null`
+
+## task_type Values
+
+Case-insensitive. Examples: `"Research"`, `"research"`, `"RESEARCH"` all work.
+
+| Value | Description |
+|-------|-------------|
+| `research` | Investigate, explore, understand |
+| `edit` | Modify existing code/files |
+| `create` | Build new things from scratch |
+| `delete` | Remove code/files |
+| `test` | Write or run tests |
+| `documentation` | Docs, comments, specs |
+| `configuration` | Config, setup, infrastructure |
+
+## Dependencies
+
+Use **1-based integer indices** (human-friendly). **Omit the field when there are no dependencies** — do not write `"dependencies": []`.
+
+```json
+"dependencies": [1, 2]        // depends on tasks 1 and 2
+"dependencies": [1]            // depends on task 1 only
+// (no field at all)           // no dependencies — preferred over []
+```
+
+## JSON Schema (Machine-Readable)
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["title", "description", "tasks"],
+  "additionalProperties": true,
+  "properties": {
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["title", "description", "task_type"],
+        "additionalProperties": true,
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "task_type": { 
+            "type": "string",
+            "enum": ["research", "edit", "create", "delete", "test", "documentation", "configuration"],
+            "pattern": "^(?i)(research|edit|create|delete|test|documentation|configuration)$"
+          },
+          "dependencies": {
+            "type": "array",
+            "items": { "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "string", "pattern": "^[0-9a-fA-F-]{36}$" }] },
+            "default": []
+          },
+          "complexity": { "type": "integer", "minimum": 1, "maximum": 5, "default": 3 },
+          "acceptance_criteria": { "type": "array", "items": { "type": "string" }, "default": [] }
+        }
+      }
+    }
+  }
+}
+```
+
+## Example Minimal Plan
+
+```json
+{
+  "title": "Add user authentication",
+  "description": "Implement login/logout flow with session management",
+  "tasks": [
+    { "title": "Research auth patterns", "description": "Look at existing auth code and pick a pattern", "task_type": "research" },
+    { "title": "Write login handler", "description": "POST /auth/login with password verification", "task_type": "create", "dependencies": [1] },
+    { "title": "Add session middleware", "description": "Attach user context to requests", "task_type": "configuration", "dependencies": [2] },
+    { "title": "Write auth tests", "description": "Test login, logout, and session expiry", "task_type": "test", "dependencies": [3], "complexity": 2 }
+  ]
+}
+```
+
+## Files
+
+- **Minimal example**: `~/.opencrabs/profiles/ops/plans/coding-plans/sample-minimal-plan.json`
+- **Full example**: `~/.opencrabs/profiles/ops/plans/coding-plans/rust-full.json`

--- a/src/tests/plan_document_test.rs
+++ b/src/tests/plan_document_test.rs
@@ -131,7 +131,7 @@ fn tasks_with_linear_deps() {
     let t1 = PlanTask::new(1, "First".to_string(), "".to_string(), TaskType::Create);
     let t1_id = t1.id;
     let mut t2 = PlanTask::new(2, "Second".to_string(), "".to_string(), TaskType::Create);
-    t2.dependencies.push(t1_id);
+    t2.dependencies.push(TaskDep::Id(t1_id));
     plan.add_task(t1);
     plan.add_task(t2);
 

--- a/src/tests/plan_mode_integration_test.rs
+++ b/src/tests/plan_mode_integration_test.rs
@@ -10,7 +10,7 @@ use opencrabs::db::models::Session;
 use opencrabs::db::repository::session::SessionRepository;
 use opencrabs::db::Database;
 use opencrabs::services::{PlanService, ServiceContext};
-use opencrabs::tui::plan::{PlanDocument, PlanStatus, PlanTask, TaskStatus, TaskType};
+use opencrabs::tui::plan::{PlanDocument, PlanStatus, PlanTask, TaskDep, TaskStatus, TaskType};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -85,7 +85,7 @@ fn create_multi_task_plan(session_id: Uuid) -> PlanDocument {
         title: "Implementation phase".to_string(),
         description: "Implement the feature".to_string(),
         task_type: TaskType::Create,
-        dependencies: vec![task1_id], // Depends on research
+        dependencies: vec![TaskDep::Id(task1_id)], // Depends on research
         complexity: 5,
         acceptance_criteria: vec![],
         status: TaskStatus::Pending,
@@ -104,7 +104,7 @@ fn create_multi_task_plan(session_id: Uuid) -> PlanDocument {
         title: "Testing phase".to_string(),
         description: "Write and run tests".to_string(),
         task_type: TaskType::Test,
-        dependencies: vec![task2_id], // Depends on implementation
+        dependencies: vec![TaskDep::Id(task2_id)], // Depends on implementation
         complexity: 4,
         acceptance_criteria: vec![],
         status: TaskStatus::Pending,

--- a/src/tui/plan.rs
+++ b/src/tui/plan.rs
@@ -2,19 +2,171 @@
 //!
 //! Core data structures for plan mode, which enables structured task decomposition
 //! and controlled execution for complex development tasks.
+//!
+//! ## Minimal Import Format
+//!
+//! Only 6 fields required: `title`, `description`, `tasks[]` with `title`, `description`, `task_type`.
+//!
+//! All other fields are auto-generated on import. See `~/.opencrabs/profiles/<profile>/plans/plan-json-spec.md`
+//! for full schema documentation and `~/.opencrabs/profiles/<profile>/plans/coding-plans/` for reference examples.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Task dependency: either a 1-based index into the task list, or a direct UUID reference.
+/// This allows both integer indices (easier for LLMs to write) and UUIDs (for explicit references).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(from = "TaskDepDef", into = "TaskDepDef")]
+pub enum TaskDep {
+    /// 1-based index into the task list. Resolved to Uuid during import.
+    Index(usize),
+    /// Direct UUID reference to a task.
+    Id(Uuid),
+}
+
+impl TaskDep {
+    /// Convert to UUID, using the provided order-to-UUID mapping if this is an index.
+    pub fn to_uuid(&self, order_to_id: &std::collections::HashMap<usize, Uuid>) -> Option<Uuid> {
+        match self {
+            TaskDep::Id(uuid) => Some(*uuid),
+            TaskDep::Index(idx) => order_to_id.get(idx).copied(),
+        }
+    }
+
+    /// Check if this is a UUID (already resolved)
+    pub fn is_uuid(&self) -> bool {
+        matches!(self, TaskDep::Id(_))
+    }
+
+    /// Get the UUID value if this is a UUID
+    pub fn as_uuid(&self) -> Option<Uuid> {
+        match self {
+            TaskDep::Id(uuid) => Some(*uuid),
+            TaskDep::Index(_) => None,
+        }
+    }
+}
+
+/// Serialization format for TaskDep - serializes as just the UUID (index is resolved before serialization)
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum TaskDepDef {
+    Uuid(Uuid),
+    Index(usize),
+}
+
+impl From<TaskDepDef> for TaskDep {
+    fn from(def: TaskDepDef) -> Self {
+        match def {
+            TaskDepDef::Uuid(uuid) => TaskDep::Id(uuid),
+            TaskDepDef::Index(idx) => TaskDep::Index(idx),
+        }
+    }
+}
+
+impl From<TaskDep> for TaskDepDef {
+    fn from(dep: TaskDep) -> Self {
+        match dep {
+            TaskDep::Id(uuid) => TaskDepDef::Uuid(uuid),
+            TaskDep::Index(idx) => TaskDepDef::Index(idx),
+        }
+    }
+}
+
+/// Custom deserializer for task dependencies - accepts both integer indices (1-based) and UUID strings.
+/// Returns Vec<TaskDep> so we preserve the index value for later resolution.
+pub fn deserialize_task_deps<'de, D>(deserializer: D) -> Result<Vec<TaskDep>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct TaskDepVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for TaskDepVisitor {
+        type Value = Vec<TaskDep>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("an array of task indices (1-based integers) or UUID strings")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut deps = Vec::new();
+            while let Some(val) = seq.next_element::<serde_json::Value>()? {
+                match val {
+                    serde_json::Value::Number(n) => {
+                        if let Some(i) = n.as_i64() {
+                            if i < 1 {
+                                return Err(serde::de::Error::custom(
+                                    "task indices start at 1",
+                                ));
+                            }
+                            deps.push(TaskDep::Index(i as usize));
+                        } else {
+                            return Err(serde::de::Error::custom(
+                                "task index must be a positive integer",
+                            ));
+                        }
+                    }
+                    serde_json::Value::String(s) => {
+                        match Uuid::parse_str(&s) {
+                            Ok(uuid) => deps.push(TaskDep::Id(uuid)),
+                            Err(_) => {
+                                return Err(serde::de::Error::custom(format!(
+                                    "invalid UUID: {}",
+                                    s
+                                )));
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(serde::de::Error::custom(
+                            "task dependency must be an integer index or UUID string",
+                        ));
+                    }
+                }
+            }
+            Ok(deps)
+        }
+    }
+
+    deserializer.deserialize_seq(TaskDepVisitor)
+}
+
+/// Custom deserializer for task type - case-insensitive
+pub fn deserialize_task_type<'de, D>(deserializer: D) -> Result<TaskType, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    match s.to_lowercase().as_str() {
+        "research" => Ok(TaskType::Research),
+        "edit" => Ok(TaskType::Edit),
+        "create" => Ok(TaskType::Create),
+        "delete" => Ok(TaskType::Delete),
+        "test" => Ok(TaskType::Test),
+        "refactor" => Ok(TaskType::Refactor),
+        "documentation" => Ok(TaskType::Documentation),
+        "configuration" => Ok(TaskType::Configuration),
+        "build" => Ok(TaskType::Build),
+        other => Ok(TaskType::Other(other.to_string())),
+    }
+}
+
+/// Task dependency: stored as UUID but deserialized from integer index (1-based) or UUID string
+
 /// Plan document containing tasks and metadata
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanDocument {
     /// Unique plan ID
-    pub id: Uuid,
+    #[serde(default)]
+    pub id: Option<Uuid>,
 
     /// Session this plan belongs to
-    pub session_id: Uuid,
+    #[serde(default)]
+    pub session_id: Option<Uuid>,
 
     /// Plan title/goal
     pub title: String,
@@ -26,28 +178,36 @@ pub struct PlanDocument {
     pub tasks: Vec<PlanTask>,
 
     /// Context and assumptions
+    #[serde(default)]
     pub context: String,
 
     /// Identified risks and unknowns
+    #[serde(default)]
     pub risks: Vec<String>,
 
     /// Testing strategy and approach
+    #[serde(default)]
     pub test_strategy: String,
 
     /// Technical stack (frameworks, libraries, tools)
+    #[serde(default)]
     pub technical_stack: Vec<String>,
 
     /// Plan status
+    #[serde(default)]
     pub status: PlanStatus,
 
     /// When the plan was created
-    pub created_at: DateTime<Utc>,
+    #[serde(default)]
+    pub created_at: Option<DateTime<Utc>>,
 
     /// When the plan was last updated
-    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub updated_at: Option<DateTime<Utc>>,
 
     /// When the plan was approved (if applicable)
-    pub approved_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub approved_at: Option<Option<DateTime<Utc>>>,
 }
 
 impl PlanDocument {
@@ -76,6 +236,43 @@ impl PlanDocument {
         self.updated_at = Utc::now();
     }
 
+    /// Resolve integer index dependencies to UUIDs.
+    /// Integer indices (1-based) in dependencies are converted to the UUID of the task at that order.
+    /// Note: This requires dependencies to use UUIDs, not integer indices.
+    /// Call this after deserialization but before validation.
+    pub fn resolve_index_deps(&mut self) {
+        use std::collections::HashMap;
+        
+        // First pass: build order -> id mapping
+        // Use 1-based indexing for tasks
+        let mut order_to_id: HashMap<usize, Uuid> = HashMap::new();
+        for (idx, task) in self.tasks.iter().enumerate() {
+            let order = task.order.unwrap_or(idx + 1);
+            if let Some(id) = task.id {
+                order_to_id.insert(order, id);
+            }
+        }
+        
+        // Second pass: resolve any index dependencies to UUIDs
+        for task in &mut self.tasks {
+            let resolved: Vec<TaskDep> = task.dependencies.iter().map(|dep| {
+                match dep {
+                    TaskDep::Index(idx) => {
+                        // Look up the UUID for this order
+                        if let Some(uuid) = order_to_id.get(idx) {
+                            TaskDep::Id(*uuid)
+                        } else {
+                            // Invalid index - keep as-is (will fail validation)
+                            TaskDep::Index(*idx)
+                        }
+                    }
+                    TaskDep::Id(_) => dep.clone(),
+                }
+            }).collect();
+            task.dependencies = resolved;
+        }
+    }
+
     /// Get tasks in dependency order using topological sort
     /// Returns None if there are circular dependencies
     pub fn tasks_in_order(&self) -> Option<Vec<&PlanTask>> {
@@ -85,13 +282,14 @@ impl PlanDocument {
         let mut in_degree: HashMap<Uuid, usize> = HashMap::new();
         let mut dependents: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
 
-        // Initialize in-degree for all tasks
+        // Initialize in-degree for all tasks (count only UUID dependencies, skip indices)
         for task in &self.tasks {
-            in_degree.insert(task.id, task.dependencies.len());
+            let uuid_deps: Vec<Uuid> = task.dependencies.iter().filter_map(|d| d.as_uuid()).collect();
+            in_degree.insert(task.id, uuid_deps.len());
 
             // Build reverse dependency map
-            for &dep_id in &task.dependencies {
-                dependents.entry(dep_id).or_default().push(task.id);
+            for dep_id in &uuid_deps {
+                dependents.entry(*dep_id).or_default().push(task.id);
             }
         }
 
@@ -205,14 +403,16 @@ impl PlanDocument {
 
         // Check for invalid task references
         for task in &self.tasks {
-            for &dep_id in &task.dependencies {
-                if !task_ids.contains(&dep_id) {
-                    return Err(format!(
-                        "❌ Invalid Dependency\n\n\
-                         Task '{}' (#{}) depends on a task that doesn't exist.\n\n\
-                         💡 Fix: Remove this dependency or ensure the referenced task is added first.",
-                        task.title, task.order
-                    ));
+            for dep in &task.dependencies {
+                if let Some(dep_id) = dep.as_uuid() {
+                    if !task_ids.contains(&dep_id) {
+                        return Err(format!(
+                            "❌ Invalid Dependency\n\n\
+                             Task '{}' (#{}) depends on a task that doesn't exist.\n\n\
+                             💡 Fix: Remove this dependency or ensure the referenced task is added first.",
+                            task.title, task.order
+                        ));
+                    }
                 }
             }
         }
@@ -257,7 +457,7 @@ impl PlanDocument {
                 && task
                     .dependencies
                     .iter()
-                    .all(|dep| completed_ids.contains(dep))
+                    .all(|dep| dep.as_uuid().map_or(false, |id| completed_ids.contains(&id)))
         })
     }
 
@@ -276,7 +476,7 @@ impl PlanDocument {
                 && task
                     .dependencies
                     .iter()
-                    .all(|dep| completed_ids.contains(dep))
+                    .all(|dep| dep.as_uuid().map_or(false, |id| completed_ids.contains(&id)))
         })
     }
 
@@ -293,8 +493,9 @@ impl PlanDocument {
 
     /// Check if all dependencies for a task are satisfied
     pub fn dependencies_satisfied(&self, task: &PlanTask) -> bool {
-        task.dependencies.iter().all(|dep_id| {
-            self.get_task(dep_id)
+        task.dependencies.iter().all(|dep| {
+            dep.as_uuid()
+                .and_then(|id| self.get_task(&id))
                 .map(|dep| matches!(dep.status, TaskStatus::Completed | TaskStatus::Skipped))
                 .unwrap_or(false)
         })
@@ -459,10 +660,12 @@ impl std::fmt::Display for PlanStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanTask {
     /// Unique task ID
-    pub id: Uuid,
+    #[serde(default)]
+    pub id: Option<Uuid>,
 
     /// Task number/order
-    pub order: usize,
+    #[serde(default)]
+    pub order: Option<usize>,
 
     /// Task title/summary
     pub title: String,
@@ -471,24 +674,31 @@ pub struct PlanTask {
     pub description: String,
 
     /// Task type (for categorization)
+    #[serde(deserialize_with = "deserialize_task_type")]
     pub task_type: TaskType,
 
-    /// Dependencies (task IDs that must complete first)
-    pub dependencies: Vec<Uuid>,
+    /// Dependencies (task IDs or 1-based indices; indices resolved to UUIDs on import)
+    #[serde(default, deserialize_with = "deserialize_task_deps")]
+    pub dependencies: Vec<TaskDep>,
 
     /// Estimated complexity (1-5)
+    #[serde(default)]
     pub complexity: u8,
 
     /// Acceptance criteria for task completion
+    #[serde(default)]
     pub acceptance_criteria: Vec<String>,
 
     /// Task status
+    #[serde(default)]
     pub status: TaskStatus,
 
     /// Execution notes/results
+    #[serde(default)]
     pub notes: Option<String>,
 
     /// When task was completed
+    #[serde(default)]
     pub completed_at: Option<DateTime<Utc>>,
 
     /// Execution history (for plan-and-execute pattern)

--- a/src/tui/plan_tests.rs
+++ b/src/tui/plan_tests.rs
@@ -236,8 +236,8 @@ mod tests {
         let task2_id = task2.id;
 
         let mut task3 = create_test_task(3, "Task 3");
-        task3.dependencies.push(task1_id);
-        task3.dependencies.push(task2_id);
+        task3.dependencies.push(TaskDep::Id(task1_id));
+        task3.dependencies.push(TaskDep::Id(task2_id));
 
         plan.add_task(task1);
         plan.add_task(task2);
@@ -262,11 +262,11 @@ mod tests {
 
         let mut task2 = create_test_task(2, "Task 2");
         let task2_id = task2.id;
-        task2.dependencies.push(task1_id);
+        task2.dependencies.push(TaskDep::Id(task1_id));
 
         // Create circular dependency: Task 1 depends on Task 2
         let mut task1_modified = task1;
-        task1_modified.dependencies.push(task2_id);
+        task1_modified.dependencies.push(TaskDep::Id(task2_id));
 
         plan.add_task(task1_modified);
         plan.add_task(task2);
@@ -284,7 +284,7 @@ mod tests {
         let task1_id = task1.id;
 
         let mut task2 = create_test_task(2, "Task 2");
-        task2.dependencies.push(task1_id);
+        task2.dependencies.push(TaskDep::Id(task1_id));
 
         plan.add_task(task1);
         plan.add_task(task2);
@@ -298,7 +298,7 @@ mod tests {
         let mut plan = create_test_plan(Uuid::new_v4());
 
         let mut task1 = create_test_task(1, "Task 1");
-        task1.dependencies.push(Uuid::new_v4()); // Non-existent task
+        task1.dependencies.push(TaskDep::Id(Uuid::new_v4())); // Non-existent task
 
         plan.add_task(task1);
 
@@ -316,10 +316,10 @@ mod tests {
 
         let mut task2 = create_test_task(2, "Task 2");
         let task2_id = task2.id;
-        task2.dependencies.push(task1_id);
+        task2.dependencies.push(TaskDep::Id(task1_id));
 
         let mut task1_modified = task1;
-        task1_modified.dependencies.push(task2_id);
+        task1_modified.dependencies.push(TaskDep::Id(task2_id));
 
         plan.add_task(task1_modified);
         plan.add_task(task2);
@@ -489,20 +489,20 @@ mod tests {
         let task1_id = task1.id;
 
         let mut task2 = create_test_task(2, "Task 2");
-        task2.dependencies.push(task1_id);
+        task2.dependencies.push(TaskDep::Id(task1_id));
         let task2_id = task2.id;
 
         let mut task3 = create_test_task(3, "Task 3");
-        task3.dependencies.push(task1_id);
+        task3.dependencies.push(TaskDep::Id(task1_id));
         let task3_id = task3.id;
 
         let mut task4 = create_test_task(4, "Task 4");
-        task4.dependencies.push(task2_id);
-        task4.dependencies.push(task3_id);
+        task4.dependencies.push(TaskDep::Id(task2_id));
+        task4.dependencies.push(TaskDep::Id(task3_id));
         let task4_id = task4.id;
 
         let mut task5 = create_test_task(5, "Task 5");
-        task5.dependencies.push(task4_id);
+        task5.dependencies.push(TaskDep::Id(task4_id));
 
         plan.add_task(task1);
         plan.add_task(task2);


### PR DESCRIPTION
Makes plan JSON imports LLM-friendly: only 3 root fields (title, description, tasks) and 3 per-task fields (title, description, task_type) are required. All UUIDs, timestamps, and lifecycle fields are auto-generated on import.

**Task dependencies** now accept either a 1-based integer index (human-friendly for LLMs) or a UUID string (machine-generated); both resolve to UUIDs internally via a new `TaskDep` enum and a `resolve_index_deps()` pass on import.

**Bundled reference plans**: 7 example plan JSONs (rust-{fast,medium,full}, python-{fast,medium,full}, sample-minimal-plan) plus `plan-json-spec.md` are now embedded in the binary via `include_str!` and exposed through a new `brain::plans` module that writes them to `~/.opencrabs/profiles/<profile>/plans/` on first access. The plan tool's description now points to these real, full-schema examples so the model can author valid imports without having to discover the schema from scratch.

**Files:**
- `src/brain/plans.rs` (new, 69 lines): embedded plan/spec files with disk fallback
- `src/docs/reference/plans/` (new): 7 coding plan JSONs + `plan-json-spec.md`
- `src/tui/plan.rs`: `TaskDep` enum, custom deserializers, `#[serde(default)]` on auto-generated fields, `resolve_index_deps()` topological resolution
- `src/brain/tools/plan_tool.rs`: import handler wires `resolve_index_deps`, tool description references bundled files
- `src/db/repository/plan.rs`: `task_from_db` reads `Vec<TaskDep>` (matches the new domain type)
- test files: wrap raw `Uuid` literals in `TaskDep::Id(...)`

**Diff size:** 16 files, +1817 / -54 (most of the +lines are bundled reference JSONs and the spec doc).