### PR TITLE
feat(prompt): three-tier project directive-file discovery

### DIFF
--- a/src/brain/directives.rs
+++ b/src/brain/directives.rs
@@ -1,0 +1,325 @@
+//! Project directive-file discovery.
+//!
+//! Scans a project working directory for the directive / rule files that the
+//! major AI coding agents use (Claude Code, Cursor, Windsurf, Cline, Gemini,
+//! GitHub Copilot, OpenCode, and the cross-tool `AGENTS.md` convention) and
+//! classifies each into one of three tiers so the system prompt can surface
+//! them with the right guidance.
+//!
+//! The module is pure and filesystem-only: no logging, no globals. It takes an
+//! already tilde-expanded `root` path and returns owned data, which keeps it
+//! trivially testable and keeps `prompt_builder` thin.
+
+use std::path::Path;
+
+use crate::brain::skills::split_frontmatter;
+
+/// When a discovered directive file should be applied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DirectiveTier {
+    /// Always relevant: plain root files, or rule files with no conditional
+    /// frontmatter (Cursor `alwaysApply: true`, Claude/Cline rules without
+    /// `paths`). Read whenever working in the project.
+    Always,
+    /// Scoped to files matching a glob / path pattern (Cursor `globs`,
+    /// Claude/Cline `paths`). The payload is the normalized pattern list.
+    Conditional(String),
+    /// Applied by judgement from a `description` (Cursor `.mdc` with neither
+    /// `alwaysApply` nor `globs`). The payload is the description text.
+    OnDemand(String),
+}
+
+/// A directive file discovered under a project root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectiveFile {
+    /// Path relative to the project root (e.g. `.cursor/rules/api.mdc`).
+    pub rel_path: String,
+    pub tier: DirectiveTier,
+}
+
+/// Root-level single-file directives, always relevant (plain markdown, no
+/// frontmatter contract).
+const ROOT_FILES: &[&str] = &[
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CLAUDE.local.md",
+    "GEMINI.md",
+    ".cursorrules",
+    ".windsurfrules",
+];
+
+/// Single-file directives at a fixed sub-path, always relevant.
+const NESTED_FILES: &[&str] = &[
+    ".claude/CLAUDE.md",
+    ".github/copilot-instructions.md",
+    ".opencode/AGENTS.md",
+];
+
+/// How a rule directory's frontmatter maps to tiers.
+enum FrontmatterKind {
+    /// Cursor `.mdc`: `alwaysApply` (bool) / `globs` (list) / `description`.
+    Cursor,
+    /// Claude Code & Cline: `paths` (list) present means conditional, absent
+    /// means always.
+    Paths,
+}
+
+/// Discover and classify directive files under `root`.
+///
+/// Returns an empty vec when `root` is not a directory or nothing is found.
+/// `root` must already be tilde-expanded to a real absolute path.
+pub fn discover(root: &Path) -> Vec<DirectiveFile> {
+    if !root.is_dir() {
+        return Vec::new();
+    }
+    let mut found: Vec<DirectiveFile> = Vec::new();
+
+    for name in ROOT_FILES {
+        if root.join(name).is_file() {
+            found.push(DirectiveFile {
+                rel_path: (*name).to_string(),
+                tier: DirectiveTier::Always,
+            });
+        }
+    }
+    for rel in NESTED_FILES {
+        if root.join(rel).is_file() {
+            found.push(DirectiveFile {
+                rel_path: (*rel).to_string(),
+                tier: DirectiveTier::Always,
+            });
+        }
+    }
+
+    // `.clinerules` may be a single file OR a directory of rule files.
+    let clinerules = root.join(".clinerules");
+    if clinerules.is_file() {
+        found.push(DirectiveFile {
+            rel_path: ".clinerules".to_string(),
+            tier: DirectiveTier::Always,
+        });
+    } else if clinerules.is_dir() {
+        collect_rule_dir(
+            root,
+            &clinerules,
+            &["md", "txt"],
+            &FrontmatterKind::Paths,
+            &mut found,
+        );
+    }
+
+    // `.claude/rules/**` — Claude Code modular rules.
+    let claude_rules = root.join(".claude").join("rules");
+    if claude_rules.is_dir() {
+        collect_rule_dir(
+            root,
+            &claude_rules,
+            &["md"],
+            &FrontmatterKind::Paths,
+            &mut found,
+        );
+    }
+
+    // `.cursor/rules/**` — Cursor `.mdc` rules.
+    let cursor_rules = root.join(".cursor").join("rules");
+    if cursor_rules.is_dir() {
+        collect_rule_dir(
+            root,
+            &cursor_rules,
+            &["mdc"],
+            &FrontmatterKind::Cursor,
+            &mut found,
+        );
+    }
+
+    found.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+    found.dedup_by(|a, b| a.rel_path == b.rel_path);
+    found
+}
+
+/// Recursively collect rule files with the given extensions from `dir`,
+/// classifying each by its frontmatter.
+fn collect_rule_dir(
+    root: &Path,
+    dir: &Path,
+    exts: &[&str],
+    kind: &FrontmatterKind,
+    out: &mut Vec<DirectiveFile>,
+) {
+    for ext in exts {
+        let pattern = dir.join("**").join(format!("*.{ext}"));
+        let Some(pat) = pattern.to_str() else {
+            continue;
+        };
+        let Ok(paths) = glob::glob(pat) else {
+            continue;
+        };
+        for path in paths.flatten() {
+            if !path.is_file() {
+                continue;
+            }
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .to_string();
+            out.push(DirectiveFile {
+                rel_path: rel,
+                tier: classify(&path, kind),
+            });
+        }
+    }
+}
+
+/// Read a rule file's frontmatter and decide its tier.
+fn classify(path: &Path, kind: &FrontmatterKind) -> DirectiveTier {
+    let raw = std::fs::read_to_string(path).unwrap_or_default();
+    let fm = split_frontmatter(&raw).map(|(f, _)| f).unwrap_or("");
+    match kind {
+        FrontmatterKind::Cursor => {
+            if frontmatter_bool(fm, "alwaysApply") == Some(true) {
+                return DirectiveTier::Always;
+            }
+            if let Some(globs) = frontmatter_list(fm, "globs") {
+                return DirectiveTier::Conditional(globs);
+            }
+            if let Some(desc) = frontmatter_scalar(fm, "description") {
+                return DirectiveTier::OnDemand(desc);
+            }
+            // `.mdc` with empty / no frontmatter: best-effort always.
+            DirectiveTier::Always
+        }
+        FrontmatterKind::Paths => match frontmatter_list(fm, "paths") {
+            Some(paths) => DirectiveTier::Conditional(paths),
+            None => DirectiveTier::Always,
+        },
+    }
+}
+
+/// Locate `key:` in a frontmatter block and return its inline value plus any
+/// following indented `- item` block-list lines. Matches only an exact `key:`
+/// (so `descriptionFoo:` never matches `description`).
+fn field(fm: &str, key: &str) -> Option<(String, Vec<String>)> {
+    let lines: Vec<&str> = fm.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        let Some(rest) = line
+            .trim_start()
+            .strip_prefix(key)
+            .and_then(|r| r.strip_prefix(':'))
+        else {
+            continue;
+        };
+        let inline = rest.trim().to_string();
+        let mut block = Vec::new();
+        if inline.is_empty() {
+            for next in &lines[i + 1..] {
+                let t = next.trim_start();
+                if let Some(item) = t.strip_prefix("- ") {
+                    block.push(item.trim().to_string());
+                } else if t.is_empty() {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+        }
+        return Some((inline, block));
+    }
+    None
+}
+
+/// Parse a boolean frontmatter scalar (`key: true`).
+fn frontmatter_bool(fm: &str, key: &str) -> Option<bool> {
+    let (inline, _) = field(fm, key)?;
+    match inline.trim().to_ascii_lowercase().as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+/// Parse a scalar frontmatter string (`description: ...`), stripping quotes.
+/// Returns `None` when the field is absent or empty.
+fn frontmatter_scalar(fm: &str, key: &str) -> Option<String> {
+    let (inline, _) = field(fm, key)?;
+    let v = clean_scalar(&inline);
+    if v.is_empty() { None } else { Some(v) }
+}
+
+/// Parse a list frontmatter field into a `", "`-joined display string.
+/// Handles inline `[a, b]` and block `- item` forms. Returns `None` when the
+/// field is absent or resolves to no items.
+fn frontmatter_list(fm: &str, key: &str) -> Option<String> {
+    let (inline, block) = field(fm, key)?;
+    let items: Vec<String> = if inline.is_empty() {
+        block
+            .iter()
+            .map(|s| clean_scalar(s))
+            .filter(|s| !s.is_empty())
+            .collect()
+    } else {
+        let inner = inline.trim().trim_start_matches('[').trim_end_matches(']');
+        inner
+            .split(',')
+            .map(clean_scalar)
+            .filter(|s| !s.is_empty())
+            .collect()
+    };
+    if items.is_empty() {
+        None
+    } else {
+        Some(items.join(", "))
+    }
+}
+
+/// Trim whitespace and surrounding quotes from a scalar token.
+fn clean_scalar(s: &str) -> String {
+    s.trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+/// Render the discovered directive files as a tiered, filenames-only prompt
+/// section. Only non-empty tiers are emitted. `root_display` is the
+/// tilde-collapsed project root for the header.
+pub fn render(root_display: &str, files: &[DirectiveFile]) -> String {
+    let mut always: Vec<&str> = Vec::new();
+    let mut conditional: Vec<(&str, &str)> = Vec::new();
+    let mut on_demand: Vec<(&str, &str)> = Vec::new();
+    for f in files {
+        match &f.tier {
+            DirectiveTier::Always => always.push(&f.rel_path),
+            DirectiveTier::Conditional(p) => conditional.push((&f.rel_path, p)),
+            DirectiveTier::OnDemand(d) => on_demand.push((&f.rel_path, d)),
+        }
+    }
+
+    let mut out = format!("--- Project Directive Files (in {}/) ---\n", root_display);
+    out.push_str(
+        "Directive / rule files from other AI coding tools were found in this project. \
+         They hold project-specific conventions that take precedence over your defaults. \
+         Load with `read_file` when relevant.\n",
+    );
+
+    if !always.is_empty() {
+        out.push_str("\nAlways apply (read when working in this project):\n  ");
+        out.push_str(&always.join(", "));
+        out.push('\n');
+    }
+    if !conditional.is_empty() {
+        out.push_str("\nConditional (read when touching matching files):\n");
+        for (path, pat) in &conditional {
+            out.push_str(&format!("  {} — matches: {}\n", path, pat));
+        }
+    }
+    if !on_demand.is_empty() {
+        out.push_str("\nOn-demand (read when the description matches your task):\n");
+        for (path, desc) in &on_demand {
+            out.push_str(&format!("  {} — \"{}\"\n", path, desc));
+        }
+    }
+    out.push('\n');
+    out
+}

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -6,6 +6,7 @@
 pub mod agent;
 pub mod commands;
 pub mod dedup_scan;
+pub mod directives;
 pub mod feedback_policy;
 pub mod filter;
 pub mod goal;

--- a/src/brain/prompt_builder.rs
+++ b/src/brain/prompt_builder.rs
@@ -626,85 +626,35 @@ impl BrainLoader {
         prompt.push('\n');
     }
 
-    /// Scan the working directory for project directive files and append
-    /// a "Project Directive Files" index to the prompt.
+    /// Scan the working directory for project directive files and append a
+    /// tiered "Project Directive Files" index to the prompt.
     ///
-    /// This closes gap #1 from the original Alexey issue: auto-discovering
-    /// directive files (AGENTS.md, CLAUDE.md, .cursorrules, etc.) in an
-    /// arbitrary repo root and surfacing them as fetchable contextual files.
+    /// Auto-discovers the directive / rule files of the major AI coding agents
+    /// (Claude Code, Cursor, Windsurf, Cline, Gemini, GitHub Copilot, OpenCode,
+    /// and the cross-tool AGENTS.md convention) in an arbitrary repo root and
+    /// surfaces them as fetchable contextual files. `.cursor/rules`,
+    /// `.claude/rules` and `.clinerules` directories are walked recursively and
+    /// their frontmatter classifies each rule into always / conditional /
+    /// on-demand tiers (see `crate::brain::directives`).
     ///
-    /// Pattern: filenames-only index (not full content injection), so it's
-    /// cheap and survives compaction since the preamble rebuilds every turn.
-    /// The agent reads them on demand via `read_file`.
+    /// Filenames-only index (not full content injection), so it's cheap and
+    /// survives compaction since the preamble rebuilds every turn. The agent
+    /// reads them on demand via `read_file`.
     ///
-    /// Gated on existence — nothing is added when no directive files are found.
+    /// `working_dir` arrives tilde-collapsed (`~/...`) per the `RuntimeInfo`
+    /// contract, so it MUST be expanded before any filesystem op. Gated on
+    /// existence: nothing is added when no directive files are found.
     fn push_project_directives(&self, prompt: &mut String, working_dir: Option<&str>) {
         let Some(wd) = working_dir else {
             return;
         };
-        let wd_path = std::path::Path::new(wd);
-        if !wd_path.is_dir() {
+        let root = crate::brain::tools::error::expand_tilde(wd);
+        let files = crate::brain::directives::discover(&root);
+        if files.is_empty() {
             return;
         }
-
-        // Known directive files to scan for in the working directory root.
-        // Covers the major AI coding agent ecosystems: Claude, Cursor, Windsurf,
-        // Cline, Copilot, and the cross-tool AGENTS.md convention.
-        const DIRECTIVE_FILES: &[(&str, &str)] = &[
-            ("AGENTS.md", "project directives (cross-tool convention)"),
-            ("CLAUDE.md", "Claude Code directives"),
-            ("GEMINI.md", "Gemini CLI directives"),
-            (".cursorrules", "Cursor directives"),
-            (".windsurfrules", "Windsurf directives"),
-            (".clinerules", "Cline directives"),
-        ];
-
-        // Also check for nested directive files (e.g. .cursor/rules/*.mdc,
-        // .github/copilot-instructions.md).
-        let nested_patterns = &[".cursor/rules/*.mdc", ".github/copilot-instructions.md"];
-
-        let mut found: Vec<String> = Vec::new();
-
-        // Check root-level files
-        for (filename, _desc) in DIRECTIVE_FILES {
-            if wd_path.join(filename).is_file() {
-                found.push(filename.to_string());
-            }
-        }
-
-        // Check nested patterns via glob
-        for pattern in nested_patterns {
-            let full_pattern = wd_path.join(pattern);
-            if let Some(pattern_str) = full_pattern.to_str()
-                && let Ok(paths) = glob::glob(pattern_str)
-            {
-                for path in paths.flatten() {
-                    if path.is_file() {
-                        // Use relative path from working dir
-                        if let Ok(rel) = path.strip_prefix(wd_path) {
-                            found.push(rel.to_string_lossy().to_string());
-                        }
-                    }
-                }
-            }
-        }
-
-        if found.is_empty() {
-            return;
-        }
-
-        // Sort for deterministic output
-        found.sort();
-
-        let wd_collapsed = crate::brain::tools::error::collapse_home(wd_path);
-        prompt.push_str(&format!(
-            "--- Project Directive Files (in {}/) ---\n\
-             Found: {}\n\
-             Load with `read_file` when working in this project. \
-             These hold project-specific conventions that take precedence over defaults.\n\n",
-            wd_collapsed,
-            found.join(", ")
-        ));
+        let display = crate::brain::tools::error::collapse_home(&root);
+        prompt.push_str(&crate::brain::directives::render(&display, &files));
     }
 }
 

--- a/src/brain/skills.rs
+++ b/src/brain/skills.rs
@@ -154,7 +154,7 @@ impl Skill {
 /// any BOM. The opening fence must be the very first line (`---\n`);
 /// the closing fence is the next standalone `---` line. Returns `None`
 /// if either fence is missing.
-fn split_frontmatter(raw: &str) -> Option<(&str, &str)> {
+pub(crate) fn split_frontmatter(raw: &str) -> Option<(&str, &str)> {
     let after_open = raw.strip_prefix("---\n")?;
 
     // Closing fence: a line that is exactly "---". Find its byte offset

--- a/src/tests/directive_discovery_test.rs
+++ b/src/tests/directive_discovery_test.rs
@@ -1,0 +1,239 @@
+//! Project directive-file discovery: tier classification, recursion, and the
+//! tilde-expansion regression.
+//!
+//! The regression: `push_project_directives` fed `RuntimeInfo.working_directory`
+//! (which arrives tilde-collapsed as `~/...`) straight into `Path::is_dir()`,
+//! which never expands `~`, so the guard bailed on every real call and the
+//! feature was dead code. The fix expands `~` via `expand_tilde` first. The
+//! `tilde_path_is_expanded_before_scan` test locks that in.
+
+use std::fs;
+use std::path::Path;
+
+use crate::brain::directives::{DirectiveTier, discover, render};
+use crate::brain::tools::error::expand_tilde;
+
+fn write(root: &Path, rel: &str, body: &str) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn tier_of<'a>(
+    files: &'a [crate::brain::directives::DirectiveFile],
+    rel: &str,
+) -> &'a DirectiveTier {
+    &files
+        .iter()
+        .find(|f| f.rel_path == rel)
+        .unwrap_or_else(|| panic!("expected {rel} in discovered set"))
+        .tier
+}
+
+#[test]
+fn root_single_files_are_always() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write(dir.path(), "AGENTS.md", "root rules");
+    write(dir.path(), ".cursorrules", "legacy cursor");
+    write(dir.path(), "README.md", "not a directive");
+
+    let files = discover(dir.path());
+    let paths: Vec<&str> = files.iter().map(|f| f.rel_path.as_str()).collect();
+    assert!(paths.contains(&"AGENTS.md"));
+    assert!(paths.contains(&".cursorrules"));
+    assert!(
+        !paths.contains(&"README.md"),
+        "README.md is not a directive file"
+    );
+    assert_eq!(tier_of(&files, "AGENTS.md"), &DirectiveTier::Always);
+}
+
+#[test]
+fn nested_single_files_are_discovered() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write(dir.path(), ".claude/CLAUDE.md", "claude project");
+    write(dir.path(), ".github/copilot-instructions.md", "copilot");
+    write(dir.path(), ".opencode/AGENTS.md", "opencode");
+
+    let files = discover(dir.path());
+    let paths: Vec<&str> = files.iter().map(|f| f.rel_path.as_str()).collect();
+    assert!(paths.contains(&".claude/CLAUDE.md"));
+    assert!(paths.contains(&".github/copilot-instructions.md"));
+    assert!(paths.contains(&".opencode/AGENTS.md"));
+}
+
+#[test]
+fn cursor_mdc_three_tiers() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write(
+        dir.path(),
+        ".cursor/rules/always.mdc",
+        "---\nalwaysApply: true\n---\nalways body",
+    );
+    write(
+        dir.path(),
+        ".cursor/rules/scoped.mdc",
+        "---\nglobs: [\"src/api/**\", \"routes/**\"]\nalwaysApply: false\n---\nscoped body",
+    );
+    write(
+        dir.path(),
+        ".cursor/rules/smart.mdc",
+        "---\ndescription: Apply when refactoring large functions\n---\nsmart body",
+    );
+
+    let files = discover(dir.path());
+    assert_eq!(
+        tier_of(&files, ".cursor/rules/always.mdc"),
+        &DirectiveTier::Always
+    );
+    assert_eq!(
+        tier_of(&files, ".cursor/rules/scoped.mdc"),
+        &DirectiveTier::Conditional("src/api/**, routes/**".to_string())
+    );
+    assert_eq!(
+        tier_of(&files, ".cursor/rules/smart.mdc"),
+        &DirectiveTier::OnDemand("Apply when refactoring large functions".to_string())
+    );
+}
+
+#[test]
+fn cursor_block_list_globs_are_normalized() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write(
+        dir.path(),
+        ".cursor/rules/block.mdc",
+        "---\nglobs:\n  - src/**/*.ts\n  - test/**\n---\nbody",
+    );
+    let files = discover(dir.path());
+    assert_eq!(
+        tier_of(&files, ".cursor/rules/block.mdc"),
+        &DirectiveTier::Conditional("src/**/*.ts, test/**".to_string())
+    );
+}
+
+#[test]
+fn claude_and_cline_rules_use_paths_frontmatter() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write(
+        dir.path(),
+        ".claude/rules/testing.md",
+        "no frontmatter, unconditional",
+    );
+    write(
+        dir.path(),
+        ".claude/rules/frontend.md",
+        "---\npaths:\n  - src/components/**\n---\nfrontend rules",
+    );
+    write(dir.path(), ".clinerules/coding.md", "cline unconditional");
+
+    let files = discover(dir.path());
+    assert_eq!(
+        tier_of(&files, ".claude/rules/testing.md"),
+        &DirectiveTier::Always
+    );
+    assert_eq!(
+        tier_of(&files, ".claude/rules/frontend.md"),
+        &DirectiveTier::Conditional("src/components/**".to_string())
+    );
+    assert_eq!(
+        tier_of(&files, ".clinerules/coding.md"),
+        &DirectiveTier::Always
+    );
+}
+
+#[test]
+fn rule_dirs_are_walked_recursively() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write(
+        dir.path(),
+        ".cursor/rules/backend/api.mdc",
+        "---\nalwaysApply: true\n---\nnested",
+    );
+    let files = discover(dir.path());
+    let paths: Vec<&str> = files.iter().map(|f| f.rel_path.as_str()).collect();
+    assert!(
+        paths.contains(&".cursor/rules/backend/api.mdc"),
+        "nested .mdc under a subdirectory must be discovered"
+    );
+}
+
+#[test]
+fn clinerules_as_single_file_is_always() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write(dir.path(), ".clinerules", "single-file cline rules");
+    let files = discover(dir.path());
+    assert_eq!(tier_of(&files, ".clinerules"), &DirectiveTier::Always);
+}
+
+#[test]
+fn empty_project_discovers_nothing() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write(dir.path(), "main.rs", "fn main() {}");
+    assert!(discover(dir.path()).is_empty());
+}
+
+#[test]
+fn nonexistent_root_discovers_nothing() {
+    assert!(discover(Path::new("/no/such/dir/anywhere")).is_empty());
+}
+
+#[test]
+fn render_emits_only_populated_tiers() {
+    let dir = tempfile::TempDir::new().unwrap();
+    write(dir.path(), "AGENTS.md", "x");
+    write(
+        dir.path(),
+        ".cursor/rules/smart.mdc",
+        "---\ndescription: Use for regex work\n---\nbody",
+    );
+    let files = discover(dir.path());
+    let out = render("~/proj", &files);
+
+    assert!(out.contains("--- Project Directive Files (in ~/proj/) ---"));
+    assert!(out.contains("Always apply"));
+    assert!(out.contains("AGENTS.md"));
+    assert!(out.contains("On-demand"));
+    assert!(out.contains("Use for regex work"));
+    // No conditional files present, so that section must be omitted.
+    assert!(!out.contains("Conditional"));
+}
+
+/// The core regression: a tilde-collapsed working directory must be expanded
+/// before the filesystem scan. Under the old code `Path::new("~/proj").is_dir()`
+/// was always false and nothing was ever discovered.
+#[test]
+fn tilde_path_is_expanded_before_scan() {
+    let temp_home = tempfile::TempDir::new().unwrap();
+    let _lock = crate::tests::HOME_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let prev_home = std::env::var_os("HOME");
+    let prev_userprofile = std::env::var_os("USERPROFILE");
+    // SAFETY: HOME_ENV_LOCK serializes HOME mutation for the guard's lifetime.
+    unsafe {
+        std::env::set_var("HOME", temp_home.path());
+        std::env::set_var("USERPROFILE", temp_home.path());
+    }
+
+    write(&temp_home.path().join("proj"), "AGENTS.md", "project rules");
+    let expanded = expand_tilde("~/proj");
+    let files = discover(&expanded);
+
+    unsafe {
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match prev_userprofile {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+    }
+
+    assert!(
+        files.iter().any(|f| f.rel_path == "AGENTS.md"),
+        "tilde path must expand and discover the directive file"
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -149,6 +149,7 @@ pub mod db_repository_plan_test;
 pub mod db_repository_project_test;
 pub mod db_repository_session_test;
 pub mod db_retry_test;
+pub mod directive_discovery_test;
 pub mod git_branch_test;
 pub mod glob_tool_test;
 pub mod goal_command_test;


### PR DESCRIPTION
## Summary

Completes project directive-file auto-discovery and fixes the dead-code guard shipped in `4e759c44`. OpenCrabs now surfaces the directive / rule files of the major AI coding agents when working inside any repo, including repos outside the OpenCrabs home.

Closes #273.

## The bug in `4e759c44`

`push_project_directives` received `RuntimeInfo.working_directory`, which by its own documented contract arrives **tilde-collapsed** (`~/srv/rs/opencrabs`) to keep the username out of the prompt cache key. The old code then ran:

```rust
let wd_path = std::path::Path::new(wd); // "~/srv/rs/opencrabs"
if !wd_path.is_dir() { return; }        // always true: Rust never expands ~
```

`Path::is_dir()` does not expand `~` (only the shell does), so the guard returned on the first check every call. **The feature never injected anything into a real prompt.** Existing tests only passed absolute paths, so they stayed green and masked it. The fix expands `~` via the existing `expand_tilde` helper before any filesystem op, locked in by a regression test that passes a `~/...` path.

## New `brain::directives` module

Pure, filesystem-only, and testable, which keeps `prompt_builder` thin. Discovers and classifies:

**Root single files:** `AGENTS.md`, `CLAUDE.md`, `CLAUDE.local.md`, `GEMINI.md`, `.cursorrules`, `.windsurfrules`
**Nested single files:** `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, `.opencode/AGENTS.md`
**Recursively walked rule dirs:** `.cursor/rules/**/*.mdc`, `.claude/rules/**/*.md`, `.clinerules/**/*.{md,txt}` (`.clinerules` may also be a single file)

## Three tiers from frontmatter

| Tier | Trigger | Rendered as |
|------|---------|-------------|
| Always | root files, Cursor `alwaysApply: true`, Claude/Cline rules with no `paths` | listed as always-relevant |
| Conditional | Cursor `globs`, Claude/Cline `paths` | listed with the patterns |
| On-demand | Cursor `.mdc` with only a `description` | listed with the description text so the agent can judge relevance |

Rendered as a tiered, filenames-only index (content read on demand via `read_file`) that rebuilds every turn, so it survives compaction and stays cheap. Only non-empty tiers are emitted. Reuses `split_frontmatter` (now `pub(crate)`).

## Validation

- `cargo clippy --all-features`: zero warnings
- 11 new discovery/classification tests plus the tilde-expansion regression, all under `src/tests/`
- Full suite: 4439 passed, 0 failed
