### PR TITLE
feat(tools): native URL-to-markdown scrape tool (web_scrape)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3231,13 +3231,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
+name = "htmd"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever_rcdom",
+ "phf 0.13.1",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -4290,6 +4311,17 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
@@ -4297,6 +4329,18 @@ dependencies = [
  "log",
  "tendril",
  "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever 0.38.0",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -4972,6 +5016,7 @@ dependencies = [
  "futures",
  "glob",
  "hound",
+ "htmd",
  "ignore",
  "image",
  "insta",
@@ -6950,7 +6995,7 @@ dependencies = [
  "cssparser",
  "ego-tree",
  "getopts",
- "html5ever",
+ "html5ever 0.39.0",
  "precomputed-hash",
  "selectors",
  "tendril",
@@ -7605,6 +7650,7 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
+ "serde",
 ]
 
 [[package]]
@@ -10218,6 +10264,16 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ctr"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2098,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2158,12 @@ checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
 dependencies = [
  "cipher 0.4.4",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -3187,6 +3231,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,6 +4289,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4528,6 +4593,12 @@ checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys 0.3.1",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -4931,6 +5002,7 @@ dependencies = [
  "rusqlite_migration",
  "rustls",
  "rwhisper",
+ "scraper",
  "serde",
  "serde_json",
  "serenity",
@@ -5533,6 +5605,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -6864,6 +6942,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6894,6 +6987,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cssparser",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash 2.1.3",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -7102,6 +7214,15 @@ dependencies = [
  "tracing",
  "typemap_rev",
  "url",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -7473,6 +7594,30 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "stringprep"
@@ -7956,6 +8101,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -9355,6 +9510,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ llama-cpp-2 = "0.1.137"
 emojis = "0.8.0"
 url = "2.5.8"
 unicode-normalization = "0.1.25"
+scraper = "0.27.0"
 
 [dev-dependencies]
 rstest = "0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ emojis = "0.8.0"
 url = "2.5.8"
 unicode-normalization = "0.1.25"
 scraper = "0.27.0"
+htmd = "0.5.4"
 
 [dev-dependencies]
 rstest = "0.25"

--- a/src/brain/tools/catalog.rs
+++ b/src/brain/tools/catalog.rs
@@ -162,6 +162,7 @@ pub fn tool_category(name: &str) -> &'static str {
         {
             "utility"
         }
+        "web_scrape" => "web",
         _ => "other",
     }
 }

--- a/src/brain/tools/mod.rs
+++ b/src/brain/tools/mod.rs
@@ -28,6 +28,7 @@ pub mod doc_parser;
 pub mod exa_search;
 pub mod notebook;
 pub mod pdf_to_images;
+pub mod web_scrape;
 pub mod web_search;
 
 // Tool implementations - Phase 3: Workflow & Integration

--- a/src/brain/tools/web_scrape/clean.rs
+++ b/src/brain/tools/web_scrape/clean.rs
@@ -1,0 +1,87 @@
+//! Structural noise removal for `web_scrape`, genericized from insight_forge's
+//! `html_content_cleaner`.
+//!
+//! insight_forge's cleaner was tuned for one Portuguese SMB site: it dropped
+//! lines containing `FORMULÁRIO`, `Nome:`, `Telefone:`, `Privacidade`, and so
+//! on. Those string matches would delete legitimate content on an arbitrary
+//! site, so none of them survive here. What remains is language-agnostic and
+//! structural: remove `<script>`/`<style>` blocks and inline event handlers
+//! (their source otherwise leaks as body text), strip HTML comments, decode the
+//! common entities, and tidy whitespace.
+//!
+//! Image and link URLs are never touched. The whole point of the tool is that
+//! images survive as markdown references the agent can vision on demand, so
+//! there is deliberately no URL-stripping phase here.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+use unicode_normalization::UnicodeNormalization;
+
+static SCRIPT_BLOCK: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<script[^>]*>.*?</script>").unwrap());
+static STYLE_BLOCK: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<style[^>]*>.*?</style>").unwrap());
+static INLINE_HANDLER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?is)\s+on\w+\s*=\s*("[^"]*"|'[^']*')"#).unwrap());
+static HTML_COMMENT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)<!--.*?-->").unwrap());
+static HTML_TAG: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<[^>]+>").unwrap());
+static BLANK_LINES: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+static INLINE_WS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[ \t]{2,}").unwrap());
+static HTML_ENTITY: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"&[a-zA-Z]+;|&#[0-9]+;|&#x[0-9a-fA-F]+;").unwrap());
+
+/// Remove script/style blocks, inline event handlers, and HTML comments from
+/// `html`. Structural only: real element text is untouched, and no `src`/`href`
+/// is rewritten or removed.
+pub fn strip_noise(html: &str) -> String {
+    let mut out = SCRIPT_BLOCK.replace_all(html, "").to_string();
+    out = STYLE_BLOCK.replace_all(&out, "").to_string();
+    out = INLINE_HANDLER.replace_all(&out, "").to_string();
+    out = HTML_COMMENT.replace_all(&out, "").to_string();
+    out
+}
+
+/// Collapse three-or-more consecutive newlines to a single blank-line separator
+/// and trim the ends. Run on converted markdown to tidy the spacing left around
+/// removed blocks.
+pub fn collapse_blank_lines(text: &str) -> String {
+    BLANK_LINES.replace_all(text.trim(), "\n\n").to_string()
+}
+
+/// Decode the handful of HTML entities that actually show up in body text.
+/// Unknown entities collapse to a space rather than being left as raw `&…;`
+/// noise.
+pub fn decode_html_entities(text: &str) -> String {
+    HTML_ENTITY
+        .replace_all(text, |caps: &regex::Captures| {
+            match caps.get(0).unwrap().as_str() {
+                "&nbsp;" => " ",
+                "&amp;" => "&",
+                "&lt;" => "<",
+                "&gt;" => ">",
+                "&quot;" => "\"",
+                "&apos;" => "'",
+                _ => " ",
+            }
+            .to_string()
+        })
+        .to_string()
+}
+
+/// Reduce `html` to plain text: strip noise, drop every remaining tag, decode
+/// entities, NFC-normalize, collapse inline whitespace, and drop blank lines.
+/// Used for the `text` output format; the markdown path uses the htmd converter
+/// instead.
+pub fn to_plain_text(html: &str) -> String {
+    let stripped = strip_noise(html);
+    let no_tags = HTML_TAG.replace_all(&stripped, " ").to_string();
+    let decoded = decode_html_entities(&no_tags);
+    let normalized: String = decoded.nfc().collect();
+    let lines: Vec<String> = normalized
+        .lines()
+        .map(|line| INLINE_WS.replace_all(line.trim(), " ").trim().to_string())
+        .filter(|line| !line.is_empty())
+        .collect();
+    lines.join("\n")
+}

--- a/src/brain/tools/web_scrape/export.rs
+++ b/src/brain/tools/web_scrape/export.rs
@@ -1,0 +1,81 @@
+//! Persist scraped markdown to disk, profile- and project-aware.
+//!
+//! When a scrape (or a whole-sitemap crawl) is asked to save its output, the
+//! files land where the rest of a session's artifacts live, not in some fixed
+//! global path:
+//!
+//! 1. If the session is assigned to a **project**, markdown goes under that
+//!    project's files dir (`projects/<slug>/files/scrapes/`), so a scrape sits
+//!    beside everything else produced for that project.
+//! 2. Otherwise it goes under the **active profile's** home in a `scrapes/`
+//!    subdir (`~/.opencrabs/scrapes/` for the default profile,
+//!    `~/.opencrabs/profiles/<name>/scrapes/` under `-p <name>`).
+//!
+//! Both resolve through the same profile-aware helpers the rest of the codebase
+//! uses, so a job running under `-p ops` never writes into the default home.
+
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+use crate::services::{FileService, ServiceContext};
+
+/// Resolve the directory scraped markdown should be written to for `session_id`.
+///
+/// Prefers the session's project files dir when the session belongs to a
+/// project; otherwise falls back to a `scrapes/` subdir of the active profile's
+/// home. Both cases are namespaced under `scrapes/` so exported pages stay
+/// grouped and never clutter the root of a project's or profile's files.
+pub async fn resolve_export_dir(
+    session_id: Uuid,
+    service_context: Option<&ServiceContext>,
+) -> PathBuf {
+    if let Some(sc) = service_context
+        && let Some(project_files) = FileService::new(sc.clone())
+            .project_files_dir(session_id)
+            .await
+    {
+        return project_files.join("scrapes");
+    }
+    crate::config::opencrabs_home().join("scrapes")
+}
+
+/// Derive a filesystem-safe `.md` filename from a page URL.
+///
+/// Uses the host plus path so files from a crawl stay distinguishable
+/// (`example.com/blog/post-1` -> `example.com-blog-post-1.md`). Every run of
+/// non-alphanumeric characters collapses to a single dash, leading/trailing
+/// dashes are trimmed, and an empty path yields a stable `index` stem so the
+/// root URL of a site still gets a sensible name.
+pub fn filename_for_url(url: &str) -> String {
+    let parsed = url::Url::parse(url).ok();
+    let host = parsed.as_ref().and_then(|u| u.host_str()).unwrap_or("page");
+    let path = parsed.as_ref().map(|u| u.path()).unwrap_or("");
+
+    let raw = format!("{host}{path}");
+    let mut slug = String::with_capacity(raw.len());
+    let mut prev_dash = false;
+    for ch in raw.chars() {
+        // Keep alphanumerics and dots (dots keep host names like `example.com`
+        // readable); collapse every other run into a single dash.
+        if ch.is_ascii_alphanumeric() || ch == '.' {
+            slug.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            slug.push('-');
+            prev_dash = true;
+        }
+    }
+    let stem = slug.trim_matches(|c| c == '-' || c == '.');
+    let stem = if stem.is_empty() { "index" } else { stem };
+    format!("{stem}.md")
+}
+
+/// Write `markdown` for `url` into `dir`, creating the directory if needed.
+/// Returns the path written so the caller can report it back to the user.
+pub async fn write_markdown(dir: &Path, url: &str, markdown: &str) -> std::io::Result<PathBuf> {
+    tokio::fs::create_dir_all(dir).await?;
+    let path = dir.join(filename_for_url(url));
+    tokio::fs::write(&path, markdown).await?;
+    Ok(path)
+}

--- a/src/brain/tools/web_scrape/extract.rs
+++ b/src/brain/tools/web_scrape/extract.rs
@@ -1,0 +1,90 @@
+//! Main-content isolation for `web_scrape`, ported from insight_forge's
+//! `extract_main_content`.
+//!
+//! Everything here is synchronous and returns owned `String`s on purpose:
+//! `scraper`'s `Html`/`Selector` types hold `Rc` and are `!Send`, so keeping
+//! them out of any `async fn` is what lets the tool's async `execute()` stay
+//! `Send` (extraction runs to completion before the pipeline ever `.await`s).
+
+use scraper::{Html, Selector};
+
+/// Content-container selectors, tried in priority order. The first match whose
+/// serialized HTML is substantial (> 100 chars) wins.
+const MAIN_SELECTORS: &[&str] = &[
+    "article#main-content",
+    "main",
+    ".main-content",
+    "#content",
+    ".content",
+    "article",
+    "[role='main']",
+    "#main",
+    ".article-content",
+];
+
+/// Structural elements removed from the `<body>` fallback — never real content.
+const JUNK_SELECTORS: &[&str] = &[
+    "header",
+    "footer",
+    "nav",
+    "aside",
+    ".sidebar",
+    "#sidebar",
+    ".widget",
+    "form",
+    "iframe",
+    "noscript",
+    ".advertisement",
+    ".ads",
+    ".cookie-notice",
+    ".share-buttons",
+    "[class*='social']",
+];
+
+/// Minimum serialized length for a container to count as "the main content".
+const MIN_CONTENT_LEN: usize = 100;
+
+/// Isolate the main content of `html` and return it as an HTML fragment.
+///
+/// Tries the priority container selectors first; if none has substantial
+/// content, falls back to `<body>` with the structural junk elements stripped.
+/// Returns the input unchanged only when there is no usable body, so the caller
+/// always has something to convert.
+pub fn extract_main_content(html: &str) -> String {
+    let document = Html::parse_document(html);
+
+    for selector in MAIN_SELECTORS {
+        if let Ok(sel) = Selector::parse(selector)
+            && let Some(element) = document.select(&sel).next()
+        {
+            let content = element.html();
+            if content.trim().len() > MIN_CONTENT_LEN {
+                return content;
+            }
+        }
+    }
+
+    // Body fallback: serialize <body>, then delete each junk element's markup.
+    // Same approach as insight_forge — selector-driven string removal against
+    // the serialized fragment.
+    if let Ok(body_sel) = Selector::parse("body")
+        && let Some(body) = document.select(&body_sel).next()
+    {
+        let mut content = body.html();
+        for selector in JUNK_SELECTORS {
+            if let Ok(sel) = Selector::parse(selector) {
+                for element in document.select(&sel) {
+                    let fragment = element.html();
+                    if !fragment.is_empty() {
+                        content = content.replace(&fragment, "");
+                    }
+                }
+            }
+        }
+        if content.trim().len() > MIN_CONTENT_LEN {
+            return content;
+        }
+    }
+
+    html.to_string()
+}

--- a/src/brain/tools/web_scrape/fetch.rs
+++ b/src/brain/tools/web_scrape/fetch.rs
@@ -1,0 +1,102 @@
+//! Network fetch for `web_scrape`.
+//!
+//! Two ways to get a page's HTML. `fetch_static` is a plain reqwest GET with a
+//! desktop browser User-Agent and a bounded timeout, which handles the common
+//! case (server-rendered HTML) at near-zero cost. `is_js_shell` is a pure,
+//! network-free heuristic that spots pages which ship almost no visible text
+//! until their JavaScript runs. When it fires, and only then, the orchestrator
+//! escalates to `fetch_rendered` (behind the `browser` feature) to let headless
+//! Chrome render the DOM before we read it.
+
+use std::time::Duration;
+
+use reqwest::Client;
+
+use super::clean::to_plain_text;
+
+/// Desktop Chrome User-Agent. Some sites 403 non-browser agents or serve
+/// degraded HTML to them, so the static fetch presents a mainstream UA.
+const BROWSER_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+     AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+/// Below this many non-whitespace characters of visible text, a page that also
+/// ships script tags is treated as an unrendered SPA shell worth escalating.
+const JS_SHELL_TEXT_THRESHOLD: usize = 200;
+
+/// Fetch raw HTML over HTTP with a browser UA and a bounded timeout. Returns the
+/// response body on 2xx, an error string otherwise.
+pub async fn fetch_static(url: &str, timeout_secs: u64) -> Result<String, String> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .user_agent(BROWSER_UA)
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
+
+    let resp = client.get(url).send().await.map_err(|e| {
+        if e.is_timeout() {
+            format!("Request timed out after {timeout_secs}s")
+        } else if e.is_connect() {
+            format!("Connection failed: {e}")
+        } else {
+            format!("Request failed: {e}")
+        }
+    })?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!(
+            "HTTP {} {} for {url}",
+            status.as_u16(),
+            status.canonical_reason().unwrap_or("Unknown")
+        ));
+    }
+
+    resp.text()
+        .await
+        .map_err(|e| format!("Failed to read response body: {e}"))
+}
+
+/// Heuristic: does this HTML look like an unrendered JavaScript shell? True when
+/// the page carries script tags yet reduces to almost no visible text once
+/// scripts, styles, and tags are stripped. Pure and network-free so it is
+/// directly unit-testable.
+pub fn is_js_shell(html: &str) -> bool {
+    if !html.to_ascii_lowercase().contains("<script") {
+        return false;
+    }
+    let visible = to_plain_text(html);
+    let visible_len = visible.chars().filter(|c| !c.is_whitespace()).count();
+    visible_len < JS_SHELL_TEXT_THRESHOLD
+}
+
+/// Render `url` with headless Chrome and return the fully-hydrated HTML. Used
+/// only when `is_js_shell` flags the static fetch as an empty SPA shell.
+#[cfg(feature = "browser")]
+pub async fn fetch_rendered(
+    manager: &crate::brain::tools::browser::BrowserManager,
+    session_id: uuid::Uuid,
+    url: &str,
+) -> Result<String, String> {
+    let page = manager
+        .get_or_create_session_page(session_id)
+        .await
+        .map_err(|e| format!("Browser error: {e}"))?;
+
+    page.goto(url)
+        .await
+        .map_err(|e| format!("Navigation failed: {e}"))?;
+
+    // Wait for network to settle rather than the bare `load` event, so
+    // client-side hydration has a chance to populate the DOM before we read it.
+    if let Err(e) = page
+        .wait_for_network_almost_idle_with_timeout(Duration::from_secs(3))
+        .await
+    {
+        tracing::debug!("web_scrape: network-idle wait timed out for {url} (proceeding): {e}");
+    }
+
+    page.content()
+        .await
+        .map_err(|e| format!("Failed to get rendered HTML: {e}"))
+}

--- a/src/brain/tools/web_scrape/mod.rs
+++ b/src/brain/tools/web_scrape/mod.rs
@@ -1,0 +1,22 @@
+//! `web_scrape` — turn a URL into clean markdown at zero AI / zero API cost.
+//!
+//! When a user shares a link and asks the agent to check what's on it, the
+//! cheap-and-correct path is: fetch the HTML, isolate the main content, strip
+//! the structural junk (scripts, nav, footers, forms), and convert what's left
+//! to markdown. The agent then reads a compact document instead of raw markup,
+//! a 10x-30x token reduction with no model call to produce it. This is the
+//! same idea as RTK for bash output, applied to the web.
+//!
+//! The pipeline is deliberately split into small, pure, single-responsibility
+//! modules (ported and genericized from insight_forge's 4-year-in-production
+//! scraper). Only [`fetch`] and [`sitemap`] touch the network; every other
+//! stage is a pure `&str -> String` function, which keeps the `scraper` crate's
+//! non-`Send` selector types off the async boundary (extraction runs to
+//! completion synchronously, before any `.await`).
+//!
+//! Images survive as markdown `![alt](url)` references resolved to absolute
+//! URLs, so the agent can see where images sit and vision only the specific
+//! ones a task needs. Nothing here renders pages to screenshots or auto-OCRs
+//! images: there is zero AI in the extraction path.
+
+pub mod ssrf;

--- a/src/brain/tools/web_scrape/mod.rs
+++ b/src/brain/tools/web_scrape/mod.rs
@@ -20,4 +20,5 @@
 //! images: there is zero AI in the extraction path.
 
 pub mod clean;
+pub mod extract;
 pub mod ssrf;

--- a/src/brain/tools/web_scrape/mod.rs
+++ b/src/brain/tools/web_scrape/mod.rs
@@ -20,6 +20,7 @@
 //! images: there is zero AI in the extraction path.
 
 pub mod clean;
+pub mod export;
 pub mod extract;
 pub mod fetch;
 pub mod sitemap;

--- a/src/brain/tools/web_scrape/mod.rs
+++ b/src/brain/tools/web_scrape/mod.rs
@@ -26,3 +26,6 @@ pub mod fetch;
 pub mod sitemap;
 pub mod ssrf;
 pub mod to_markdown;
+pub mod tool;
+
+pub use tool::WebScrapeTool;

--- a/src/brain/tools/web_scrape/mod.rs
+++ b/src/brain/tools/web_scrape/mod.rs
@@ -19,4 +19,5 @@
 //! ones a task needs. Nothing here renders pages to screenshots or auto-OCRs
 //! images: there is zero AI in the extraction path.
 
+pub mod clean;
 pub mod ssrf;

--- a/src/brain/tools/web_scrape/mod.rs
+++ b/src/brain/tools/web_scrape/mod.rs
@@ -21,5 +21,6 @@
 
 pub mod clean;
 pub mod extract;
+pub mod fetch;
 pub mod ssrf;
 pub mod to_markdown;

--- a/src/brain/tools/web_scrape/mod.rs
+++ b/src/brain/tools/web_scrape/mod.rs
@@ -22,3 +22,4 @@
 pub mod clean;
 pub mod extract;
 pub mod ssrf;
+pub mod to_markdown;

--- a/src/brain/tools/web_scrape/mod.rs
+++ b/src/brain/tools/web_scrape/mod.rs
@@ -22,5 +22,6 @@
 pub mod clean;
 pub mod extract;
 pub mod fetch;
+pub mod sitemap;
 pub mod ssrf;
 pub mod to_markdown;

--- a/src/brain/tools/web_scrape/sitemap.rs
+++ b/src/brain/tools/web_scrape/sitemap.rs
@@ -1,0 +1,168 @@
+//! Sitemap discovery and URL enumeration for `web_scrape`.
+//!
+//! Ported and simplified from insight_forge's sitemap crawler. Two jobs:
+//! [`discover_sitemap_url`] locates a site's sitemap (well-known path, then
+//! `robots.txt` `Sitemap:` directives, then common alternates), and
+//! [`collect_sitemap_urls`] walks it into a flat list of page URLs, following
+//! `<sitemapindex>` entries into their child sitemaps.
+//!
+//! The XML is parsed by pulling `<loc>` values with a regex rather than a full
+//! XML parser: sitemaps are machine-generated and always express both page URLs
+//! and nested-sitemap URLs as `<loc>`, so this reuses the existing `regex`
+//! dependency and adds nothing new to the tree. Recursion is handled with an
+//! explicit work queue (not async recursion), which bounds total fetches, dedups
+//! visited sitemaps, and needs no boxed futures.
+
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use regex::Regex;
+use url::Url;
+
+use super::fetch::fetch_static;
+
+/// Captures the text content of a sitemap `<loc>…</loc>` element.
+static LOC: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<loc>\s*([^<\s][^<]*?)\s*</loc>").unwrap());
+
+/// Safety cap on how many sitemap documents a single crawl will fetch, so a
+/// pathological sitemap index can't fan out into an unbounded fetch storm.
+const MAX_SITEMAP_DOCS: usize = 50;
+
+/// Auto-discover a sitemap URL for `root_url`.
+///
+/// Tries, in order: `/sitemap.xml`, `Sitemap:` directives in `/robots.txt`, then
+/// a handful of common alternate names. Returns the first URL whose body looks
+/// like a real sitemap (`<urlset` or `<sitemapindex`), or `None` when nothing
+/// matches.
+pub async fn discover_sitemap_url(root_url: &str, timeout_secs: u64) -> Option<String> {
+    let parsed = Url::parse(root_url).ok()?;
+    let base = format!("{}://{}", parsed.scheme(), parsed.host_str()?);
+
+    // Well-known location first.
+    let primary = format!("{base}/sitemap.xml");
+    if looks_like_sitemap(
+        &fetch_static(&primary, timeout_secs)
+            .await
+            .unwrap_or_default(),
+    ) {
+        return Some(primary);
+    }
+
+    // robots.txt may point at the real sitemap.
+    if let Ok(robots) = fetch_static(&format!("{base}/robots.txt"), timeout_secs).await {
+        for line in robots.lines() {
+            let trimmed = line.trim();
+            if trimmed.to_ascii_lowercase().starts_with("sitemap:") {
+                let url = trimmed["sitemap:".len()..].trim();
+                if !url.is_empty() {
+                    return Some(url.to_string());
+                }
+            }
+        }
+    }
+
+    // Common alternate names used by CMSs and sitemap plugins.
+    const ALTERNATES: &[&str] = &[
+        "/sitemap_index.xml",
+        "/sitemap-index.xml",
+        "/wp-sitemap.xml",
+        "/sitemap/sitemap.xml",
+    ];
+    for alt in ALTERNATES {
+        let candidate = format!("{base}{alt}");
+        if looks_like_sitemap(
+            &fetch_static(&candidate, timeout_secs)
+                .await
+                .unwrap_or_default(),
+        ) {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+/// Walk `sitemap_url` into a flat, deduplicated list of page URLs.
+///
+/// A `<sitemapindex>` document contributes its `<loc>` entries as further
+/// sitemaps to fetch; a plain `<urlset>` contributes its `<loc>` entries as page
+/// URLs. Nested sitemaps are followed via an explicit work queue up to
+/// [`MAX_SITEMAP_DOCS`] documents. Fetch failures on individual sitemaps are
+/// logged and skipped rather than failing the whole crawl.
+pub async fn collect_sitemap_urls(sitemap_url: &str, timeout_secs: u64) -> Vec<String> {
+    let mut pages: Vec<String> = Vec::new();
+    let mut seen_pages: HashSet<String> = HashSet::new();
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: Vec<String> = vec![sitemap_url.to_string()];
+    let mut fetched = 0usize;
+
+    while let Some(current) = queue.pop() {
+        if !visited.insert(current.clone()) {
+            continue;
+        }
+        if fetched >= MAX_SITEMAP_DOCS {
+            tracing::debug!("web_scrape: sitemap crawl hit {MAX_SITEMAP_DOCS}-doc cap, stopping");
+            break;
+        }
+        fetched += 1;
+
+        let body = match fetch_static(&current, timeout_secs).await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::debug!("web_scrape: sitemap {current} fetch failed: {e}");
+                continue;
+            }
+        };
+
+        let base = Url::parse(&current).ok();
+        let locs = extract_locs(&body, base.as_ref());
+        if body.contains("<sitemapindex") {
+            // Index document: every loc is another sitemap to walk.
+            queue.extend(locs);
+        } else {
+            // Leaf urlset: every loc is a page. Dedup as we go.
+            for page in locs {
+                if seen_pages.insert(page.clone()) {
+                    pages.push(page);
+                }
+            }
+        }
+    }
+
+    pages
+}
+
+/// Does this body look like a sitemap document?
+pub fn looks_like_sitemap(body: &str) -> bool {
+    body.contains("<urlset") || body.contains("<sitemapindex")
+}
+
+/// Pull every `<loc>` value out of a sitemap document.
+///
+/// Values are XML-entity decoded (sitemaps escape `&` as `&amp;`) and resolved
+/// to absolute URLs against `base` when they arrive relative. Anything that
+/// stays un-absolutizable is dropped.
+pub fn extract_locs(xml: &str, base: Option<&Url>) -> Vec<String> {
+    LOC.captures_iter(xml)
+        .filter_map(|c| c.get(1))
+        .map(|m| decode_xml_entities(m.as_str().trim()))
+        .filter_map(|loc| {
+            if loc.starts_with("http://") || loc.starts_with("https://") {
+                Some(loc)
+            } else {
+                base.and_then(|b| b.join(&loc).ok()).map(|u| u.to_string())
+            }
+        })
+        .collect()
+}
+
+/// Decode the five predefined XML entities. Sitemap `<loc>` values escape `&` in
+/// query strings as `&amp;`; the others are decoded for completeness.
+fn decode_xml_entities(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}

--- a/src/brain/tools/web_scrape/ssrf.rs
+++ b/src/brain/tools/web_scrape/ssrf.rs
@@ -1,0 +1,60 @@
+//! SSRF guard for `web_scrape`.
+//!
+//! Ported from insight_forge's `url_validator`. A URL-to-markdown tool is a
+//! server-side fetcher, so an unguarded fetch is a classic SSRF primitive:
+//! point it at `http://169.254.169.254/…` or `http://localhost:6379/` and it
+//! happily reaches into the host's network. This rejects anything that isn't a
+//! plain public `http(s)` resource before a single byte goes out.
+//!
+//! Host classification goes through [`url::Host`] rather than parsing
+//! `host_str()`, because `host_str()` keeps the brackets on IPv6 literals
+//! (`[::1]`), which then fail `IpAddr` parsing and slip past the filter.
+
+use url::{Host, Url};
+
+/// Validate that `url` is safe to fetch. Returns the parsed [`Url`] on success
+/// (handy as a base for resolving relative links later), or a human-readable
+/// reason on rejection.
+pub fn validate_url(url: &str) -> Result<Url, String> {
+    let parsed = Url::parse(url).map_err(|e| format!("invalid URL: {e}"))?;
+
+    // Only plain web schemes. `file://` in particular would let the tool read
+    // local files, so it is called out explicitly.
+    match parsed.scheme() {
+        "http" | "https" => {}
+        "file" => return Err("file:// URLs are not allowed".to_string()),
+        other => return Err(format!("unsupported scheme: {other}")),
+    }
+
+    match parsed.host() {
+        None => return Err("URL has no host".to_string()),
+        Some(Host::Domain(host)) => {
+            let lower = host.to_ascii_lowercase();
+            if lower == "localhost" || lower == "localhost.localdomain" {
+                return Err("requests to localhost are not allowed".to_string());
+            }
+        }
+        Some(Host::Ipv4(v4)) => {
+            // Link-local (169.254.0.0/16) also covers the cloud metadata
+            // endpoint 169.254.169.254.
+            if v4.is_private() || v4.is_loopback() || v4.is_link_local() || v4.is_broadcast() {
+                return Err("requests to private/internal IP addresses are not allowed".to_string());
+            }
+            if v4.is_multicast() {
+                return Err("requests to multicast addresses are not allowed".to_string());
+            }
+        }
+        Some(Host::Ipv6(v6)) => {
+            if v6.is_loopback() || v6.is_multicast() {
+                return Err("requests to internal IPv6 addresses are not allowed".to_string());
+            }
+            // Unique-local addresses (fc00::/7) are the IPv6 analogue of the
+            // IPv4 private ranges.
+            if (v6.segments()[0] & 0xfe00) == 0xfc00 {
+                return Err("requests to private IPv6 addresses are not allowed".to_string());
+            }
+        }
+    }
+
+    Ok(parsed)
+}

--- a/src/brain/tools/web_scrape/to_markdown.rs
+++ b/src/brain/tools/web_scrape/to_markdown.rs
@@ -1,0 +1,62 @@
+//! HTML-to-markdown conversion for `web_scrape`.
+//!
+//! Two steps. First resolve relative `src`/`href` attributes to absolute URLs
+//! against the page's base, so image and link targets in the markdown are
+//! directly fetchable and vision-able. Then convert to markdown with `htmd`.
+//! Images come out as `![alt](absolute-url)`: the agent reads the page as text
+//! and visions only the specific images a task needs — no AI runs here.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+use url::Url;
+
+/// Matches a `src="…"` or `href="…"` attribute (double-quoted). Capture 1 is
+/// the leading whitespace + attribute name, capture 2 is the value.
+static URL_ATTR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)(\s(?:src|href))\s*=\s*"([^"]*)""#).unwrap());
+
+/// Rewrite relative `src`/`href` values in `html` to absolute URLs resolved
+/// against `base`. Already-absolute URLs, in-page anchors (`#…`), and
+/// `data:`/`mailto:`/`tel:`/`javascript:` URIs are left untouched.
+pub fn absolutize_urls(html: &str, base: &Url) -> String {
+    URL_ATTR
+        .replace_all(html, |caps: &regex::Captures| {
+            let attr = &caps[1];
+            let resolved = resolve(&caps[2], base);
+            format!(r#"{attr}="{resolved}""#)
+        })
+        .to_string()
+}
+
+/// Resolve a single attribute value against `base`, returning it unchanged when
+/// it should not be rewritten or when resolution fails.
+fn resolve(value: &str, base: &Url) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("data:")
+        || trimmed.starts_with("mailto:")
+        || trimmed.starts_with("tel:")
+        || trimmed.starts_with("javascript:")
+    {
+        return value.to_string();
+    }
+    // Absolute already (has its own scheme+host) — keep as-is. Protocol-relative
+    // (`//host/…`) fails this parse and correctly falls through to base.join,
+    // which supplies the page's scheme.
+    if Url::parse(trimmed).is_ok() {
+        return value.to_string();
+    }
+    match base.join(trimmed) {
+        Ok(absolute) => absolute.to_string(),
+        Err(_) => value.to_string(),
+    }
+}
+
+/// Convert an HTML fragment to markdown. Relative URLs should already be
+/// absolutized via [`absolutize_urls`]. On the rare conversion error the input
+/// is returned rather than panicking the tool.
+pub fn to_markdown(html: &str) -> String {
+    htmd::convert(html).unwrap_or_else(|_| html.to_string())
+}

--- a/src/brain/tools/web_scrape/tool.rs
+++ b/src/brain/tools/web_scrape/tool.rs
@@ -1,0 +1,345 @@
+//! The `web_scrape` tool: the thin orchestrator that wires the pipeline modules
+//! into a single agent-callable tool.
+//!
+//! It owns no scraping logic of its own. Each stage lives in its own module
+//! ([`super::ssrf`], [`super::fetch`], [`super::extract`], [`super::clean`],
+//! [`super::to_markdown`], [`super::sitemap`], [`super::export`]); this file
+//! only sequences them and shapes the result.
+//!
+//! Modes:
+//! - `readable` (default): fetch a page, isolate its main content, strip
+//!   structural noise, and return clean markdown with images kept as
+//!   `![alt](url)` references.
+//! - `raw`: same, but skip main-content isolation and convert the whole page.
+//! - `sitemap`: discover and crawl the site's sitemap into a URL list. With
+//!   `export`, every page in the sitemap is scraped and written to disk.
+//!
+//! With `export: true`, the produced markdown is also written under the
+//! session's project (or the active profile) via [`super::export`], so a scrape
+//! can be captured to disk without the agent pasting the whole document back.
+
+use super::super::error::{Result, ToolError};
+use super::super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
+use super::{clean, export, extract, fetch, sitemap, ssrf, to_markdown};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+/// Largest markdown payload returned inline. Exports write the full document to
+/// disk regardless, so truncating the inline copy only bounds context, never
+/// loses data.
+const MAX_INLINE_BYTES: usize = 100_000;
+
+/// Hard ceiling on pages scraped during a `sitemap` + `export` crawl, so a large
+/// site can't fan a single call into thousands of fetches.
+const SITEMAP_EXPORT_HARD_CAP: usize = 100;
+
+/// Which extraction depth a page scrape uses.
+#[derive(Clone, Copy)]
+enum Mode {
+    /// Isolate the main content container before converting.
+    Readable,
+    /// Convert the whole page after structural cleaning.
+    Raw,
+}
+
+/// Native URL-to-markdown scraper. Holds an optional browser manager so it can
+/// escalate JavaScript-only pages to a headless render; without the `browser`
+/// feature it is a pure HTTP fetcher.
+#[derive(Default)]
+pub struct WebScrapeTool {
+    #[cfg(feature = "browser")]
+    browser: Option<std::sync::Arc<crate::brain::tools::browser::BrowserManager>>,
+}
+
+impl WebScrapeTool {
+    /// Attach a browser manager for JS-shell render escalation.
+    #[cfg(feature = "browser")]
+    pub fn with_browser(
+        mut self,
+        manager: std::sync::Arc<crate::brain::tools::browser::BrowserManager>,
+    ) -> Self {
+        self.browser = Some(manager);
+        self
+    }
+
+    /// Fetch a page's HTML, escalating to a headless render only when the static
+    /// fetch looks like an unrendered JavaScript shell and a browser is wired.
+    async fn fetch_html(
+        &self,
+        url: &str,
+        session_id: Uuid,
+        timeout: u64,
+    ) -> std::result::Result<String, String> {
+        let html = fetch::fetch_static(url, timeout).await?;
+
+        #[cfg(feature = "browser")]
+        if fetch::is_js_shell(&html)
+            && let Some(browser) = &self.browser
+        {
+            match fetch::fetch_rendered(browser, session_id, url).await {
+                Ok(rendered) => return Ok(rendered),
+                Err(e) => tracing::debug!("web_scrape: render escalation failed for {url}: {e}"),
+            }
+        }
+        #[cfg(not(feature = "browser"))]
+        let _ = session_id;
+
+        Ok(html)
+    }
+
+    /// Run the full page pipeline: SSRF-validate, fetch, isolate (readable) or
+    /// keep (raw) the content, strip noise, absolutize URLs, convert to markdown.
+    async fn scrape_markdown(
+        &self,
+        url: &str,
+        mode: Mode,
+        session_id: Uuid,
+        timeout: u64,
+    ) -> std::result::Result<String, String> {
+        let base = ssrf::validate_url(url)?;
+        let html = self.fetch_html(url, session_id, timeout).await?;
+
+        let content = match mode {
+            Mode::Readable => extract::extract_main_content(&html),
+            Mode::Raw => html,
+        };
+        let cleaned = clean::strip_noise(&content);
+        let absolute = to_markdown::absolutize_urls(&cleaned, &base);
+        let markdown = to_markdown::to_markdown(&absolute);
+        Ok(clean::collapse_blank_lines(&markdown))
+    }
+
+    /// `sitemap` mode. Without `export`, return the discovered page-URL list for
+    /// the agent to pick from. With `export`, scrape each page (bounded) and
+    /// write the markdown to the session's export directory.
+    async fn run_sitemap(
+        &self,
+        url: &str,
+        export: bool,
+        max_pages: usize,
+        session_id: Uuid,
+        timeout: u64,
+        context: &ToolExecutionContext,
+    ) -> Result<ToolResult> {
+        // Root URL is SSRF-checked before we start touching robots.txt/sitemaps.
+        if let Err(e) = ssrf::validate_url(url) {
+            return Ok(ToolResult::error(format!("web_scrape: {e}")));
+        }
+
+        // A URL that already points at a sitemap is used directly; otherwise we
+        // auto-discover one from the site root.
+        let sitemap_url = if url.to_ascii_lowercase().contains("sitemap") && url.ends_with(".xml") {
+            url.to_string()
+        } else {
+            match sitemap::discover_sitemap_url(url, timeout).await {
+                Some(s) => s,
+                None => {
+                    return Ok(ToolResult::error(format!(
+                        "web_scrape: no sitemap found for {url} (tried /sitemap.xml, robots.txt, common alternates)"
+                    )));
+                }
+            }
+        };
+
+        let pages = sitemap::collect_sitemap_urls(&sitemap_url, timeout).await;
+        if pages.is_empty() {
+            return Ok(ToolResult::error(format!(
+                "web_scrape: sitemap {sitemap_url} yielded no page URLs"
+            )));
+        }
+
+        if !export {
+            let joined = pages.join("\n");
+            let listing = truncate_utf8(&joined, MAX_INLINE_BYTES);
+            return Ok(ToolResult::success(format!(
+                "Found {} page URLs in {sitemap_url}:\n\n{listing}",
+                pages.len()
+            ))
+            .with_metadata("sitemap_url".into(), sitemap_url)
+            .with_metadata("url_count".into(), pages.len().to_string()));
+        }
+
+        // Export: scrape each page up to the requested cap and write to disk.
+        let dir = export::resolve_export_dir(session_id, context.service_context.as_ref()).await;
+        let limit = max_pages.min(SITEMAP_EXPORT_HARD_CAP).min(pages.len());
+        let mut written = 0usize;
+        let mut failed = 0usize;
+
+        for page in pages.iter().take(limit) {
+            match self
+                .scrape_markdown(page, Mode::Readable, session_id, timeout)
+                .await
+            {
+                Ok(md) => match export::write_markdown(&dir, page, &md).await {
+                    Ok(_) => written += 1,
+                    Err(e) => {
+                        failed += 1;
+                        tracing::debug!("web_scrape: export write failed for {page}: {e}");
+                    }
+                },
+                Err(e) => {
+                    failed += 1;
+                    tracing::debug!("web_scrape: scrape failed for {page}: {e}");
+                }
+            }
+        }
+
+        let mut summary = format!(
+            "Exported {written} of {} sitemap pages to {}",
+            pages.len(),
+            dir.display()
+        );
+        if limit < pages.len() {
+            summary.push_str(&format!(
+                "\n(capped at {limit} pages; raise max_pages up to {SITEMAP_EXPORT_HARD_CAP} for more)"
+            ));
+        }
+        if failed > 0 {
+            summary.push_str(&format!("\n{failed} page(s) failed and were skipped."));
+        }
+
+        Ok(ToolResult::success(summary)
+            .with_metadata("export_dir".into(), dir.display().to_string())
+            .with_metadata("pages_written".into(), written.to_string())
+            .with_metadata("pages_total".into(), pages.len().to_string()))
+    }
+}
+
+#[async_trait]
+impl Tool for WebScrapeTool {
+    fn name(&self) -> &str {
+        "web_scrape"
+    }
+
+    fn description(&self) -> &str {
+        "Fetch a URL and return clean markdown at zero AI / zero API cost. Isolates \
+         the main content, strips scripts/nav/footers, and keeps images as \
+         ![alt](url) references so you can vision only the ones a task needs. \
+         Modes: 'readable' (default, main content only), 'raw' (whole page), \
+         'sitemap' (list a site's page URLs, or with export=true scrape them all \
+         to disk). Set export=true to also save markdown under the session's \
+         project or profile directory. Prefer this over http_request for reading \
+         page content."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The page URL to scrape, or a site root / sitemap URL in sitemap mode."
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["readable", "raw", "sitemap"],
+                    "description": "readable = main content as markdown (default); raw = whole page; sitemap = enumerate a site's page URLs.",
+                    "default": "readable"
+                },
+                "export": {
+                    "type": "boolean",
+                    "description": "Also write the markdown to disk under the session's project (projects/<slug>/files/scrapes/) or active profile (~/.opencrabs[/profiles/<name>]/scrapes/). In sitemap mode, scrapes and saves every page.",
+                    "default": false
+                },
+                "max_pages": {
+                    "type": "integer",
+                    "description": "sitemap + export only: cap on pages scraped (default 20, hard max 100).",
+                    "default": 20
+                }
+            },
+            "required": ["url"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        // Network only. Export writes are confined to the workspace scrapes
+        // directory (never a user-supplied path), so this stays approval-free
+        // like the other read-oriented web tools rather than gating every scrape.
+        vec![ToolCapability::Network]
+    }
+
+    async fn execute(&self, input: Value, context: &ToolExecutionContext) -> Result<ToolResult> {
+        let url = input
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| ToolError::InvalidInput("web_scrape requires a 'url'".into()))?;
+
+        let mode_str = input
+            .get("mode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("readable");
+        let export = input
+            .get("export")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let max_pages = input
+            .get("max_pages")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(20) as usize;
+
+        // Bound the per-request timeout so a slow site can't hang the agent.
+        let timeout = context.timeout_secs.clamp(5, 120);
+        let session_id = context.session_id;
+
+        if mode_str == "sitemap" {
+            return self
+                .run_sitemap(url, export, max_pages, session_id, timeout, context)
+                .await;
+        }
+
+        let mode = match mode_str {
+            "raw" => Mode::Raw,
+            _ => Mode::Readable,
+        };
+
+        let markdown = match self.scrape_markdown(url, mode, session_id, timeout).await {
+            Ok(md) => md,
+            Err(e) => {
+                return Ok(ToolResult::error(format!(
+                    "web_scrape failed for {url}: {e}"
+                )));
+            }
+        };
+
+        let mut header = String::new();
+        if export {
+            let dir =
+                export::resolve_export_dir(session_id, context.service_context.as_ref()).await;
+            match export::write_markdown(&dir, url, &markdown).await {
+                Ok(path) => header = format!("Saved to {}\n\n", path.display()),
+                Err(e) => {
+                    tracing::warn!("web_scrape: export write failed for {url}: {e}");
+                    header = format!("(export failed: {e})\n\n");
+                }
+            }
+        }
+
+        let body = truncate_utf8(&markdown, MAX_INLINE_BYTES);
+        let truncated = markdown.len() > body.len();
+        let mut output = format!("{header}{body}");
+        if truncated {
+            output.push_str(&format!(
+                "\n\n[truncated to {} of {} bytes{}]",
+                body.len(),
+                markdown.len(),
+                if export {
+                    "; full document written to disk"
+                } else {
+                    ""
+                }
+            ));
+        }
+
+        Ok(ToolResult::success(output)
+            .with_metadata("url".into(), url.to_string())
+            .with_metadata("bytes".into(), markdown.len().to_string()))
+    }
+}
+
+/// Truncate `s` to at most `max_bytes` on a UTF-8 char boundary.
+fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
+    crate::utils::string::truncate_str(s, max_bytes)
+}

--- a/src/cli/tool_setup.rs
+++ b/src/cli/tool_setup.rs
@@ -230,11 +230,24 @@ pub(crate) fn register_runtime_tools(tool_registry: &Arc<ToolRegistry>, config: 
         tool_registry.register(Arc::new(
             crate::brain::tools::browser::BrowserFindTool::new(browser_manager.clone()),
         ));
+        // web_scrape escalates JS-only pages to a headless render, so it takes a
+        // clone of the browser manager here (kept out of CORE_TOOLS, surfaced via
+        // tool_search). Registered before BrowserCloseTool consumes the manager.
+        tool_registry.register(Arc::new(
+            crate::brain::tools::web_scrape::WebScrapeTool::default()
+                .with_browser(browser_manager.clone()),
+        ));
         tool_registry.register(Arc::new(
             crate::brain::tools::browser::BrowserCloseTool::new(browser_manager),
         ));
         tracing::info!("Browser automation tools registered (9 tools)");
     }
     #[cfg(not(feature = "browser"))]
-    let _ = config;
+    {
+        let _ = config;
+        // No browser to escalate JS shells; web_scrape still serves static pages.
+        tool_registry.register(Arc::new(
+            crate::brain::tools::web_scrape::WebScrapeTool::default(),
+        ));
+    }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -380,6 +380,7 @@ pub mod voice_onboarding_test;
 pub mod voice_stt_dispatch_test;
 pub mod wait_agent_resolver_test;
 pub mod web_browser_routing_test;
+pub mod web_scrape_ssrf_test;
 pub mod whatsapp_state_test;
 
 // Channel handler tests (moved from inline #[cfg(test)] modules)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -381,6 +381,7 @@ pub mod voice_stt_dispatch_test;
 pub mod wait_agent_resolver_test;
 pub mod web_browser_routing_test;
 pub mod web_scrape_clean_test;
+pub mod web_scrape_export_test;
 pub mod web_scrape_extract_test;
 pub mod web_scrape_fetch_test;
 pub mod web_scrape_markdown_test;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -387,6 +387,7 @@ pub mod web_scrape_fetch_test;
 pub mod web_scrape_markdown_test;
 pub mod web_scrape_sitemap_test;
 pub mod web_scrape_ssrf_test;
+pub mod web_scrape_tool_test;
 pub mod whatsapp_state_test;
 
 // Channel handler tests (moved from inline #[cfg(test)] modules)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -382,6 +382,7 @@ pub mod wait_agent_resolver_test;
 pub mod web_browser_routing_test;
 pub mod web_scrape_clean_test;
 pub mod web_scrape_extract_test;
+pub mod web_scrape_markdown_test;
 pub mod web_scrape_ssrf_test;
 pub mod whatsapp_state_test;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -380,6 +380,7 @@ pub mod voice_onboarding_test;
 pub mod voice_stt_dispatch_test;
 pub mod wait_agent_resolver_test;
 pub mod web_browser_routing_test;
+pub mod web_scrape_clean_test;
 pub mod web_scrape_ssrf_test;
 pub mod whatsapp_state_test;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -384,6 +384,7 @@ pub mod web_scrape_clean_test;
 pub mod web_scrape_extract_test;
 pub mod web_scrape_fetch_test;
 pub mod web_scrape_markdown_test;
+pub mod web_scrape_sitemap_test;
 pub mod web_scrape_ssrf_test;
 pub mod whatsapp_state_test;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -382,6 +382,7 @@ pub mod wait_agent_resolver_test;
 pub mod web_browser_routing_test;
 pub mod web_scrape_clean_test;
 pub mod web_scrape_extract_test;
+pub mod web_scrape_fetch_test;
 pub mod web_scrape_markdown_test;
 pub mod web_scrape_ssrf_test;
 pub mod whatsapp_state_test;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -381,6 +381,7 @@ pub mod voice_stt_dispatch_test;
 pub mod wait_agent_resolver_test;
 pub mod web_browser_routing_test;
 pub mod web_scrape_clean_test;
+pub mod web_scrape_extract_test;
 pub mod web_scrape_ssrf_test;
 pub mod whatsapp_state_test;
 

--- a/src/tests/web_scrape_clean_test.rs
+++ b/src/tests/web_scrape_clean_test.rs
@@ -1,0 +1,89 @@
+//! Tests for the genericized structural cleaner. The key guarantees: script/
+//! style/handler/comment noise is removed, image and link URLs are preserved
+//! (they must survive into the markdown so the agent can vision them on
+//! demand), and none of insight_forge's Portuguese/client-specific line
+//! filters leak in to delete legitimate content.
+
+use crate::brain::tools::web_scrape::clean::{
+    collapse_blank_lines, decode_html_entities, strip_noise, to_plain_text,
+};
+
+#[test]
+fn strip_noise_removes_script_and_style_blocks() {
+    let html =
+        r#"<p>keep me</p><script>alert('x')</script><style>.a{color:red}</style><p>and me</p>"#;
+    let out = strip_noise(html);
+    assert!(out.contains("keep me"));
+    assert!(out.contains("and me"));
+    assert!(!out.contains("alert"));
+    assert!(!out.contains("color:red"));
+}
+
+#[test]
+fn strip_noise_removes_inline_handlers_and_comments() {
+    let html = r#"<a href="/x" onclick="steal()">link</a><!-- tracking pixel -->"#;
+    let out = strip_noise(html);
+    assert!(!out.contains("onclick"));
+    assert!(!out.contains("steal"));
+    assert!(!out.contains("tracking pixel"));
+    // The href and the visible text survive.
+    assert!(out.contains(r#"href="/x""#));
+    assert!(out.contains("link"));
+}
+
+#[test]
+fn strip_noise_preserves_image_and_link_urls() {
+    // Images and links are the payload the agent visions on demand — the
+    // cleaner must never strip their URLs.
+    let html = r#"<img src="https://cdn.example.com/chart.png" alt="Q3 chart"><a href="https://example.com/report">report</a>"#;
+    let out = strip_noise(html);
+    assert!(out.contains("https://cdn.example.com/chart.png"));
+    assert!(out.contains("https://example.com/report"));
+    assert!(out.contains("Q3 chart"));
+}
+
+#[test]
+fn decode_html_entities_maps_common_ones() {
+    assert_eq!(decode_html_entities("a&amp;b"), "a&b");
+    assert_eq!(decode_html_entities("x&lt;y&gt;z"), "x<y>z");
+    assert_eq!(decode_html_entities("&quot;q&quot;"), "\"q\"");
+    // nbsp becomes a plain space.
+    assert_eq!(decode_html_entities("a&nbsp;b"), "a b");
+}
+
+#[test]
+fn collapse_blank_lines_reduces_runs() {
+    assert_eq!(collapse_blank_lines("a\n\n\n\n\nb"), "a\n\nb");
+    assert_eq!(collapse_blank_lines("\n\nhello\n\n"), "hello");
+}
+
+#[test]
+fn to_plain_text_end_to_end() {
+    let html = r#"
+        <div>
+          <h1>Title</h1>
+          <script>var x = 1;</script>
+          <p>First   paragraph with   spaces.</p>
+          <p>Second&nbsp;paragraph.</p>
+        </div>
+    "#;
+    let text = to_plain_text(html);
+    assert!(text.contains("Title"));
+    assert!(text.contains("First paragraph with spaces."));
+    assert!(text.contains("Second paragraph."));
+    assert!(!text.contains("var x"));
+    // No raw tags remain.
+    assert!(!text.contains('<'));
+    assert!(!text.contains('>'));
+}
+
+#[test]
+fn to_plain_text_keeps_generic_form_words() {
+    // insight_forge's cleaner deleted lines containing "Contact", "Nome:",
+    // "Privacy", etc. On a generic site those are legitimate content and must
+    // survive.
+    let html = "<p>Contact us for a quote.</p><p>Your Privacy matters to us.</p>";
+    let text = to_plain_text(html);
+    assert!(text.contains("Contact us for a quote."));
+    assert!(text.contains("Your Privacy matters to us."));
+}

--- a/src/tests/web_scrape_export_test.rs
+++ b/src/tests/web_scrape_export_test.rs
@@ -1,0 +1,51 @@
+//! Tests for scraped-markdown export. The directory resolution is DB- and
+//! profile-aware and exercised end-to-end, so here we pin the pure filename
+//! derivation (host+path -> safe `.md` stem) and prove a write round-trips to
+//! the resolved path.
+
+use crate::brain::tools::web_scrape::export::{filename_for_url, write_markdown};
+
+#[test]
+fn derives_host_and_path_filename() {
+    assert_eq!(
+        filename_for_url("https://example.com/blog/post-1"),
+        "example.com-blog-post-1.md"
+    );
+}
+
+#[test]
+fn root_url_gets_index_stem() {
+    // No path beyond "/" — the host alone names the file, so a bare domain still
+    // yields a sensible, non-empty stem.
+    assert_eq!(filename_for_url("https://example.com/"), "example.com.md");
+}
+
+#[test]
+fn collapses_runs_of_unsafe_chars() {
+    // The name comes from host + path (port and query live elsewhere on the
+    // URL and are dropped); repeated path separators collapse to single dashes
+    // with dots preserved for readability and no trailing dash.
+    let name = filename_for_url("https://sub.example.com:8443/a//b?x=1&y=2");
+    assert_eq!(name, "sub.example.com-a-b.md");
+}
+
+#[test]
+fn unparsable_url_still_names_a_file() {
+    let name = filename_for_url("not a url");
+    assert!(name.ends_with(".md"));
+    assert!(!name.is_empty());
+}
+
+#[tokio::test]
+async fn write_markdown_round_trips_to_dir() {
+    let dir = std::env::temp_dir().join(format!("web_scrape_export_{}", uuid::Uuid::new_v4()));
+    let written = write_markdown(&dir, "https://example.com/page", "# Hello\n\nbody")
+        .await
+        .expect("write should succeed");
+
+    assert_eq!(written, dir.join("example.com-page.md"));
+    let back = std::fs::read_to_string(&written).expect("file should exist");
+    assert_eq!(back, "# Hello\n\nbody");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/tests/web_scrape_extract_test.rs
+++ b/src/tests/web_scrape_extract_test.rs
@@ -1,0 +1,75 @@
+//! Tests for main-content isolation. Prove the selector cascade prefers real
+//! content containers over surrounding chrome, that the body fallback strips
+//! nav/footer/aside when no container matches, and that content images survive
+//! extraction (they carry into the markdown for on-demand vision).
+
+use crate::brain::tools::web_scrape::extract::extract_main_content;
+
+const PADDING: &str =
+    "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor";
+
+#[test]
+fn prefers_main_over_surrounding_chrome() {
+    let html = format!(
+        r#"<html><body>
+            <nav>site navigation links here</nav>
+            <main><p>The real article body. {PADDING}</p></main>
+            <footer>copyright and contact footer</footer>
+        </body></html>"#
+    );
+    let out = extract_main_content(&html);
+    assert!(out.contains("The real article body"));
+    assert!(!out.contains("site navigation"));
+    assert!(!out.contains("copyright and contact"));
+}
+
+#[test]
+fn falls_back_to_article_when_no_main() {
+    let html = format!(
+        r#"<html><body>
+            <div class="header">header stuff</div>
+            <article><p>Article content lives here. {PADDING}</p></article>
+        </body></html>"#
+    );
+    let out = extract_main_content(&html);
+    assert!(out.contains("Article content lives here"));
+}
+
+#[test]
+fn body_fallback_strips_nav_and_footer() {
+    // No recognized content container — fall back to <body> minus junk.
+    let html = format!(
+        r#"<html><body>
+            <nav>menu one menu two menu three</nav>
+            <div><p>Plain content with no semantic wrapper. {PADDING}</p></div>
+            <footer>footer boilerplate text here</footer>
+            <aside>related sidebar widgets here</aside>
+        </body></html>"#
+    );
+    let out = extract_main_content(&html);
+    assert!(out.contains("Plain content with no semantic wrapper"));
+    assert!(!out.contains("menu one menu two"));
+    assert!(!out.contains("footer boilerplate"));
+    assert!(!out.contains("related sidebar"));
+}
+
+#[test]
+fn preserves_content_images() {
+    let html = format!(
+        r#"<html><body><main>
+            <p>See the chart. {PADDING}</p>
+            <img src="https://cdn.example.com/q3.png" alt="Q3 revenue">
+        </main></body></html>"#
+    );
+    let out = extract_main_content(&html);
+    assert!(out.contains("https://cdn.example.com/q3.png"));
+    assert!(out.contains("Q3 revenue"));
+}
+
+#[test]
+fn returns_something_for_bodyless_input() {
+    // Pathological input with no body still yields a non-empty fragment so the
+    // caller always has something to convert.
+    let out = extract_main_content("<p>bare fragment</p>");
+    assert!(out.contains("bare fragment"));
+}

--- a/src/tests/web_scrape_fetch_test.rs
+++ b/src/tests/web_scrape_fetch_test.rs
@@ -1,0 +1,46 @@
+//! Tests for the `web_scrape` fetch stage. Only the network-free `is_js_shell`
+//! heuristic is exercised here: the reqwest and headless-Chrome paths are I/O
+//! and are covered end-to-end elsewhere. The heuristic is what decides whether a
+//! cheap static fetch is enough or the page needs a browser render, so its
+//! boundaries are worth pinning down.
+
+use crate::brain::tools::web_scrape::fetch::is_js_shell;
+
+#[test]
+fn server_rendered_page_is_not_a_shell() {
+    let html = "<html><body><article><h1>Real Article</h1><p>\
+        This is a fully server-rendered page with plenty of visible prose. \
+        It has multiple sentences of genuine content that a reader can see \
+        without running any JavaScript at all, so it must not be flagged as \
+        an empty shell needing a browser render.</p></article></body></html>";
+    assert!(!is_js_shell(html));
+}
+
+#[test]
+fn empty_spa_shell_with_scripts_is_flagged() {
+    let html = "<html><head><script src=\"/bundle.js\"></script></head>\
+        <body><div id=\"root\"></div><script>window.__APP__=1;</script></body></html>";
+    assert!(is_js_shell(html));
+}
+
+#[test]
+fn empty_page_without_scripts_is_not_a_shell() {
+    // No scripts at all means there is nothing a browser render would reveal,
+    // so even a sparse page should not escalate.
+    let html = "<html><body><div id=\"root\"></div></body></html>";
+    assert!(!is_js_shell(html));
+}
+
+#[test]
+fn script_heavy_page_with_real_text_is_not_a_shell() {
+    // Scripts present, but the body already carries the content: no escalation.
+    let html = "<html><head><script src=\"/analytics.js\"></script></head><body>\
+        <main><p>The quarterly results are in and revenue grew across every \
+        region we operate in. Below is a detailed breakdown of the numbers, \
+        the drivers behind them, and what we expect for the next period. Growth \
+        was strongest in the enterprise segment, where new logos and expansion \
+        deals both outpaced our internal targets, while the self-serve tier held \
+        steady quarter over quarter. Costs stayed flat, so most of that top-line \
+        gain fell through to margin.</p></main><script>track();</script></body></html>";
+    assert!(!is_js_shell(html));
+}

--- a/src/tests/web_scrape_markdown_test.rs
+++ b/src/tests/web_scrape_markdown_test.rs
@@ -1,0 +1,64 @@
+//! Tests for HTML-to-markdown conversion and URL absolutization. The headline
+//! guarantee: images survive as markdown `![alt](absolute-url)` references so
+//! the agent can vision the specific ones it needs, and relative URLs are
+//! resolved against the page base so those references are directly fetchable.
+
+use crate::brain::tools::web_scrape::to_markdown::{absolutize_urls, to_markdown};
+use url::Url;
+
+fn base() -> Url {
+    Url::parse("https://example.com/blog/post").unwrap()
+}
+
+#[test]
+fn absolutize_resolves_relative_src_and_href() {
+    let html = r#"<img src="/img/a.png"><a href="../about">about</a>"#;
+    let out = absolutize_urls(html, &base());
+    assert!(out.contains(r#"src="https://example.com/img/a.png""#));
+    assert!(out.contains(r#"href="https://example.com/about""#));
+}
+
+#[test]
+fn absolutize_leaves_absolute_and_special_urls() {
+    let html = r##"<img src="https://cdn.example.com/x.png"><a href="#section">jump</a><a href="mailto:a@b.com">mail</a>"##;
+    let out = absolutize_urls(html, &base());
+    assert!(out.contains(r#"src="https://cdn.example.com/x.png""#));
+    assert!(out.contains(r##"href="#section""##));
+    assert!(out.contains(r#"href="mailto:a@b.com""#));
+}
+
+#[test]
+fn absolutize_handles_protocol_relative() {
+    let html = r#"<img src="//cdn.example.com/y.png">"#;
+    let out = absolutize_urls(html, &base());
+    // Protocol-relative URLs pick up the page's https scheme.
+    assert!(out.contains(r#"src="https://cdn.example.com/y.png""#));
+}
+
+#[test]
+fn markdown_keeps_headings_and_links() {
+    let md = to_markdown(r#"<h1>Title</h1><p>Some <a href="https://example.com/x">link</a> text.</p>"#);
+    assert!(md.contains("# Title"));
+    assert!(md.contains("[link](https://example.com/x)"));
+    assert!(md.contains("text."));
+}
+
+#[test]
+fn markdown_keeps_images_as_url_tags() {
+    // The core design guarantee: an <img> becomes a markdown image reference,
+    // never OCR'd or dropped.
+    let md = to_markdown(r#"<p>chart:</p><img src="https://cdn.example.com/q3.png" alt="Q3 revenue">"#);
+    assert!(md.contains("https://cdn.example.com/q3.png"));
+    assert!(md.contains("Q3 revenue"));
+    assert!(md.contains("!["));
+}
+
+#[test]
+fn absolutize_then_markdown_yields_fetchable_image() {
+    // End-to-end: a relative image on the page becomes an absolute markdown
+    // image reference the agent can hand straight to vision.
+    let html = r#"<main><p>See below. lorem ipsum dolor sit amet.</p><img src="/media/fig1.png" alt="Figure 1"></main>"#;
+    let md = to_markdown(&absolutize_urls(html, &base()));
+    assert!(md.contains("https://example.com/media/fig1.png"));
+    assert!(md.contains("Figure 1"));
+}

--- a/src/tests/web_scrape_markdown_test.rs
+++ b/src/tests/web_scrape_markdown_test.rs
@@ -37,7 +37,8 @@ fn absolutize_handles_protocol_relative() {
 
 #[test]
 fn markdown_keeps_headings_and_links() {
-    let md = to_markdown(r#"<h1>Title</h1><p>Some <a href="https://example.com/x">link</a> text.</p>"#);
+    let md =
+        to_markdown(r#"<h1>Title</h1><p>Some <a href="https://example.com/x">link</a> text.</p>"#);
     assert!(md.contains("# Title"));
     assert!(md.contains("[link](https://example.com/x)"));
     assert!(md.contains("text."));
@@ -47,7 +48,8 @@ fn markdown_keeps_headings_and_links() {
 fn markdown_keeps_images_as_url_tags() {
     // The core design guarantee: an <img> becomes a markdown image reference,
     // never OCR'd or dropped.
-    let md = to_markdown(r#"<p>chart:</p><img src="https://cdn.example.com/q3.png" alt="Q3 revenue">"#);
+    let md =
+        to_markdown(r#"<p>chart:</p><img src="https://cdn.example.com/q3.png" alt="Q3 revenue">"#);
     assert!(md.contains("https://cdn.example.com/q3.png"));
     assert!(md.contains("Q3 revenue"));
     assert!(md.contains("!["));

--- a/src/tests/web_scrape_sitemap_test.rs
+++ b/src/tests/web_scrape_sitemap_test.rs
@@ -1,0 +1,73 @@
+//! Tests for sitemap XML parsing. Prove `<loc>` extraction pulls every page URL,
+//! decodes the `&amp;` entities generators emit in query strings, resolves
+//! relative locs against the sitemap's own URL, and that the sitemap sniffer
+//! recognizes both `<urlset>` leaves and `<sitemapindex>` documents. These are
+//! the pure, network-free halves of the crawler; the async walk that fetches
+//! nested sitemaps is exercised end-to-end, not here.
+
+use crate::brain::tools::web_scrape::sitemap::{extract_locs, looks_like_sitemap};
+use url::Url;
+
+#[test]
+fn extracts_all_page_locs() {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>https://example.com/a</loc></url>
+          <url><loc>https://example.com/b</loc></url>
+          <url><loc>https://example.com/c</loc></url>
+        </urlset>"#;
+    let locs = extract_locs(xml, None);
+    assert_eq!(locs.len(), 3);
+    assert!(locs.contains(&"https://example.com/a".to_string()));
+    assert!(locs.contains(&"https://example.com/c".to_string()));
+}
+
+#[test]
+fn decodes_amp_entities_in_query_strings() {
+    // Sitemap generators escape `&` as `&amp;` inside URLs; the raw loc must be
+    // decoded back to a real, fetchable URL.
+    let xml = r#"<urlset><url><loc>https://example.com/p?a=1&amp;b=2</loc></url></urlset>"#;
+    let locs = extract_locs(xml, None);
+    assert_eq!(locs, vec!["https://example.com/p?a=1&b=2".to_string()]);
+}
+
+#[test]
+fn resolves_relative_locs_against_base() {
+    // Rare but legal: a loc expressed relative to the sitemap's own location.
+    let base = Url::parse("https://example.com/sitemap.xml").unwrap();
+    let xml = r#"<urlset><url><loc>/blog/post-1</loc></url></urlset>"#;
+    let locs = extract_locs(xml, Some(&base));
+    assert_eq!(locs, vec!["https://example.com/blog/post-1".to_string()]);
+}
+
+#[test]
+fn drops_relative_locs_without_a_base() {
+    // With no base to resolve against, an un-absolutizable loc is dropped rather
+    // than handed back as a broken relative string.
+    let xml = r#"<urlset><url><loc>/blog/post-1</loc></url></urlset>"#;
+    let locs = extract_locs(xml, None);
+    assert!(locs.is_empty());
+}
+
+#[test]
+fn extracts_nested_sitemap_locs_from_index() {
+    // A `<sitemapindex>` lists child sitemaps as `<loc>` too — same extraction.
+    let xml = r#"<sitemapindex>
+          <sitemap><loc>https://example.com/sitemap-posts.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap-pages.xml</loc></sitemap>
+        </sitemapindex>"#;
+    let locs = extract_locs(xml, None);
+    assert_eq!(locs.len(), 2);
+    assert!(locs.contains(&"https://example.com/sitemap-posts.xml".to_string()));
+}
+
+#[test]
+fn recognizes_urlset_and_index_documents() {
+    assert!(looks_like_sitemap(
+        r#"<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">"#
+    ));
+    assert!(looks_like_sitemap("<sitemapindex>"));
+    assert!(!looks_like_sitemap(
+        "<html><body>not a sitemap</body></html>"
+    ));
+}

--- a/src/tests/web_scrape_ssrf_test.rs
+++ b/src/tests/web_scrape_ssrf_test.rs
@@ -1,0 +1,62 @@
+//! SSRF guard tests for `web_scrape`. Prove the fetcher refuses every
+//! non-public target (localhost, private/loopback/link-local IPs, cloud
+//! metadata, non-http schemes) and accepts ordinary public URLs.
+
+use crate::brain::tools::web_scrape::ssrf::validate_url;
+
+#[test]
+fn accepts_public_http_and_https() {
+    assert!(validate_url("https://example.com/article").is_ok());
+    assert!(validate_url("http://example.com").is_ok());
+    // 8.8.8.8 is a public IP literal — allowed.
+    assert!(validate_url("https://8.8.8.8/").is_ok());
+}
+
+#[test]
+fn returns_parsed_url_for_relative_base() {
+    let parsed = validate_url("https://example.com/blog/post").unwrap();
+    // The returned Url is usable as a base for resolving relative links.
+    let joined = parsed.join("/img/logo.png").unwrap();
+    assert_eq!(joined.as_str(), "https://example.com/img/logo.png");
+}
+
+#[test]
+fn rejects_non_web_schemes() {
+    assert!(validate_url("file:///etc/passwd").is_err());
+    assert!(validate_url("ftp://example.com/x").is_err());
+    assert!(validate_url("gopher://example.com").is_err());
+}
+
+#[test]
+fn rejects_localhost() {
+    assert!(validate_url("http://localhost/").is_err());
+    assert!(validate_url("http://localhost.localdomain/").is_err());
+}
+
+#[test]
+fn rejects_cloud_metadata_endpoint() {
+    assert!(validate_url("http://169.254.169.254/latest/meta-data/").is_err());
+    // Any link-local 169.254.0.0/16 host is refused.
+    assert!(validate_url("http://169.254.1.1/").is_err());
+}
+
+#[test]
+fn rejects_private_ipv4_ranges() {
+    assert!(validate_url("http://127.0.0.1/").is_err());
+    assert!(validate_url("http://10.0.0.5/").is_err());
+    assert!(validate_url("http://192.168.1.1/").is_err());
+    assert!(validate_url("http://172.16.0.1/").is_err());
+}
+
+#[test]
+fn rejects_internal_ipv6() {
+    assert!(validate_url("http://[::1]/").is_err());
+    // Unique-local address (fc00::/7).
+    assert!(validate_url("http://[fd00::1]/").is_err());
+}
+
+#[test]
+fn rejects_garbage() {
+    assert!(validate_url("not a url").is_err());
+    assert!(validate_url("https://").is_err());
+}

--- a/src/tests/web_scrape_tool_test.rs
+++ b/src/tests/web_scrape_tool_test.rs
@@ -1,0 +1,70 @@
+//! Tests for the `web_scrape` tool surface and its no-network guard paths. The
+//! scraping pipeline itself is covered by the per-stage module tests; here we
+//! pin the tool contract (name, schema, approval-free Network capability) and
+//! that bad input and SSRF-blocked URLs fail cleanly before any fetch.
+
+use crate::brain::tools::r#trait::{Tool, ToolCapability, ToolExecutionContext};
+use crate::brain::tools::web_scrape::WebScrapeTool;
+use serde_json::json;
+use uuid::Uuid;
+
+fn ctx() -> ToolExecutionContext {
+    ToolExecutionContext::new(Uuid::new_v4())
+}
+
+#[test]
+fn advertises_stable_contract() {
+    let tool = WebScrapeTool::default();
+    assert_eq!(tool.name(), "web_scrape");
+    // Network only — never gates on approval like a general file writer would.
+    assert_eq!(tool.capabilities(), vec![ToolCapability::Network]);
+    assert!(!tool.requires_approval());
+}
+
+#[test]
+fn schema_requires_url_and_offers_modes() {
+    let schema = WebScrapeTool::default().input_schema();
+    assert_eq!(schema["required"][0], "url");
+    let modes = &schema["properties"]["mode"]["enum"];
+    assert!(modes.as_array().unwrap().iter().any(|m| m == "readable"));
+    assert!(modes.as_array().unwrap().iter().any(|m| m == "sitemap"));
+}
+
+#[tokio::test]
+async fn missing_url_is_invalid_input() {
+    let err = WebScrapeTool::default()
+        .execute(json!({}), &ctx())
+        .await
+        .expect_err("missing url must error");
+    assert!(err.to_string().to_lowercase().contains("url"));
+}
+
+#[tokio::test]
+async fn blank_url_is_invalid_input() {
+    let err = WebScrapeTool::default()
+        .execute(json!({ "url": "   " }), &ctx())
+        .await
+        .expect_err("blank url must error");
+    assert!(err.to_string().to_lowercase().contains("url"));
+}
+
+#[tokio::test]
+async fn ssrf_blocked_url_fails_without_fetch() {
+    // file:// is rejected by the SSRF guard before any network call, so this
+    // returns a clean error result rather than hanging or panicking.
+    let result = WebScrapeTool::default()
+        .execute(json!({ "url": "file:///etc/passwd" }), &ctx())
+        .await
+        .expect("execute should return a result, not an error");
+    assert!(!result.success);
+    assert!(result.error.unwrap_or(result.output).contains("web_scrape"));
+}
+
+#[tokio::test]
+async fn localhost_url_is_blocked() {
+    let result = WebScrapeTool::default()
+        .execute(json!({ "url": "http://localhost:8080/admin" }), &ctx())
+        .await
+        .expect("execute should return a result");
+    assert!(!result.success);
+}


### PR DESCRIPTION
## Summary

Add a native, on-demand `web_scrape` tool that turns a URL (or a whole sitemap) into clean markdown at **zero AI and zero API cost**, so the agent reads a compact denoised document instead of raw HTML. Ports the extraction pipeline from `insight_forge` (our 4-year-in-production Rust scraper), genericized for arbitrary sites.

Full research doc lives at `~/.opencrabs/projects/opencrabs/research/SCRAPING_RESEARCH.md` (workspace, not repo). This PR description is the implementation spec.

## Why

OpenCrabs has **no HTML-to-markdown / readability capability today**. When a user shares a URL and asks the agent to check it, we route to:

| Tool | Problem |
|------|---------|
| `http_request` | Returns raw HTML body: script/nav/footer soup, token-expensive |
| `browser_navigate` | Heavy CDP render, slow, token-heavy DOM dump |
| `doc_parser` | Local files only, no URL fetch, naive tag-strip |
| `web_search`/`exa_search` | Search results, not page content |

Raw HTML of a typical article is 50k-300k chars. Extracted markdown is 2k-15k. That is a **10x-30x token reduction before the model reads a single token**, no AI call to produce it. Same value proposition as RTK for bash output, applied to the web.

## Design principles

1. **Zero AI in the extraction path.** Fetch -> isolate main content -> clean -> markdown. All deterministic.
2. **Images stay as markdown URL tags.** `<img>` becomes `![alt](absolute-url)` inline. The agent reads compact text, sees image URLs where they belong, and visions ONLY the specific ones that matter for the task. No page-to-PNG, no blanket vision pass, no auto-OCR. Vision is a deliberate agent-driven step on individual URLs.
3. **reqwest-first, browser as escalation.** Plain GET for server-rendered pages (the 90% case). Escalate to the existing `chromey` CDP browser only for JS shells. No new browser dependency.
4. **Completely modular, small pure services.** No fat tool file, no logic added to existing files.

## Module layout (net-new files under `src/brain/tools/web_scrape/`)

| File | Responsibility | Purity | ~Size |
|------|---------------|--------|-------|
| `mod.rs` | Thin `Tool` impl: parse input, orchestrate pipeline, format `ToolResult`. No extraction logic. | orchestration | ~120 |
| `fetch.rs` | reqwest GET + chromey escalation (`is_js_shell`). Only IO module. | async | ~90 |
| `extract.rs` | `extract_main_content`: `scraper` CSS-selector cascade + body fallback. | pure | ~110 |
| `clean.rs` | Structural denoise (scripts/styles/forms/footers/nav/social/iframes), entity decode, NFC. No client-specific strings, no image-URL stripping. | pure | ~130 |
| `to_markdown.rs` | HTML-to-markdown + relative->absolute `img src`/`a href` resolution. | pure | ~70 |
| `ssrf.rs` | `validate_url` guard: reject file://, localhost, private/link-local/multicast IPs, cloud metadata. | pure | ~90 |
| `sitemap.rs` | `discover_sitemap_url` + recursive `extract_urls_from_sitemap` + bounded crawl. | async | ~150 |

Every pure module is unit-testable with fixture HTML and zero network. Extraction runs synchronously on the fetched string before any await (avoids `scraper`'s `!Send`-across-await trap).

## Edits to existing files (minimal)

- `src/brain/tools/mod.rs`: `pub mod web_scrape;` (one line)
- `src/cli/tool_setup.rs`: `tool_registry.register(Arc::new(WebScrapeTool));` (one line)
- `src/brain/tools/catalog.rs`: optional `web` category arm (one line)

**Zero lines added to any existing tool implementation.** Deferred by default (not in `CORE_TOOLS`), surfaced on demand via `tool_search`.

## Tool interface

```
web_scrape({
  url: string,           // required
  mode: "readable" | "raw" | "sitemap",  // default readable
  render: bool,          // default false; force chromey for JS pages
  max_length: int,       // default ~20000; truncate markdown
  max_pages: int         // default 20; sitemap crawl cap
})
```

Capability: `Network` only (no approval gate, read-only).

## Dependencies

Already present: `reqwest`, `unicode-normalization`, `regex`, `url`, `chromey` (browser feature).
MVP adds two: `scraper` + one HTML-to-markdown crate (`htmd` recommended, `html2md` for exact insight_forge parity). Sitemap phase adds `roxmltree` or reuses transitive `quick-xml`.

## Phased plan

- **Phase 1 (MVP):** single URL, `readable` + `raw` modes, reqwest fetch, extract, clean, markdown, truncate. Full test coverage.
- **Phase 2 (safety + JS):** port SSRF guard (mandatory), chromey fallback for JS shells.
- **Phase 3 (sitemap):** discovery + recursive crawl, bounded (semaphore, `max_pages`, rate limit).
- **Phase 4 (optional, later):** PDF text via optional `pdfium` feature; disk-write mode for large crawls.

## Testing

One test file per submodule under `src/tests/` (repo rule: no inline `#[cfg(test)]`), registered in `src/tests/mod.rs`: `web_scrape_extract_test.rs`, `web_scrape_clean_test.rs`, `web_scrape_markdown_test.rs`, `web_scrape_ssrf_test.rs`, `web_scrape_sitemap_test.rs`. Fixture HTML in, expected markdown out, no network.

## Open decisions

1. HTML-to-markdown crate: `htmd` (modern) vs `html2md` (parity)
2. Sitemap XML: new `roxmltree` vs transitive `quick-xml`
3. Tool name: `web_scrape` vs `fetch_markdown` vs `read_url`
4. Sitemap mode: auto-scrape pages, or return URL list only (cheaper, agent picks)
5. Ship phases 1-3 together, or land phase 1 first and iterate

## Genericization note

`insight_forge`'s `clean_content` carries hardcoded Portuguese/client-site patterns (`FORMULARIO DE CONTACTO`, `Nome:`, etc). These get stripped to structural cleaning only before shipping. Keep the structure, drop the client-specific string matches.