### PR TITLE
fix(telegram): preserve rich tables when appending context footer

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2544,16 +2544,11 @@ pub(crate) async fn handle_message(
                         .copied()
                         .zip(s.sent_intermediates.last().cloned())
                 };
-                if let Some((inter_id, inter_text)) = last_inter
-                    && let Some(edited) = build_last_intermediate_with_footer(&inter_text, &footer)
-                    && let Err(e) = bot
-                        .edit_message_text(msg.chat.id, inter_id, &edited)
-                        .parse_mode(ParseMode::Html)
-                        .await
-                {
-                    tracing::warn!(
-                        "Telegram: failed to append ctx footer to last intermediate ({e})"
-                    );
+                if let Some((inter_id, inter_text)) = last_inter {
+                    append_footer_to_last_intermediate(
+                        &bot, msg.chat.id, inter_id, &inter_text, &footer,
+                    )
+                    .await;
                 }
                 let _ = bot.delete_message(msg.chat.id, mid).await;
             }
@@ -3233,16 +3228,11 @@ pub(crate) async fn resume_session(
                         .copied()
                         .zip(s.sent_intermediates.last().cloned())
                 };
-                if let Some((inter_id, inter_text)) = last_inter
-                    && let Some(edited) = build_last_intermediate_with_footer(&inter_text, &footer)
-                    && let Err(e) = bot
-                        .edit_message_text(chat_id, inter_id, &edited)
-                        .parse_mode(ParseMode::Html)
-                        .await
-                {
-                    tracing::warn!(
-                        "Telegram resume: failed to append ctx footer to last intermediate ({e})"
-                    );
+                if let Some((inter_id, inter_text)) = last_inter {
+                    append_footer_to_last_intermediate(
+                        &bot, chat_id, inter_id, &inter_text, &footer,
+                    )
+                    .await;
                 }
                 let _ = bot.delete_message(chat_id, mid).await;
             }
@@ -3685,6 +3675,40 @@ pub(crate) fn build_last_intermediate_with_footer(
         None
     } else {
         Some(combined)
+    }
+}
+
+/// Append a footer to the last intermediate message, preserving rich format
+/// when the intermediate was sent as a native rich message. Editing with
+/// ParseMode::Html would downgrade rich tables to card view — this helper
+/// tries the rich edit first and falls back to HTML only on failure.
+async fn append_footer_to_last_intermediate(
+    bot: &Bot,
+    chat_id: ChatId,
+    inter_id: MessageId,
+    inter_text: &str,
+    footer: &str,
+) {
+    if super::rich::should_send_native_rich(inter_text) {
+        let rich_md = format!("{inter_text}\n\n{footer}");
+        match super::rich::api::edit_rich_markdown(bot.token(), chat_id.0, inter_id.0, &rich_md)
+            .await
+        {
+            Ok(()) => return,
+            Err(e) => {
+                tracing::warn!(
+                    "Telegram: rich footer edit failed, falling back to HTML ({e})"
+                );
+            }
+        }
+    }
+    if let Some(edited) = build_last_intermediate_with_footer(inter_text, footer)
+        && let Err(e) = bot
+            .edit_message_text(chat_id, inter_id, &edited)
+            .parse_mode(ParseMode::Html)
+            .await
+    {
+        tracing::warn!("Telegram: failed to append ctx footer to last intermediate ({e})");
     }
 }
 
@@ -4188,3 +4212,4 @@ pub(crate) fn make_approval_callback(
         })
     })
 }
+

--- a/src/channels/telegram/rich/api.rs
+++ b/src/channels/telegram/rich/api.rs
@@ -54,6 +54,24 @@ pub(crate) async fn send_rich_markdown_id(
         .ok_or_else(|| anyhow::anyhow!("sendRichMessage ok but response carried no message_id"))
 }
 
+/// Edit an existing message with rich markdown via `editMessageText` + `rich_message`.
+/// Used to append footers to intermediate rich messages without downgrading to HTML.
+/// Returns `Err` so the caller can fall back to the HTML edit path.
+pub(crate) async fn edit_rich_markdown(
+    token: &str,
+    chat_id: i64,
+    message_id: i32,
+    markdown: &str,
+) -> anyhow::Result<()> {
+    let url = format!("https://api.telegram.org/bot{token}/editMessageText");
+    let body = serde_json::json!({
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "rich_message": { "markdown": markdown },
+    });
+    post_and_check(&url, &body).await
+}
+
 /// POST `body` to `url`, treating anything other than `{"ok":true,...}` as an
 /// error (surfacing Telegram's `description`). Returns the `result` object.
 async fn post_rich(url: &str, body: &serde_json::Value) -> anyhow::Result<serde_json::Value> {


### PR DESCRIPTION
## Problem

The footer-append edit path uses `ParseMode::Html` to edit the last intermediate message. When that intermediate was sent via `sendRichMessage` (native rich), the edit downgrades it to HTML card view — destroying native tables.

## Proof

Spike confirmed that `editMessageText` with `rich_message` format works:

1. Send native table via `sendRichMessage` → ok, native table rendered
2. Edit same message via `editMessageText` with `ParseMode::Html` → table replaced by card view (bug)
3. Edit same message via `editMessageText` with `rich_message` format → table preserved (fix)

## Fix

- Add `edit_rich_markdown()` to `rich/api.rs` — calls `editMessageText` with `rich_message` format
- Add `append_footer_to_last_intermediate()` helper — tries rich edit first, falls back to HTML on failure
- Both `handle_message` and `resume_session` call sites updated

## Files changed

- `src/channels/telegram/rich/api.rs` — new `edit_rich_markdown` function
- `src/channels/telegram/handler.rs` — new helper + 2 call site updates
