### PR TITLE
evolve: check migration compatibility before swapping binary

### DIFF
--- a/src/brain/tools/evolve.rs
+++ b/src/brain/tools/evolve.rs
@@ -358,6 +358,45 @@ async fn health_check_binary(path: &std::path::Path) -> std::result::Result<(), 
     }
 }
 
+/// Run the binary with `print-migration-count` and return the parsed count.
+/// Returns an error if the binary doesn't support this flag or the output
+/// can't be parsed.
+async fn get_binary_migration_count(path: &std::path::Path) -> std::result::Result<usize, String> {
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        tokio::process::Command::new(path)
+            .arg("print-migration-count")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(output)) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let count = stdout.trim().parse::<usize>().map_err(|e| {
+                format!(
+                    "could not parse migration count from '{stdout}': {e}"
+                )
+            })?;
+            Ok(count)
+        }
+        Ok(Ok(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let snippet: String = stderr.chars().take(200).collect();
+            Err(format!(
+                "print-migration-count exited with {}: {}",
+                output.status,
+                if snippet.is_empty() { "no stderr" } else { &snippet }
+            ))
+        }
+        Ok(Err(e)) => Err(format!("failed to spawn binary: {e}")),
+        Err(_) => Err("timed out after 10s".into()),
+    }
+}
+
 pub struct EvolveTool {
     progress: Option<ProgressCallback>,
 }
@@ -407,6 +446,10 @@ impl Tool for EvolveTool {
             .get("check_only")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+
+        let current_user_version: Option<i64> = input
+            .get("current_user_version")
+            .and_then(|v| v.as_i64());
 
         let current_version = crate::VERSION;
         let sid = context.session_id;
@@ -568,6 +611,7 @@ impl Tool for EvolveTool {
                         current_version,
                         latest_tag,
                         latest_version,
+                        current_user_version,
                     )
                     .await;
             }
@@ -664,6 +708,7 @@ impl EvolveTool {
         current_version: &str,
         latest_tag: &str,
         latest_version: &str,
+        current_user_version: Option<i64>,
     ) -> Result<ToolResult> {
         let suffix = match platform_suffix() {
             Some(s) => s,
@@ -907,6 +952,43 @@ impl EvolveTool {
             return Ok(ToolResult::error(format!(
                 "Health check failed ({reason}). Keeping current v{current_version}."
             )));
+        }
+
+        // Migration compatibility check: ensure new binary can handle the current DB schema
+        if let Some(db_version) = current_user_version {
+            match get_binary_migration_count(&tmp_path).await {
+                Ok(new_migration_count) => {
+                    let db_migration = db_version as usize;
+                    if db_migration > new_migration_count {
+                        tracing::warn!(
+                            target: "evolve",
+                            db_user_version = db_version,
+                            new_binary_migration_count = new_migration_count,
+                            session_id = %sid,
+                            "evolve: database schema v{} is newer than new binary's migration \
+                             count v{} — refusing to swap",
+                            db_migration,
+                            new_migration_count,
+                        );
+                        let _ = std::fs::remove_file(&tmp_path);
+                        return Ok(ToolResult::error(format!(
+                            "Database schema v{db_migration} is newer than v{latest_version}'s \
+                             migration support (v{new_migration_count}). \
+                             Keeping current v{current_version}. \
+                             This usually means the release predates your database schema."
+                        )));
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "evolve",
+                        error = %e,
+                        session_id = %sid,
+                        "evolve: could not determine new binary's migration count, \
+                         skipping compatibility check"
+                    );
+                }
+            }
         }
 
         // Backup

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -159,6 +159,9 @@ pub enum Commands {
     /// Print version and exit
     Version,
 
+    /// Print the database schema migration count (used by evolve for compatibility checks)
+    PrintMigrationCount,
+
     /// Check for and install the latest OpenCrabs release
     Evolve {
         /// Only check for updates without installing
@@ -505,7 +508,11 @@ pub async fn run() -> Result<()> {
             println!("opencrabs {}", env!("CARGO_PKG_VERSION"));
             Ok(())
         }
-        Some(Commands::Evolve { check_only }) => commands::cmd_evolve(check_only).await,
+        Some(Commands::PrintMigrationCount) => {
+            println!("{}", crate::db::Database::MIGRATION_COUNT);
+            Ok(())
+        }
+        Some(Commands::Evolve { check_only }) => commands::cmd_evolve(&config, check_only).await,
         Some(Commands::Migrate { source, dry_run }) => migrate::cmd_migrate(source, dry_run).await,
     }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2227,7 +2227,7 @@ pub(crate) async fn cmd_profile(operation: ProfileCommands) -> Result<()> {
 }
 
 /// Check for and install the latest OpenCrabs release
-pub(crate) async fn cmd_evolve(check_only: bool) -> Result<()> {
+pub(crate) async fn cmd_evolve(config: &crate::config::Config, check_only: bool) -> Result<()> {
     let current_version = crate::VERSION;
     println!("🔄 OpenCrabs v{current_version} — checking for updates...\n");
 
@@ -2244,6 +2244,30 @@ pub(crate) async fn cmd_evolve(check_only: bool) -> Result<()> {
         return Ok(());
     }
 
+    // Read the current database user_version for migration compatibility check
+    let current_user_version: Option<i64> = {
+        let db_path = &config.database.path;
+        if db_path.exists() {
+            match crate::db::Database::connect(db_path).await {
+                Ok(db) => {
+                    match db.get_user_version().await {
+                        Ok(ver) => Some(ver),
+                        Err(e) => {
+                            tracing::warn!("evolve: could not read user_version: {e}");
+                            None
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("evolve: could not open database: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    };
+
     // Full evolve — instantiate the tool and execute
     use crate::brain::tools::evolve::EvolveTool;
     use crate::brain::tools::{Tool, ToolExecutionContext};
@@ -2251,7 +2275,10 @@ pub(crate) async fn cmd_evolve(check_only: bool) -> Result<()> {
     use std::collections::HashMap;
 
     let tool = EvolveTool::new(None);
-    let input = json!({"check_only": false});
+    let input = json!({
+        "check_only": false,
+        "current_user_version": current_user_version
+    });
     let context = ToolExecutionContext {
         session_id: uuid::Uuid::new_v4(),
         working_directory: std::env::current_dir().unwrap_or_default(),

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -167,7 +167,7 @@ impl Database {
     }
 
     /// Total number of migrations defined below — keep in sync when adding new ones.
-    const MIGRATION_COUNT: usize = 27;
+    pub const MIGRATION_COUNT: usize = 27;
 
     /// Run database migrations
     pub async fn run_migrations(&self) -> Result<()> {
@@ -319,6 +319,23 @@ impl Database {
     pub fn close(&self) {
         self.pool.close();
         tracing::info!("Database connection closed");
+    }
+
+    /// Get the current database user_version (migration level).
+    ///
+    /// This is used by the evolve tool to check if the current binary
+    /// can handle the database before swapping.
+    pub async fn get_user_version(&self) -> Result<i64> {
+        let version = self
+            .pool
+            .get()
+            .await
+            .context("Failed to get connection for user_version")?
+            .interact(|conn| conn.pragma_query_value(None, "user_version", |r| r.get(0)))
+            .await
+            .map_err(interact_err)?
+            .context("Failed to read user_version")?;
+        Ok(version)
     }
 }
 


### PR DESCRIPTION
hey, this adds a check before the binary swap during evolve to prevent the case where the new binary can't handle the db schema.

the evolve tool runs \opencrabs print-migration-count\ on the downloaded binary, compares it to the current database's user_version, and bails out if the db is too new. also added a \print-migration-count\ subcommand so binaries can report their compiled-in migration count.

refs #205