### PR TITLE
fix: gracefully handle Kitty keyboard enhancement on Windows

### DIFF
--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -148,12 +148,17 @@ pub async fn run(mut app: App) -> Result<()> {
         EnterAlternateScreen,
         EnableBracketedPaste,
         EnableFocusChange,
-        EnableMouseCapture,
-        // Kitty keyboard protocol: enables unambiguous modifier reporting
-        // so Shift+Enter is distinguishable from plain Enter. Silently
-        // ignored by terminals that don't support it (no-op, no errors).
-        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        EnableMouseCapture
     )?;
+    // Kitty keyboard protocol: enables unambiguous modifier reporting
+    // so Shift+Enter is distinguishable from plain Enter. Silently
+    // ignored by terminals that don't support it (no-op, no errors).
+    // On Windows, the legacy Console API errors instead of ignoring, so
+    // we deliberately discard the result.
+    let _ = execute!(
+        stdout,
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+    );
 
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;


### PR DESCRIPTION
## Problem

On Windows, the TUI crashes during startup with:

`
OpenCrabs crashed during startup
Keyboard progressive enhancement not implemented for the legacy Windows API.
`

This affects all Windows users, regardless of whether they use Windows Terminal or legacy console.

## Root Cause

PushKeyboardEnhancementFlags in src/tui/runner.rs is part of the Kitty keyboard protocol. On Windows, the legacy Console API throws an error instead of silently ignoring this feature (unlike Linux/macOS terminals).

The comment says it should be silently ignored, but it's inside an execute! macro with ? which propagates the error fatally.

## Fix

Split PushKeyboardEnhancementFlags out of the main execute! block and use let _ = to discard the result. The TUI starts fine without keyboard enhancement — Shift+Enter detection degrades gracefully on unsupported terminals.

1 file changed, 10 insertions(+), 5 deletions(-)