### PR TITLE
feat(telegram): inbound reaction processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ OpenCrabs runs as a **single binary on your terminal** — no server, no gateway
 - Browser automation (optional, `browser` feature — auto-detects Chromium-based browsers via CDP, not Firefox)
 - Dynamic tool HTTP requests (only when you define HTTP tools in `tools.toml`)
 
+### 🔒 Zero Telemetry — Not Even Opt-In
+
+**OpenCrabs does not phone home. Ever.**
+
+No analytics. No tracking. No usage statistics. No remote logging. No crash reports. No "anonymous telemetry." Nothing.
+
+Your data stays on your machine. Your conversations, your tools, your memory, your configuration, your API keys — all of it. The only outbound traffic is what you explicitly initiate: LLM API calls, web searches, GitHub commands, browser automation.
+
+Other AI harnesses silently collect usage data, performance metrics, and behavioral analytics. OpenCrabs makes a different bet: **what happens on your machine stays on your machine.**
+
+This isn't a privacy policy checkbox. It's an architectural decision. There is no telemetry code to disable, no opt-out flag to set, no analytics service to block. There's simply nothing to send.
+
 ---
 
 ## Table of Contents

--- a/src/channels/telegram/agent.rs
+++ b/src/channels/telegram/agent.rs
@@ -3,7 +3,7 @@
 //! Agent struct and startup logic.
 
 use super::TelegramState;
-use super::handler::handle_message;
+use super::handler::{handle_message, handle_reaction};
 use crate::brain::agent::AgentService;
 use crate::config::Config;
 use crate::db::ChannelMessageRepository;
@@ -1063,10 +1063,25 @@ impl TelegramAgent {
             // updates in teloxide 0.17+ — they flow through msg_handler and are
             // captured in handler.rs BEFORE the allowlist check so bot/user IDs
             // are logged even when the joining user isn't allowlisted yet.
+
+            // Inbound reaction handler: user reacts on a bot message, bot may
+            // react back or respond with text. See handle.rs for details.
+            let reaction_handler = Update::filter_message_reaction_updated().endpoint({
+                let deps = deps.clone();
+                move |bot: Bot, reaction: teloxide::types::MessageReactionUpdated| {
+                    let deps = deps.clone();
+                    async move {
+                        spawn_handle_reaction(bot, reaction, deps);
+                        ResponseResult::Ok(())
+                    }
+                }
+            });
+
             let tree = dptree::entry()
                 .branch(msg_handler)
                 .branch(edited_handler)
-                .branch(cb_handler);
+                .branch(cb_handler)
+                .branch(reaction_handler);
 
             // Retry loop: if the dispatcher exits (network hiccup, Telegram conflict
             // from another process using the same token, etc.), wait and reconnect.
@@ -1149,9 +1164,40 @@ fn spawn_handle_message(bot: Bot, msg: Message, deps: DispatchDeps) {
     });
 }
 
+/// Dispatch an inbound reaction to the agent in the background.
+/// Same pattern as `spawn_handle_message`: isolate panics, keep dispatcher free.
+fn spawn_handle_reaction(
+    bot: Bot,
+    reaction: teloxide::types::MessageReactionUpdated,
+    deps: DispatchDeps,
+) {
+    tokio::spawn(async move {
+        let result = tokio::task::spawn(async move {
+            handle_reaction(
+                bot,
+                reaction,
+                deps.agent,
+                deps.shared_session,
+                deps.telegram_state,
+                deps.config_rx,
+                deps.channel_msg_repo,
+            )
+            .await
+        })
+        .await;
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::error!("Telegram handle_reaction error: {e}"),
+            Err(panic_err) => {
+                tracing::error!("Telegram handle_reaction panicked: {:?}", panic_err)
+            }
+        }
+    });
+}
+
 /// Wait for a peer bot's edit stream to go quiet, then process the final
 /// text. If a newer frame arrived while we waited (generation moved on) we
-/// bow out — that frame's own watcher will fire. The matching watcher
+/// bow out: that frame's own watcher will fire. The matching watcher
 /// removes the pending entry, so the map self-cleans.
 fn spawn_settle_watcher(
     key: (ChatId, MessageId),

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -3290,6 +3290,12 @@ pub(crate) async fn handle_message(
             let text_only = crate::utils::sanitize::strip_llm_artifacts(&text_only);
             let text_only = redact_secrets(&text_only);
 
+            // Extract <<react:emoji>> directive — the LLM outputs this to
+            // signal a reaction-only response (no text bubble). If the
+            // response is ONLY a reaction, the emoji is sent as a Telegram
+            // reaction on the user's message and text delivery is skipped.
+            let (text_only, react_emoji) = crate::utils::extract_react_marker(&text_only);
+
             // Dedup: strip text that was already sent as intermediate messages
             // to avoid duplicating content on Telegram. An intermediate chunk
             // that already carries the final answer (e.g. "Done. Uploaded to
@@ -3317,6 +3323,34 @@ pub(crate) async fn handle_message(
             } else {
                 text_only
             };
+
+            // Reaction directive: if the LLM included <<react:emoji>>, send
+            // a reaction on the user's message. For reaction-only responses
+            // (empty text after stripping the directive), skip all text/TTS
+            // delivery and just react.
+            if let Some(ref emoji) = react_emoji {
+                let reaction = teloxide::types::ReactionType::Emoji {
+                    emoji: emoji.clone(),
+                };
+                if let Err(e) = bot
+                    .set_message_reaction(msg.chat.id, msg.id)
+                    .reaction(vec![reaction])
+                    .is_big(false)
+                    .await
+                {
+                    tracing::warn!("Telegram: failed to set reaction: {}", e);
+                }
+                if text_only.trim().is_empty() {
+                    tracing::info!(
+                        "Telegram: reaction-only response ({}), skipping text delivery",
+                        emoji
+                    );
+                    if let Some(mid) = streaming_msg_id {
+                        let _ = bot.delete_message(msg.chat.id, mid).await;
+                    }
+                    return Ok(());
+                }
+            }
 
             // Context budget footer is appended to the response text for
             // display only. It must NOT be stored in the session/messages
@@ -4191,6 +4225,9 @@ pub(crate) async fn resume_session(
             let text_only = crate::utils::sanitize::strip_llm_artifacts(&text_only);
             let text_only = redact_secrets(&text_only);
 
+            // Extract <<react:emoji>> directive — see handle_message.
+            let (text_only, react_emoji) = crate::utils::extract_react_marker(&text_only);
+
             // Dedup intermediates already delivered so we don't duplicate
             // them when editing the streaming placeholder with the final.
             let sent = {
@@ -4207,6 +4244,23 @@ pub(crate) async fn resume_session(
             } else {
                 text_only
             };
+
+            // Reaction-only: if text is empty after dedup and the LLM used
+            // <<react:emoji>>, skip delivery. Unlike handle_message, resume
+            // has no user message to react to (the original message id is
+            // lost across restarts), so we just clean up the placeholder.
+            if text_only.trim().is_empty()
+                && let Some(ref emoji) = react_emoji
+            {
+                tracing::info!(
+                    "Telegram resume: reaction-only response ({}), skipping delivery",
+                    emoji
+                );
+                if let Some(mid) = streaming_msg_id {
+                    let _ = bot.delete_message(chat_id, mid).await;
+                }
+                return Ok(());
+            }
 
             // Context budget footer is appended to display text, not sent as separate message
             let ctx_max = agent.context_limit_for_session(session_id);

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2462,7 +2462,18 @@ pub(crate) async fn handle_message(
     let agent_input = format!(
         "[Channel: Telegram — your text response is automatically sent to this chat. \
          Do NOT call telegram_send to deliver your answer. Only use telegram_send for: \
-         sending to a different chat_id, media, polls, buttons, reactions, or moderation.]\n{agent_input}"
+         sending to a different chat_id, media, polls, buttons, reactions, or moderation.]\n\
+         \n\
+         [Reaction directive: You can react to the user's message using <<react:EMOJI>>. \
+         This is for UTILITARIAN acknowledgment only — not decorative or companion behavior. \
+         Use it sparingly when:\n\
+         - A simple acknowledgment suffices (thumbs up for confirmations, checkmark for completed tasks)\n\
+         - The user shared a link and you have nothing to add (eyes emoji)\n\
+         - A quick yes/no reaction is more appropriate than a text response\n\
+         To react-only (no text), output ONLY the directive: <<react:👍>>\n\
+         To react AND respond, include the directive at the start: <<react:✅>> Done, uploaded to Drive.\n\
+         Do NOT use for: expressing emotions, being cute, filling silence, or replacing substantive answers.]\n\
+         {agent_input}"
     );
 
     // ── Streaming setup ───────────────────────────────────────────────────────

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -4468,6 +4468,197 @@ pub(crate) async fn resume_session(
     Ok(())
 }
 
+/// Handle an inbound reaction event (user reacted to a message in a chat).
+///
+/// When a user adds an emoji reaction to one of the bot's messages, we:
+/// 1. Extract newly-added emoji reactions (ignore removals and non-emoji)
+/// 2. Check the reactor is allowlisted and not the bot itself
+/// 3. Look up the bot's original message content from `channel_messages`
+/// 4. Forward a synthetic prompt to the LLM: "User reacted with 🤔 to your message: ..."
+/// 5. Deliver the LLM's response — which may be text, a reaction-only ack, or both
+///
+/// Reactions on user-to-user messages (not the bot's messages) are silently skipped
+/// since we have no bot content to contextualise.
+pub(crate) async fn handle_reaction(
+    bot: Bot,
+    reaction: teloxide::types::MessageReactionUpdated,
+    agent: Arc<AgentService>,
+    shared_session: Arc<Mutex<Option<Uuid>>>,
+    telegram_state: Arc<TelegramState>,
+    config_rx: tokio::sync::watch::Receiver<Config>,
+    channel_msg_repo: ChannelMessageRepository,
+) -> ResponseResult<()> {
+    // ── 1. Extract newly-added emoji reactions ──────────────────────────
+    // new_reaction is the FULL current set; old_reaction was the previous set.
+    // The difference tells us what was *added*.
+    let added: Vec<&teloxide::types::ReactionType> = reaction
+        .new_reaction
+        .iter()
+        .filter(|r| !reaction.old_reaction.contains(r))
+        .collect();
+    if added.is_empty() {
+        return Ok(()); // Only removals, nothing to process
+    }
+
+    let emoji = match added.first() {
+        Some(teloxide::types::ReactionType::Emoji { emoji }) => emoji.clone(),
+        _ => return Ok(()), // Custom-emoji or paid reaction — skip
+    };
+
+    // ── 2. Resolve the actor ────────────────────────────────────────────
+    let (user_id, user_name) = if let Some(user) = reaction.actor.user() {
+        (user.id.0 as i64, user.first_name.clone())
+    } else {
+        // Anonymous channel/chat reaction — skip
+        return Ok(());
+    };
+
+    // ── 3. Allowlist check ──────────────────────────────────────────────
+    let cfg = config_rx.borrow().clone();
+    let chat_id = reaction.chat.id;
+    let chat_id_str = chat_id.0.to_string();
+    let is_dm = matches!(reaction.chat.kind, ChatKind::Private { .. });
+    if !cfg.channels.telegram.user_allowed(&user_id.to_string(), &chat_id_str, is_dm) {
+        tracing::debug!(
+            "Telegram reaction: ignoring non-allowed user {} ({}), emoji={}",
+            user_id, user_name, emoji
+        );
+        return Ok(());
+    }
+
+    // ── 4. Ignore bot's own reactions ───────────────────────────────────
+    if let Some(bot_uid) = telegram_state.bot_user_id().await
+        && user_id == bot_uid
+    {
+        return Ok(());
+    }
+
+    // ── 5. Look up the reacted-to message in channel_messages ───────────
+    // Only proceed if the message was sent by the bot.
+    let msg_id = reaction.message_id;
+    let content = match channel_msg_repo
+        .bot_content_by_platform_message_id(
+            "telegram",
+            &chat_id_str,
+            &msg_id.0.to_string(),
+        )
+        .await
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            tracing::debug!(
+                "Telegram reaction: message {} not a stored bot message — skipping",
+                msg_id.0
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            tracing::warn!("Telegram reaction: DB lookup failed for msg {}: {}", msg_id.0, e);
+            return Ok(());
+        }
+    };
+
+    // ── 6. Resolve session ──────────────────────────────────────────────
+    // Reactions carry no forum-thread info, so topic_id = None.
+    let session_id = if let Some(sid) = telegram_state.chat_session(chat_id.0, None).await {
+        sid
+    } else if let Some(sid) = *shared_session.lock().await {
+        sid
+    } else {
+        tracing::debug!(
+            "Telegram reaction: no session for chat {} — skipping",
+            chat_id.0
+        );
+        return Ok(());
+    };
+
+    // ── 7. Build synthetic prompt ───────────────────────────────────────
+    // Truncate the original message to keep the prompt lightweight.
+    let preview: String = content.chars().take(500).collect();
+    let prompt = format!(
+        "[Reaction notification] User \"{}\" reacted with {} to your message:\n\"{}\"\n\n\
+         You may react back (use <<react:EMOJI>>), reply with text, \
+         or do both. If the reaction doesn't warrant a response, reply with \
+         <<react:{}>> to silently acknowledge.",
+        user_name, emoji, preview, emoji
+    );
+
+    tracing::info!(
+        "Telegram reaction: {} ({}) reacted with {} on bot message {} in chat {}, \
+         forwarding to session {}",
+        user_name, user_id, emoji, msg_id.0, chat_id.0, session_id
+    );
+
+    // ── 8. Call agent ───────────────────────────────────────────────────
+    let response = match agent.send_message(session_id, prompt, None).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("Telegram reaction: agent error for session {}: {}", session_id, e);
+            return Ok(());
+        }
+    };
+
+    // ── 9. Sanitize ─────────────────────────────────────────────────────
+    let (text_only, _img_paths) = crate::utils::extract_img_markers(&response.content);
+    let text_only = crate::utils::sanitize::strip_llm_artifacts(&text_only);
+    let text_only = redact_secrets(&text_only);
+    let (text_only, react_emoji) = crate::utils::extract_react_marker(&text_only);
+
+    // ── 10. Deliver reaction back on the original message ───────────────
+    if let Some(ref r_emoji) = react_emoji {
+        let reaction_type = teloxide::types::ReactionType::Emoji {
+            emoji: r_emoji.clone(),
+        };
+        if let Err(e) = bot
+            .set_message_reaction(chat_id, msg_id)
+            .reaction(vec![reaction_type])
+            .is_big(false)
+            .await
+        {
+            tracing::warn!("Telegram reaction: failed to set reaction: {}", e);
+        }
+        if text_only.trim().is_empty() {
+            tracing::info!(
+                "Telegram reaction: reaction-only ack ({}) on message {}",
+                r_emoji, msg_id.0
+            );
+            return Ok(());
+        }
+    }
+
+    // ── 11. Deliver text response ───────────────────────────────────────
+    if !text_only.trim().is_empty() {
+        let html = md_to_html(&text_only);
+        if let Err(e) = message_in_thread(&bot, chat_id, None, html).await {
+            tracing::warn!("Telegram reaction: failed to send text reply: {}", e);
+            return Ok(());
+        }
+
+        // Record in channel_messages so conversation history sees the reply
+        let bot_display_name = telegram_state
+            .bot_username()
+            .await
+            .map(|u| format!("@{}", u))
+            .unwrap_or_else(|| "OpenCrabs".to_string());
+        let chat_title = reaction.chat.title().unwrap_or("DM");
+        let cm = DbChannelMessage::new(
+            "telegram".to_string(),
+            chat_id.0.to_string(),
+            Some(chat_title.to_string()),
+            "bot:opencrabs".to_string(),
+            bot_display_name,
+            text_only,
+            "text".to_string(),
+            None,
+        );
+        if let Err(e) = channel_msg_repo.insert(&cm).await {
+            tracing::warn!("Telegram reaction: failed to record bot reply: {}", e);
+        }
+    }
+
+    Ok(())
+}
+
 /// Format a reply-to context line for the agent prompt.
 ///
 /// When a Telegram user replies to a message they can optionally

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -3324,13 +3324,24 @@ pub(crate) async fn handle_message(
                 sent.len(),
             );
             let pre_dedup_text = text_only.clone();
-            let text_only = if !sent.is_empty() && sent.iter().any(|i| i.trim() == text_only.trim())
-            {
-                tracing::info!(
-                    "Telegram dedup: exact match found among {} intermediates — suppressing final response",
-                    sent.len()
-                );
-                String::new()
+            // Normalize whitespace for comparison — collapse runs of
+            // whitespace (including newlines) to single spaces so that
+            // minor formatting differences between the streamed
+            // intermediate and the final response don't bypass dedup.
+            let norm = |s: &str| -> String {
+                s.split_whitespace().collect::<Vec<_>>().join(" ")
+            };
+            let text_only = if !sent.is_empty() {
+                let norm_final = norm(&text_only);
+                if sent.iter().any(|i| norm(i) == norm_final) {
+                    tracing::info!(
+                        "Telegram dedup: match found among {} intermediates (normalized) — suppressing final response",
+                        sent.len()
+                    );
+                    String::new()
+                } else {
+                    text_only
+                }
             } else {
                 text_only
             };

--- a/src/channels/whatsapp/agent.rs
+++ b/src/channels/whatsapp/agent.rs
@@ -195,6 +195,11 @@ impl WhatsAppAgent {
                                     wa_state
                                         .set_owner_jid(format!("{num}@s.whatsapp.net"))
                                         .await;
+                                    // Flag this as a fresh pairing so the
+                                    // Connected handler knows to fire the
+                                    // one-time greeting (not suppress it as a
+                                    // routine restart).
+                                    wa_state.set_first_pair_pending();
                                 }
                             }
                             Event::Connected(_) => {
@@ -206,14 +211,15 @@ impl WhatsAppAgent {
                                     Some(j) => Some(j),
                                     None => owner_jid.clone(),
                                 };
-                                // Greet only on the FIRST connect of this run, not
-                                // on every reconnect. Keepalive timeouts force
-                                // frequent reconnects, each emitting Connected; the
-                                // `connected` flag stays set across them (only a
-                                // user reset clears it), so a true reading here
-                                // means this is a reconnect and the greeting must
-                                // be suppressed. Otherwise the owner is spammed
-                                // with the same confirmation over and over.
+                                // Greet only on a fresh pairing (first-time or
+                                // re-pair after reset), not on every app restart
+                                // or reconnect. The `first_pair_pending` flag is
+                                // set by PairSuccess and consumed here: it is
+                                // `true` exactly once per pairing, so a plain
+                                // restart (where no PairSuccess fires) never
+                                // triggers the greeting. The `was_connected`
+                                // guard still suppresses keepalive reconnects
+                                // within the same session.
                                 let was_connected = wa_state.is_connected().await;
                                 wa_state.set_connected(client.clone(), owner.clone()).await;
                                 if was_connected {
@@ -221,22 +227,29 @@ impl WhatsAppAgent {
                                         "WhatsApp: reconnected — suppressing duplicate \
                                          confirmation greeting"
                                     );
-                                } else if let Some(jid) = owner {
-                                    // First connect: a real agent turn into the
+                                } else if wa_state.take_first_pair_pending() {
+                                    // Fresh pairing: a real agent turn into the
                                     // owner's self-chat. Spawned so the event loop
                                     // is never blocked by a full agent turn.
-                                    let num = jid.split('@').next().unwrap_or(&jid).to_string();
-                                    tokio::spawn(handler::send_connection_greeting(
-                                        client.clone(),
-                                        agent.clone(),
-                                        session_svc.clone(),
-                                        wa_state.clone(),
-                                        num,
-                                    ));
+                                    if let Some(jid) = owner {
+                                        let num = jid.split('@').next().unwrap_or(&jid).to_string();
+                                        tokio::spawn(handler::send_connection_greeting(
+                                            client.clone(),
+                                            agent.clone(),
+                                            session_svc.clone(),
+                                            wa_state.clone(),
+                                            num,
+                                        ));
+                                    } else {
+                                        tracing::warn!(
+                                            "WhatsApp: connected but no owner number known — \
+                                             skipping confirmation greeting"
+                                        );
+                                    }
                                 } else {
-                                    tracing::warn!(
-                                        "WhatsApp: connected but no owner number known — \
-                                         skipping confirmation greeting"
+                                    tracing::debug!(
+                                        "WhatsApp: connected (app restart) — no fresh pair, \
+                                         staying silent"
                                     );
                                 }
                             }

--- a/src/channels/whatsapp/mod.rs
+++ b/src/channels/whatsapp/mod.rs
@@ -82,6 +82,12 @@ pub struct WhatsAppState {
     /// flashes a QR after the account is already linked. Reset by
     /// `request_restart` when a fresh pairing is requested.
     connected: std::sync::atomic::AtomicBool,
+    /// Set on `Event::PairSuccess` so the subsequent `Event::Connected`
+    /// knows this is a fresh pairing (first-time or re-pair after reset),
+    /// not a routine reconnect after a restart. Consumed by
+    /// `take_first_pair_pending` so the greeting fires only once per
+    /// pairing and never on a plain app restart.
+    first_pair_pending: std::sync::atomic::AtomicBool,
     /// Photo batching buffer: (chat_jid) → Vec<(img_marker, caption)>
     /// When multiple photos arrive in quick succession (WhatsApp sends
     /// each as a separate message), we buffer them and dispatch together.
@@ -116,6 +122,7 @@ impl WhatsAppState {
             last_qr: std::sync::Mutex::new(None),
             restart_requested: std::sync::atomic::AtomicBool::new(false),
             connected: std::sync::atomic::AtomicBool::new(false),
+            first_pair_pending: std::sync::atomic::AtomicBool::new(false),
             photo_buffer: Mutex::new(HashMap::new()),
             photo_debounce: Mutex::new(HashMap::new()),
         }
@@ -219,6 +226,21 @@ impl WhatsAppState {
     /// Consume the restart request (returns whether one was pending).
     pub fn take_restart_request(&self) -> bool {
         self.restart_requested
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Mark that a fresh pairing just succeeded. The next `Connected` event
+    /// will fire the one-time connection greeting.
+    pub fn set_first_pair_pending(&self) {
+        self.first_pair_pending
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Consume the first-pair flag. Returns `true` exactly once per pairing
+    /// (first-time or re-pair after reset), then resets to `false` so a plain
+    /// app restart never re-triggers the greeting.
+    pub fn take_first_pair_pending(&self) -> bool {
+        self.first_pair_pending
             .swap(false, std::sync::atomic::Ordering::SeqCst)
     }
 

--- a/src/db/repository/channel_message.rs
+++ b/src/db/repository/channel_message.rs
@@ -197,6 +197,38 @@ impl ChannelMessageRepository {
             .context("Failed to look up channel message by platform id")
     }
 
+    /// Like [`content_by_platform_message_id`] but only returns content when the
+    /// message was sent by the bot (sender_id = 'bot:opencrabs'). Used by the
+    /// inbound reaction handler to skip reactions on user-to-user messages.
+    pub async fn bot_content_by_platform_message_id(
+        &self,
+        channel: &str,
+        chat_id: &str,
+        platform_message_id: &str,
+    ) -> Result<Option<String>> {
+        let ch = channel.to_string();
+        let cid = chat_id.to_string();
+        let pmid = platform_message_id.to_string();
+        self.pool
+            .get()
+            .await
+            .context("Failed to get connection")?
+            .interact(move |conn| {
+                conn.query_row(
+                    "SELECT content FROM channel_messages \
+                     WHERE channel = ?1 AND channel_chat_id = ?2 \
+                     AND platform_message_id = ?3 AND sender_id = 'bot:opencrabs' \
+                     ORDER BY created_at DESC LIMIT 1",
+                    params![ch, cid, pmid],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()
+            })
+            .await
+            .map_err(interact_err)?
+            .context("Failed to look up bot message by platform id")
+    }
+
     /// Most recent non-null forum topic name for a thread, used to label the
     /// session after the topic ("Devops") instead of its numeric thread id
     /// ("topic:2"). Telegram only carries the name on regular topic messages

--- a/src/tests/onboarding_wizard_test.rs
+++ b/src/tests/onboarding_wizard_test.rs
@@ -460,7 +460,7 @@ fn test_supports_model_fetch() {
         ("openrouter", true),
         ("minimax", false),
         ("zhipu", true),
-        ("claude-cli", false),
+        ("claude-cli", true),
         ("opencode-cli", true),
         ("codex-cli", true),
         ("codex", true),

--- a/src/tui/provider_selector.rs
+++ b/src/tui/provider_selector.rs
@@ -152,6 +152,7 @@ impl ProviderSelectorState {
                 | "codex-cli"
                 | "codex"
                 | "opencode"
+                | "claude-cli"
                 | "ollama"
         )
     }

--- a/src/utils/image.rs
+++ b/src/utils/image.rs
@@ -14,6 +14,23 @@ pub fn extract_vid_markers(text: &str) -> (String, Vec<String>) {
     extract_markers_with_prefix(text, "<<VID:")
 }
 
+/// Extract `<<react:emoji>>` directive from text.
+///
+/// Returns `(cleaned_text, Option<emoji>)` — the text has all `<<react:...>>`
+/// markers removed and trimmed, and the first valid emoji is returned.
+/// Follows the same `<<PREFIX:value>>` pattern as `<<IMG:path>>` and
+/// `<<VID:path>>`. Multiple directives are stripped but only the first
+/// emoji is returned.
+///
+/// The LLM outputs `<<react:👍>>` to signal a reaction-only response
+/// (or a reaction alongside text). Channel handlers use the returned
+/// emoji to call `set_message_reaction` on the user's message.
+pub fn extract_react_marker(text: &str) -> (String, Option<String>) {
+    let (cleaned, markers) = extract_markers_with_prefix(text, "<<react:");
+    let emoji = markers.into_iter().next();
+    (cleaned, emoji)
+}
+
 /// Generic `<<PREFIX:path>>` marker extractor. Walks the text, removes every
 /// `<<PREFIX:...>>` occurrence, and collects the inner paths in order. UTF-8
 /// safe (works on byte indices that lie on char boundaries — `find`/`replace_range`
@@ -36,4 +53,71 @@ fn extract_markers_with_prefix(text: &str, prefix: &str) -> (String, Vec<String>
     }
 
     (out.trim().to_string(), paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── extract_react_marker ─────────────────────────────────────────────
+
+    #[test]
+    fn react_bare_directive() {
+        let (text, emoji) = extract_react_marker("<<react:👍>>");
+        assert_eq!(text, "");
+        assert_eq!(emoji.as_deref(), Some("👍"));
+    }
+
+    #[test]
+    fn react_directive_with_text() {
+        let (text, emoji) = extract_react_marker("Sure thing! <<react:✅>>");
+        assert_eq!(text, "Sure thing!");
+        assert_eq!(emoji.as_deref(), Some("✅"));
+    }
+
+    #[test]
+    fn react_no_directive() {
+        let (text, emoji) = extract_react_marker("Just a normal message.");
+        assert_eq!(text, "Just a normal message.");
+        assert!(emoji.is_none());
+    }
+
+    #[test]
+    fn react_multiple_directives_uses_first() {
+        let (text, emoji) = extract_react_marker("<<react:👍>> and <<react:❤️>>");
+        assert_eq!(text, "and");
+        assert_eq!(emoji.as_deref(), Some("👍"));
+    }
+
+    #[test]
+    fn react_empty_directive_ignored() {
+        let (text, emoji) = extract_react_marker("<<react:>>");
+        assert_eq!(text, "");
+        assert!(emoji.is_none());
+    }
+
+    #[test]
+    fn react_malformed_no_closing() {
+        // Missing >> — should be left untouched
+        let (text, emoji) = extract_react_marker("<<react:👍");
+        assert_eq!(text, "<<react:👍");
+        assert!(emoji.is_none());
+    }
+
+    #[test]
+    fn react_whitespace_trimmed() {
+        let (text, emoji) = extract_react_marker("  <<react:🔥>>  ");
+        assert_eq!(text, "");
+        assert_eq!(emoji.as_deref(), Some("🔥"));
+    }
+
+    // ── extract_img_markers (existing, regression) ───────────────────────
+
+    #[test]
+    fn img_basic() {
+        let (text, paths) = extract_img_markers("here <<IMG:/tmp/a.png>> done");
+        // The extractor removes the marker but doesn't collapse interior whitespace.
+        assert_eq!(text, "here  done");
+        assert_eq!(paths, vec!["/tmp/a.png"]);
+    }
 }

--- a/src/utils/image.rs
+++ b/src/utils/image.rs
@@ -111,6 +111,36 @@ mod tests {
         assert_eq!(emoji.as_deref(), Some("🔥"));
     }
 
+    #[test]
+    fn react_non_emoji_text_still_extracted() {
+        // Even non-standard emoji text is extracted as-is; the caller decides validity
+        let (text, emoji) = extract_react_marker("<<react:hello>>");
+        assert_eq!(text, "");
+        assert_eq!(emoji.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn react_with_surrounding_newlines() {
+        let (text, emoji) = extract_react_marker("\n\n<<react:🔥>>\n\n");
+        assert_eq!(text, "");
+        assert_eq!(emoji.as_deref(), Some("🔥"));
+    }
+
+    #[test]
+    fn react_embedded_in_middle() {
+        let (text, emoji) = extract_react_marker("Hello <<react:👋>> world");
+        assert_eq!(text, "Hello  world");
+        assert_eq!(emoji.as_deref(), Some("👋"));
+    }
+
+    #[test]
+    fn react_only_react_with_no_extra_text() {
+        // The common reaction-only case: LLM outputs just the directive
+        let (text, emoji) = extract_react_marker("<<react:✅>>");
+        assert!(text.trim().is_empty());
+        assert_eq!(emoji.as_deref(), Some("✅"));
+    }
+
     // ── extract_img_markers (existing, regression) ───────────────────────
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,7 +20,7 @@ pub use approval::{
     check_approval_policy, persist_auto_always_policy, persist_auto_session_policy,
 };
 pub use file_extract::{FileContent, classify_file, inject_file_content, process_file_with_vision};
-pub use image::{extract_img_markers, extract_vid_markers};
+pub use image::{extract_img_markers, extract_react_marker, extract_vid_markers};
 pub use retry::{RetryConfig, RetryableError, retry, retry_with_check};
 pub use sanitize::{redact_secrets, redact_tool_input};
 pub use string::{format_ctx_footer, strip_ctx_footer, truncate_str};


### PR DESCRIPTION
## What

When a user reacts to an OpenCrabs message on Telegram (e.g. thinking, thumbs up, X), the bot now **sees** the reaction, resolves the original message content, and lets the LLM decide whether to react back, text reply, or stay silent.

This completes the reaction system started in #257 (outbound reaction-only responses).

## Why

User reactions on bot messages are real-time feedback signals. A thinking emoji means "I have a question". A thumbs up means "got it". An X means "that's wrong". The LLM should be aware of this and respond appropriately.

## Scope

| Component | Change |
|-----------|--------|
| **Channel message repo** | New `bot_content_by_platform_message_id` method: looks up bot messages only (sender_id = `bot:opencrabs`) |
| **handler.rs** | New `handle_reaction` function: extracts added reactions, filters non-allowed users + bot self-reactions, resolves bot message content, builds synthetic prompt for LLM, delivers response (reaction-only or text) |
| **agent.rs** | Wire `Update::filter_message_reaction_updated().endpoint(handle_reaction)` into dispatcher tree |

## Flow

```
User reacts thinking emoji on bot message #42
  -> MessageReactionUpdated arrives
  -> Check: allowed user? Not bot itself?
  -> Look up message #42 in channel_messages (bot messages only)
  -> Found: "Here is the answer to your question..."
  -> Resolve session for this chat
  -> Build synthetic prompt: "User reacted with thinking to your message: ..."
  -> LLM decides: react back, text reply, or nothing
  -> Deliver response
```

## Known Limitations

- **Forum topics:** `MessageReactionUpdated` does not carry thread/topic info. Replies go to the General topic. TODO for future.
- **Rate limiting:** Not yet implemented. If users spam reactions, each triggers an agent call. Can add cooldown later.

## Testing

- React with thinking emoji on a bot message, bot should react back or text reply
- React with thumbs up on a bot message, bot should acknowledge silently
- React on a user message, bot should ignore (not a bot message)
- Non-allowed user reacts, bot should ignore
- React with non-emoji (custom sticker), bot should ignore
- Multiple rapid reactions, no spam (manual check, rate limiting TBD)

## Commits (on this branch)

Will include atomic commits per task:
1. `feat(db): bot_content_by_platform_message_id method`
2. `feat(telegram): handle_reaction endpoint`
3. `feat(telegram): wire reaction handler into dispatcher`
