### PR TITLE
feat(telegram): fold intermediate text into the in-place processing log (#300)

### DIFF
--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -260,6 +260,15 @@ async fn append_tool_group(
                     }
                 }
                 s.open_group_msg_id = Some(mid);
+                // A NEW message just landed below the streaming placeholder —
+                // re-post it next tick so the response stays at the bottom.
+                // This is the ONLY tool-driven recreate: consecutive tool
+                // completions merely edit this group in place, so the old
+                // recreate-per-ToolCompleted was a delete+send pair per tick
+                // against Telegram's ~20/min per-group send budget (#299).
+                if s.msg_id.is_some() {
+                    s.recreate = true;
+                }
             }
         }
     }
@@ -3253,10 +3262,11 @@ pub(crate) async fn handle_message(
                             tool.completed = Some(success);
                             tool.dirty = true;
                         }
-                        // Push response to bottom so it stays below tool/approval messages
-                        if s.msg_id.is_some() {
-                            s.recreate = true;
-                        }
+                        // No recreate here (#299): a completion only edits the
+                        // open group block in place — nothing new lands below
+                        // the placeholder. The re-post happens where a message
+                        // is actually SENT (fresh group in append_tool_group,
+                        // and the IntermediateText arm below).
                     }
                 }
                 ProgressEvent::IntermediateText { text, reasoning: _ } => {
@@ -4314,9 +4324,9 @@ pub(crate) async fn resume_session(
                         tool.completed = Some(success);
                         tool.dirty = true;
                     }
-                    if s.msg_id.is_some() {
-                        s.recreate = true;
-                    }
+                    // No recreate here (#299) — see the handle_message arm:
+                    // completions edit the group in place, nothing new lands
+                    // below the placeholder.
                 }
             }
             ProgressEvent::IntermediateText { text, reasoning: _ } => {

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -54,6 +54,20 @@ pub(crate) enum DisplayItem {
     Intermediate(String),
 }
 
+/// One entry in the in-place processing log (the growing `<blockquote
+/// expandable>` message). Tool entries reference `tool_msgs` by index so a
+/// status flip (⚙️ → ✅/❌) re-renders live; text entries hold the already
+/// sanitized intermediate text (escaped at render time). Interleaving both in
+/// one ordered flow lets tool calls and intermediate text share a single
+/// collapsed block instead of each landing as a separate message.
+#[derive(Clone)]
+pub(crate) enum FlowEntry {
+    /// A tool call at this index in `tool_msgs`.
+    Tool(usize),
+    /// Sanitized intermediate text (plain; escaped when rendered).
+    Text(String),
+}
+
 pub(crate) struct StreamingState {
     /// Response/thinking message (always at bottom)
     msg_id: Option<MessageId>,
@@ -63,12 +77,17 @@ pub(crate) struct StreamingState {
     tool_msgs: Vec<ToolMsg>,
     /// Ordered queue of new display items (tools + intermediates in chronological order)
     display_queue: Vec<DisplayItem>,
-    /// Message ID of the currently open tool-call group. Consecutive tool calls
-    /// are appended to this one message (edited in place) so a run of tools
-    /// collapses into a single growing `<blockquote expandable>` block instead
-    /// of one message per flush window. Set when a group is opened, cleared when
-    /// an intermediate text or the final response breaks the run.
+    /// Message ID of the open processing-log message. Tool calls and
+    /// intermediate text are appended to this one message (edited in place) so
+    /// the whole procedural trace of a turn collapses into a single growing
+    /// `<blockquote expandable>` block instead of one message per event. Set
+    /// when the first entry lands; stays open for the rest of the turn so the
+    /// final response is the only clean message at the bottom.
     open_group_msg_id: Option<MessageId>,
+    /// Ordered entries in the open processing-log message (tool calls +
+    /// intermediate text, in chronological order). Rendered together into the
+    /// `open_group_msg_id` message on every append/status change.
+    flow_entries: Vec<FlowEntry>,
     /// Response text from streaming chunks — own message at bottom
     response: String,
     dirty: bool,
@@ -120,36 +139,62 @@ pub(crate) struct StreamingState {
     user_message_preview: Option<String>,
 }
 
-/// Render a group of tool calls as final Telegram HTML.
-/// Groups consecutive tool calls into a single `<blockquote expandable>`
-/// block: native Telegram HTML (Bot API 7.3+) that renders collapsed with a
-/// tap-to-expand arrow in groups, DMs, and all official clients, with no
-/// dependency on the rich message API. A single tool call renders as a plain
-/// one-liner. Output is ready to send via `send_html_or_plain` — do NOT pass
-/// it through `markdown_to_telegram_html` (it would double-process the HTML).
-pub(crate) fn render_tool_group(tools: &[(String, String)]) -> String {
-    fn line(label: &str, context: &str) -> String {
-        if context.is_empty() {
-            format!("<b>{}</b>", escape_html(label))
-        } else {
-            format!("<b>{}</b> {}", escape_html(label), escape_html(context))
+/// A resolved line in the processing-log flow, ready to render. Tool lines
+/// carry the status label (icon + name) and context; text lines carry the
+/// sanitized intermediate text. Both are HTML-escaped at render time.
+pub(crate) enum FlowLine {
+    Tool { label: String, context: String },
+    Text(String),
+}
+
+/// Render resolved flow lines into final Telegram HTML. A lone tool line with
+/// no other content stays a plain one-liner (mirrors #296); anything else
+/// collapses into a single `<blockquote expandable>` block (Bot API 7.3+) that
+/// renders with a tap-to-expand arrow in groups, DMs, and all official clients
+/// with no rich-API dependency. Tool calls and intermediate text share the same
+/// block so only the final response stays clean at the bottom (#300). Output is
+/// final HTML — send via `send_html_or_plain`, never through
+/// `markdown_to_telegram_html` (it would double-process the HTML).
+pub(crate) fn render_flow_html(lines: &[FlowLine]) -> String {
+    let mut out: Vec<String> = Vec::new();
+    let mut tool_count = 0usize;
+    for line in lines {
+        match line {
+            FlowLine::Tool { label, context } => {
+                tool_count += 1;
+                if context.is_empty() {
+                    out.push(format!("<b>{}</b>", escape_html(label)));
+                } else {
+                    out.push(format!(
+                        "<b>{}</b> {}",
+                        escape_html(label),
+                        escape_html(context)
+                    ));
+                }
+            }
+            FlowLine::Text(text) => {
+                let text = text.trim();
+                if !text.is_empty() {
+                    out.push(escape_html(text));
+                }
+            }
         }
     }
-    if tools.is_empty() {
+    if out.is_empty() {
         return String::new();
     }
-    if tools.len() == 1 {
-        return line(&tools[0].0, &tools[0].1);
+    if out.len() == 1 && tool_count == 1 {
+        return out.remove(0);
     }
-    let body = tools
-        .iter()
-        .map(|(label, context)| line(label, context))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let header = if tool_count > 0 {
+        format!("{} tool calls", tool_count)
+    } else {
+        "Processing log".to_string()
+    };
     format!(
-        "<blockquote expandable><b>{} tool calls</b>\n{}</blockquote>",
-        tools.len(),
-        body
+        "<blockquote expandable><b>{}</b>\n{}</blockquote>",
+        header,
+        out.join("\n")
     )
 }
 
@@ -162,64 +207,73 @@ fn tool_status_icon(completed: Option<bool>) -> &'static str {
     }
 }
 
-/// Build `(label, context)` render pairs for the given tool indices.
-fn tool_group_details(
-    streaming: &Arc<std::sync::Mutex<StreamingState>>,
-    indices: &[usize],
-) -> Vec<(String, String)> {
-    let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-    indices
+/// Resolve the open processing-log flow (tool calls + intermediate text, in
+/// order) into final Telegram HTML via `render_flow_html`.
+fn render_flow(s: &StreamingState) -> String {
+    let lines: Vec<FlowLine> = s
+        .flow_entries
         .iter()
-        .filter_map(|&idx| {
-            s.tool_msgs.get(idx).map(|t| {
-                (
-                    format!("{} {}", tool_status_icon(t.completed), t.name),
-                    t.context.clone(),
-                )
-            })
+        .filter_map(|entry| match entry {
+            FlowEntry::Tool(idx) => s.tool_msgs.get(*idx).map(|t| FlowLine::Tool {
+                label: format!("{} {}", tool_status_icon(t.completed), t.name),
+                context: t.context.clone(),
+            }),
+            FlowEntry::Text(text) => Some(FlowLine::Text(text.clone())),
         })
-        .collect()
+        .collect();
+    render_flow_html(&lines)
 }
 
-/// Re-render every tool sharing `group_mid` and edit that message in place.
-/// Used both to grow an open group (append) and to reflect a tool's status
-/// change (⚙️ → ✅/❌) after it completes. A no-op edit ("message is not
-/// modified") and transient errors are ignored: the message already shows the
-/// correct content and the next tick retries.
-async fn refresh_tool_group(
-    bot: &Bot,
-    chat: ChatId,
-    streaming: &Arc<std::sync::Mutex<StreamingState>>,
-    group_mid: MessageId,
-) {
-    let details: Vec<(String, String)> = {
+/// Re-render the open processing-log flow and edit its message in place. Used
+/// after appending an entry and after a tool status flip (⚙️ → ✅/❌). A no-op
+/// edit ("message is not modified") and transient errors are ignored: the
+/// message already shows the correct content and the next tick retries.
+async fn refresh_flow(bot: &Bot, chat: ChatId, streaming: &Arc<std::sync::Mutex<StreamingState>>) {
+    let (mid, html) = {
         let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-        s.tool_msgs
-            .iter()
-            .filter(|t| t.msg_id == Some(group_mid))
-            .map(|t| {
-                (
-                    format!("{} {}", tool_status_icon(t.completed), t.name),
-                    t.context.clone(),
-                )
-            })
-            .collect()
+        match s.open_group_msg_id {
+            Some(mid) => (mid, render_flow(&s)),
+            None => return,
+        }
     };
-    if details.is_empty() {
+    if html.is_empty() {
         return;
     }
-    let html = render_tool_group(&details);
     let _ = bot
-        .edit_message_text(chat, group_mid, html)
+        .edit_message_text(chat, mid, html)
         .parse_mode(ParseMode::Html)
         .await;
 }
 
-/// Append buffered tool calls to the current open group, editing that message
-/// in place so consecutive tool calls collapse into one growing block. When no
-/// group is open, a new message is sent and becomes the open group. The open
-/// group is closed via `close_tool_group` when an intermediate text or the
-/// final response breaks the run of consecutive tool calls.
+/// Send the open processing-log message for the first time and record its id.
+/// A newly landed message re-posts the streaming placeholder next tick so the
+/// response stays at the bottom (the only flow-driven recreate; subsequent
+/// entries merely edit this message in place — #299).
+async fn open_flow(
+    bot: &Bot,
+    chat: ChatId,
+    thread_id: Option<teloxide::types::ThreadId>,
+    streaming: &Arc<std::sync::Mutex<StreamingState>>,
+) {
+    let html = {
+        let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+        render_flow(&s)
+    };
+    if html.is_empty() {
+        return;
+    }
+    if let Ok(mid) = send_html_or_plain(bot, chat, thread_id, &html).await {
+        let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+        s.open_group_msg_id = Some(mid);
+        if s.msg_id.is_some() {
+            s.recreate = true;
+        }
+    }
+}
+
+/// Append buffered tool calls to the open processing-log flow, editing that one
+/// message in place (or opening it if none is live yet) so consecutive tool
+/// calls collapse into a single growing block.
 async fn append_tool_group(
     bot: &Bot,
     chat: ChatId,
@@ -230,58 +284,65 @@ async fn append_tool_group(
     if buffer.is_empty() {
         return;
     }
-    let open = streaming
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .open_group_msg_id;
-    match open {
-        Some(mid) => {
-            {
-                let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                for &idx in buffer {
-                    if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                        tool.msg_id = Some(mid);
-                    }
-                }
-            }
-            refresh_tool_group(bot, chat, streaming, mid).await;
+    let open = {
+        let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+        for &idx in buffer {
+            s.flow_entries.push(FlowEntry::Tool(idx));
         }
-        None => {
-            let details = tool_group_details(streaming, buffer);
-            if details.is_empty() {
-                return;
+        s.open_group_msg_id
+    };
+    if open.is_some() {
+        // Tag the tools with the open message so status flips find them.
+        {
+            let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+            let mid = s.open_group_msg_id;
+            for &idx in buffer {
+                if let Some(tool) = s.tool_msgs.get_mut(idx) {
+                    tool.msg_id = mid;
+                }
             }
-            let html = render_tool_group(&details);
-            if let Ok(mid) = send_html_or_plain(bot, chat, thread_id, &html).await {
-                let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                for &idx in buffer {
-                    if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                        tool.msg_id = Some(mid);
-                    }
-                }
-                s.open_group_msg_id = Some(mid);
-                // A NEW message just landed below the streaming placeholder —
-                // re-post it next tick so the response stays at the bottom.
-                // This is the ONLY tool-driven recreate: consecutive tool
-                // completions merely edit this group in place, so the old
-                // recreate-per-ToolCompleted was a delete+send pair per tick
-                // against Telegram's ~20/min per-group send budget (#299).
-                if s.msg_id.is_some() {
-                    s.recreate = true;
-                }
+        }
+        refresh_flow(bot, chat, streaming).await;
+    } else {
+        open_flow(bot, chat, thread_id, streaming).await;
+        let mid = streaming
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .open_group_msg_id;
+        let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+        for &idx in buffer {
+            if let Some(tool) = s.tool_msgs.get_mut(idx) {
+                tool.msg_id = mid;
             }
         }
     }
 }
 
-/// Close the current open tool group so the next tool call starts a fresh
-/// message. Called when an intermediate text or the final response interrupts
-/// the run of consecutive tool calls.
-fn close_tool_group(streaming: &Arc<std::sync::Mutex<StreamingState>>) {
-    streaming
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .open_group_msg_id = None;
+/// Append sanitized intermediate text to the open processing-log flow, editing
+/// that one message in place (or opening it if none is live yet). The text is
+/// folded into the collapsed block instead of landing as its own message, so
+/// only the final response stays clean at the bottom. Empty text (e.g. a
+/// react-only intermediate) is ignored.
+async fn append_intermediate_to_flow(
+    bot: &Bot,
+    chat: ChatId,
+    thread_id: Option<teloxide::types::ThreadId>,
+    streaming: &Arc<std::sync::Mutex<StreamingState>>,
+    text: &str,
+) {
+    if text.trim().is_empty() {
+        return;
+    }
+    let open = {
+        let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+        s.flow_entries.push(FlowEntry::Text(text.to_string()));
+        s.open_group_msg_id
+    };
+    if open.is_some() {
+        refresh_flow(bot, chat, streaming).await;
+    } else {
+        open_flow(bot, chat, thread_id, streaming).await;
+    }
 }
 
 impl StreamingState {
@@ -2755,6 +2816,7 @@ pub(crate) async fn handle_message(
         tool_msgs: Vec::new(),
         display_queue: Vec::new(),
         open_group_msg_id: None,
+        flow_entries: Vec::new(),
         response: String::new(),
         dirty: false,
         recreate: false,
@@ -2913,128 +2975,40 @@ pub(crate) async fn handle_message(
                                     tool_buffer.push(*idx);
                                 }
                                 DisplayItem::Intermediate(text) => {
-                                    // Flush buffered tools into the open group, then
-                                    // close it: an intermediate breaks the run so the
-                                    // next tool call starts a fresh block.
+                                    // Flush buffered tools into the open flow,
+                                    // then fold this intermediate into the SAME
+                                    // in-place processing-log message. It no
+                                    // longer lands as its own message, so only
+                                    // the final response stays clean at the
+                                    // bottom (#300).
                                     append_tool_group(&bot, chat, thread_id, &st, &tool_buffer)
                                         .await;
-                                    close_tool_group(&st);
                                     tool_buffer.clear();
 
-                                    // Now process the intermediate text
-                                    // Apply the same sanitization chain as the
-                                    // final response path: strip LLM artifacts
-                                    // AND redact secrets. Without the redact
-                                    // step here, an intermediate carrying a
-                                    // Drive URL `…/file/d/<id>/view` goes out
-                                    // with the raw id, while the final-response
-                                    // edit of the same text gets redacted to
-                                    // `[REDACTED_TOKEN]`. Two different strings
-                                    // → dedup's substring replace fails → both
-                                    // shown verbatim as back-to-back duplicate
-                                    // messages (2026-04-18 20:57 + 21:21 TG
-                                    // screenshots). Redact here so both sides
-                                    // match.
-                                    let text =
-                                        crate::utils::sanitize::strip_llm_artifacts(text);
+                                    // Sanitize exactly as before folding:
+                                    // strip LLM artifacts, redact secrets, strip
+                                    // <<IMG:>> markers (the final-response
+                                    // handler sends the image), and extract +
+                                    // fire <<react:>> now so a mid-turn reaction
+                                    // acknowledges the user immediately (#261).
+                                    let text = crate::utils::sanitize::strip_llm_artifacts(text);
                                     let text = redact_secrets(&text);
-                                    // Strip <<IMG:path>> markers from
-                                    // intermediates. The final-response handler
-                                    // already does this and sends the image via
-                                    // send_photo; if the LLM emits the marker
-                                    // mid-stream it leaks raw into the chat
-                                    // (2026-05-05 18:45 incident: a generated-
-                                    // image turn shipped two intermediates,
-                                    // one clean "There it is..." and one
-                                    // prefixed with <<IMG:/Users/.../...png>>
-                                    // + the same body — the marker prefix
-                                    // broke exact-equality dedup, both
-                                    // landed, and the user saw the duplicate
-                                    // along with the raw marker token).
                                     let (text, _img_paths) =
                                         crate::utils::extract_img_markers(&text);
-                                    // Strip <<react:emoji>> directives too: a
-                                    // directive streamed mid-turn must neither
-                                    // leak raw into the chat nor differ from
-                                    // the final text (which extracts it BEFORE
-                                    // its dedup pass, so an unstripped copy
-                                    // here breaks exact-match and both copies
-                                    // land). Fire the reaction NOW so a
-                                    // mid-turn directive acknowledges the user
-                                    // immediately instead of only at the end
-                                    // (#261).
                                     let (text, react_emoji) =
                                         crate::utils::extract_react_marker(&text);
                                     if let Some(ref emoji) = react_emoji {
                                         fire_reaction(&bot, msg.chat.id, msg.id, emoji).await;
                                     }
 
-                                    // Pre-send dedup: if this exact text was
-                                    // already delivered as an intermediate in
-                                    // this turn, skip. Downstream dedup only
-                                    // strips the final-placeholder edit — it
-                                    // cannot un-send intermediates already in
-                                    // the chat. Twin intermediates from a
-                                    // retry loop (e.g. truncation-retry
-                                    // firing on a URL-terminated response
-                                    // and producing the same text in
-                                    // iteration N+1) would otherwise land
-                                    // verbatim twice (2026-04-18 23:12/23:13).
-                                    {
-                                        let s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                        if s.sent_intermediates.iter().any(|prev| prev == &text) {
-                                            tracing::info!(
-                                                "Telegram: suppressing duplicate intermediate (len={})",
-                                                text.len()
-                                            );
-                                            continue;
-                                        }
-                                    }
-
-                                    // Rich-first: a structured intermediate
-                                    // (table / heading / list / math) is sent as
-                                    // a native rich message and tracked by id; no
-                                    // structure or a rich rejection falls through
-                                    // to the HTML chunking path below.
-                                    if let Some(id) =
-                                        try_send_intermediate_rich(&bot, chat, thread_id, &text)
-                                            .await
-                                    {
-                                        let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                        s.sent_intermediates.push(text.clone());
-                                        s.intermediate_msg_ids.push(id);
-                                        continue;
-                                    }
-
-                                    let html = markdown_to_telegram_html(&text);
-                                    if !html.is_empty() {
-                                        // Chunk to 4096 and only record as delivered if every
-                                        // chunk succeeded — if we record on failure, dedup later
-                                        // strips text the user never saw.
-                                        let chunks: Vec<String> = split_message(&html, 4096)
-                                            .into_iter()
-                                            .map(|s| s.to_string())
-                                            .collect();
-                                        let mut sent_ids: Vec<MessageId> = Vec::new();
-                                        let mut all_ok = true;
-                                        for chunk in &chunks {
-                                            match send_html_or_plain(&bot, chat, thread_id, chunk).await {
-                                                Ok(id) => sent_ids.push(id),
-                                                Err(e) => {
-                                                    tracing::warn!(
-                                                        "Telegram edit-loop intermediate send failed ({e}) — NOT marking as delivered; final response will carry it",
-                                                    );
-                                                    all_ok = false;
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                        if all_ok {
-                                            let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                            s.sent_intermediates.push(text.clone());
-                                            s.intermediate_msg_ids.extend(sent_ids);
-                                        }
-                                    }
+                                    // Folded intermediates are hidden inside the
+                                    // collapsed log, so they are NOT recorded in
+                                    // sent_intermediates: the final-response
+                                    // dedup must not suppress the visible answer
+                                    // just because it also appears in the
+                                    // collapsed trace.
+                                    append_intermediate_to_flow(&bot, chat, thread_id, &st, &text)
+                                        .await;
                                 }
                             }
                         }
@@ -3049,12 +3023,11 @@ pub(crate) async fn handle_message(
                         // siblings, so re-render the whole group (never a single
                         // tool line, which would overwrite the block). Refresh each
                         // distinct group once.
-                        let mut refreshed: Vec<MessageId> = Vec::new();
-                        for (_, _, _, mid) in &snap.tool_edits {
-                            if !refreshed.contains(mid) {
-                                refreshed.push(*mid);
-                                refresh_tool_group(&bot, chat, &st, *mid).await;
-                            }
+                        // A tool status flip (⚙️ → ✅/❌) re-renders the whole
+                        // processing-log flow (tools + folded intermediates) in
+                        // its single message.
+                        if !snap.tool_edits.is_empty() {
+                            refresh_flow(&bot, chat, &st).await;
                         }
 
                         // ── Rolling context-aware status during processing ──
@@ -3497,74 +3470,19 @@ pub(crate) async fn handle_message(
                 tool_buffer.push(idx);
             }
             DisplayItem::Intermediate(text) => {
-                // Flush tool buffer into the open group, then close it: the
-                // intermediate breaks the run of consecutive tool calls.
+                // Fold the intermediate into the open processing-log flow
+                // instead of sending it as its own message (#300). Sanitize as
+                // before folding; fire any <<react:>> now (#261).
                 append_tool_group(&bot, msg.chat.id, thread_id, &streaming, &tool_buffer).await;
-                close_tool_group(&streaming);
                 tool_buffer.clear();
                 let text = crate::utils::sanitize::strip_llm_artifacts(&text);
                 let text = redact_secrets(&text);
-                // Strip <<IMG:path>> markers — see edit-loop site above.
                 let (text, _img_paths) = crate::utils::extract_img_markers(&text);
-                // Strip <<react:emoji>> too; see edit-loop site above. Fire
-                // the reaction immediately (#261), not just from the final
-                // path.
                 let (text, react_emoji) = crate::utils::extract_react_marker(&text);
                 if let Some(ref emoji) = react_emoji {
                     fire_reaction(&bot, msg.chat.id, msg.id, emoji).await;
                 }
-                // Pre-send dedup — see matching block in edit-loop above.
-                {
-                    let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                    if s.sent_intermediates.iter().any(|prev| prev == &text) {
-                        tracing::info!(
-                            "Telegram: suppressing duplicate intermediate (len={})",
-                            text.len()
-                        );
-                        continue;
-                    }
-                }
-                // Rich-first: structured intermediates render natively; no
-                // structure or a rich rejection falls through to HTML below.
-                if let Some(id) =
-                    try_send_intermediate_rich(&bot, msg.chat.id, thread_id, &text).await
-                {
-                    let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                    s.sent_intermediates.push(text.clone());
-                    s.intermediate_msg_ids.push(id);
-                    continue;
-                }
-
-                let html = markdown_to_telegram_html(&text);
-                if !html.is_empty() {
-                    // Chunk to Telegram's 4096-char limit and send each chunk.
-                    // Only record as "sent" if every chunk succeeded — otherwise
-                    // the dedup pass on the final response would strip a message
-                    // the user never actually saw, leaving them with no reply.
-                    let chunks: Vec<String> = split_message(&html, 4096)
-                        .into_iter()
-                        .map(|s| s.to_string())
-                        .collect();
-                    let mut sent_ids: Vec<MessageId> = Vec::new();
-                    let mut all_ok = true;
-                    for chunk in &chunks {
-                        match send_html_or_plain(&bot, msg.chat.id, thread_id, chunk).await {
-                            Ok(id) => sent_ids.push(id),
-                            Err(e) => {
-                                tracing::warn!(
-                                    "Telegram intermediate send failed ({e}) — NOT marking as delivered; final response will carry it",
-                                );
-                                all_ok = false;
-                                break;
-                            }
-                        }
-                    }
-                    if all_ok {
-                        let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                        s.sent_intermediates.push(text.clone());
-                        s.intermediate_msg_ids.extend(sent_ids);
-                    }
-                }
+                append_intermediate_to_flow(&bot, msg.chat.id, thread_id, &streaming, &text).await;
             }
         }
     }
@@ -4081,6 +3999,7 @@ pub(crate) async fn resume_session(
         tool_msgs: Vec::new(),
         display_queue: Vec::new(),
         open_group_msg_id: None,
+        flow_entries: Vec::new(),
         response: String::new(),
         dirty: false,
         recreate: false,
@@ -4150,69 +4069,24 @@ pub(crate) async fn resume_session(
                                     tool_buffer.push(idx);
                                 }
                                 DisplayItem::Intermediate(text) => {
-                                    // Flush tool buffer into the open group, then close
-                                    // it: the intermediate breaks the run.
+                                    // Fold the intermediate into the open
+                                    // processing-log flow (#300). A resumed
+                                    // session has no inbound user message, so a
+                                    // <<react:>> directive is stripped but no
+                                    // reaction fires (#261).
                                     append_tool_group(&bot, chat_id, thread_id, &st, &tool_buffer)
                                         .await;
-                                    close_tool_group(&st);
                                     tool_buffer.clear();
                                     let text = crate::utils::sanitize::strip_llm_artifacts(&text);
                                     let text = redact_secrets(&text);
-                                    // Strip <<IMG:path>> markers — see handle_message.
                                     let (text, _img_paths) =
                                         crate::utils::extract_img_markers(&text);
-                                    // Strip <<react:emoji>> too; see handle_message.
-                                    // A resumed session has no inbound user
-                                    // message to react to, so the directive is
-                                    // stripped but no reaction fires here (#261).
                                     let (text, _react_emoji) =
                                         crate::utils::extract_react_marker(&text);
-                                    // Pre-send dedup — see handle_message.
-                                    {
-                                        let s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                        if s.sent_intermediates.iter().any(|prev| prev == &text) {
-                                            tracing::info!(
-                                                "Telegram resume: suppressing duplicate intermediate (len={})",
-                                                text.len()
-                                            );
-                                            continue;
-                                        }
-                                    }
-                                    if let Some(id) =
-                                        try_send_intermediate_rich(&bot, chat_id, thread_id, &text)
-                                            .await
-                                    {
-                                        let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                        s.sent_intermediates.push(text.clone());
-                                        s.intermediate_msg_ids.push(id);
-                                        continue;
-                                    }
-                                    let html = markdown_to_telegram_html(&text);
-                                    if !html.is_empty() {
-                                        let chunks: Vec<String> = split_message(&html, 4096)
-                                            .into_iter()
-                                            .map(|s| s.to_string())
-                                            .collect();
-                                        let mut sent_ids: Vec<MessageId> = Vec::new();
-                                        let mut all_ok = true;
-                                        for chunk in &chunks {
-                                            match send_html_or_plain(&bot, chat_id, thread_id, chunk).await {
-                                                Ok(id) => sent_ids.push(id),
-                                                Err(e) => {
-                                                    tracing::warn!(
-                                                        "Telegram (voice) edit-loop intermediate send failed ({e}) — NOT marking as delivered",
-                                                    );
-                                                    all_ok = false;
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                        if all_ok {
-                                            let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                            s.sent_intermediates.push(text.clone());
-                                            s.intermediate_msg_ids.extend(sent_ids);
-                                        }
-                                    }
+                                    append_intermediate_to_flow(
+                                        &bot, chat_id, thread_id, &st, &text,
+                                    )
+                                    .await;
                                 }
                             }
                         }
@@ -4456,66 +4330,16 @@ pub(crate) async fn resume_session(
                 tool_buffer.push(idx);
             }
             DisplayItem::Intermediate(text) => {
-                // Flush tool buffer into the open group, then close it: the
-                // intermediate breaks the run of consecutive tool calls.
+                // Fold the intermediate into the open processing-log flow
+                // (#300). Resumed sessions have no inbound user message, so a
+                // <<react:>> directive is stripped but no reaction fires (#261).
                 append_tool_group(&bot, chat_id, thread_id, &streaming, &tool_buffer).await;
-                close_tool_group(&streaming);
                 tool_buffer.clear();
                 let text = crate::utils::sanitize::strip_llm_artifacts(&text);
                 let text = redact_secrets(&text);
-                // Strip <<IMG:path>> markers — see handle_message.
                 let (text, _img_paths) = crate::utils::extract_img_markers(&text);
-                // Strip <<react:emoji>> too; see handle_message. Resumed
-                // sessions have no inbound user message to react to, so the
-                // directive is stripped but no reaction fires here (#261).
                 let (text, _react_emoji) = crate::utils::extract_react_marker(&text);
-                // Pre-send dedup — see handle_message.
-                {
-                    let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                    if s.sent_intermediates.iter().any(|prev| prev == &text) {
-                        tracing::info!(
-                            "Telegram resume: suppressing duplicate intermediate (len={})",
-                            text.len()
-                        );
-                        continue;
-                    }
-                }
-                if let Some(id) = try_send_intermediate_rich(&bot, chat_id, thread_id, &text).await
-                {
-                    let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                    s.sent_intermediates.push(text.clone());
-                    s.intermediate_msg_ids.push(id);
-                    continue;
-                }
-                let html = markdown_to_telegram_html(&text);
-                if !html.is_empty() {
-                    // Same chunk-and-confirm pattern as the group handler —
-                    // don't mark as delivered unless every chunk succeeded,
-                    // otherwise dedup will strip a message the user never saw.
-                    let chunks: Vec<String> = split_message(&html, 4096)
-                        .into_iter()
-                        .map(|s| s.to_string())
-                        .collect();
-                    let mut sent_ids: Vec<MessageId> = Vec::new();
-                    let mut all_ok = true;
-                    for chunk in &chunks {
-                        match send_html_or_plain(&bot, chat_id, thread_id, chunk).await {
-                            Ok(id) => sent_ids.push(id),
-                            Err(e) => {
-                                tracing::warn!(
-                                    "Telegram (DM) intermediate send failed ({e}) — NOT marking as delivered",
-                                );
-                                all_ok = false;
-                                break;
-                            }
-                        }
-                    }
-                    if all_ok {
-                        let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                        s.sent_intermediates.push(text.clone());
-                        s.intermediate_msg_ids.extend(sent_ids);
-                    }
-                }
+                append_intermediate_to_flow(&bot, chat_id, thread_id, &streaming, &text).await;
             }
         }
     }

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -114,29 +114,37 @@ pub(crate) struct StreamingState {
     user_message_preview: Option<String>,
 }
 
-/// Render a group of tool calls as a collapsible `<details>` block.
-/// Groups consecutive tool calls into a single expandable message to reduce
-/// visual noise while preserving full transparency (user can expand to see
-/// each individual call with its status and context).
-fn render_tool_group(tools: &[(String, String)]) -> String {
-    let count = tools.len();
-    let summary = if count == 1 {
-        tools[0].0.clone()
-    } else {
-        format!("{} tool calls", count)
-    };
-    
-    let mut result = format!("<details><summary>{}</summary>\n\n", summary);
-    for (status_label, context) in tools {
+/// Render a group of tool calls as final Telegram HTML.
+/// Groups consecutive tool calls into a single `<blockquote expandable>`
+/// block: native Telegram HTML (Bot API 7.3+) that renders collapsed with a
+/// tap-to-expand arrow in groups, DMs, and all official clients, with no
+/// dependency on the rich message API. A single tool call renders as a plain
+/// one-liner. Output is ready to send via `send_html_or_plain` — do NOT pass
+/// it through `markdown_to_telegram_html` (it would double-process the HTML).
+pub(crate) fn render_tool_group(tools: &[(String, String)]) -> String {
+    fn line(label: &str, context: &str) -> String {
         if context.is_empty() {
-            result.push_str(status_label);
+            format!("<b>{}</b>", escape_html(label))
         } else {
-            result.push_str(&format!("{} {}", status_label, context));
+            format!("<b>{}</b> {}", escape_html(label), escape_html(context))
         }
-        result.push('\n');
     }
-    result.push_str("\n</details>");
-    result
+    if tools.is_empty() {
+        return String::new();
+    }
+    if tools.len() == 1 {
+        return line(&tools[0].0, &tools[0].1);
+    }
+    let body = tools
+        .iter()
+        .map(|(label, context)| line(label, context))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "<blockquote expandable><b>{} tool calls</b>\n{}</blockquote>",
+        tools.len(),
+        body
+    )
 }
 
 impl StreamingState {
@@ -2723,7 +2731,7 @@ pub(crate) async fn handle_message(
                         // ── Ordered display: tools and intermediates in chronological order ──
                         // Buffer consecutive tool calls to group them into collapsible blocks
                         let mut tool_buffer: Vec<usize> = Vec::new();
-                        
+
                         for item in &snap.display_items {
                             match item {
                                 DisplayItem::NewTool(idx) => {
@@ -2734,38 +2742,27 @@ pub(crate) async fn handle_message(
                                     // Flush buffered tools as a grouped block
                                     if !tool_buffer.is_empty() {
                                         // Render grouped tool calls
-                                        let tools_text = {
+                                        let tool_details: Vec<(String, String)> = {
                                             let s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                            let mut lines = Vec::new();
-                                            for &idx in &tool_buffer {
-                                                if let Some(t) = s.tool_msgs.get(idx) {
-                                                    let label = format!("**{}**{}", t.name, t.context);
-                                                    let status = match t.completed {
-                                                        None => "⚙️",
-                                                        Some(true) => "✅",
-                                                        Some(false) => "❌",
-                                                    };
-                                                    lines.push(format!("{} {}", status, label));
-                                                }
-                                            }
-                                            let count = tool_buffer.len();
-                                            let summary = if count == 1 {
-                                                lines[0].clone()
-                                            } else {
-                                                format!("**{} tool calls**", count)
-                                            };
-                                            if count == 1 {
-                                                summary
-                                            } else {
-                                                format!(
-                                                    "<details><summary>{}</summary>\n{}</details>",
-                                                    summary,
-                                                    lines.join("\n")
-                                                )
-                                            }
+                                            tool_buffer
+                                                .iter()
+                                                .filter_map(|&idx| {
+                                                    s.tool_msgs.get(idx).map(|t| {
+                                                        let status = match t.completed {
+                                                            None => "⚙️",
+                                                            Some(true) => "✅",
+                                                            Some(false) => "❌",
+                                                        };
+                                                        (
+                                                            format!("{} {}", status, t.name),
+                                                            t.context.clone(),
+                                                        )
+                                                    })
+                                                })
+                                                .collect()
                                         };
-                                        
-                                        let html = markdown_to_telegram_html(&tools_text);
+
+                                        let html = render_tool_group(&tool_details);
                                         if let Ok(mid) = send_html_or_plain(&bot, chat, thread_id, &html).await {
                                             // Mark all buffered tools as having messages
                                             let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
@@ -2777,7 +2774,7 @@ pub(crate) async fn handle_message(
                                         }
                                         tool_buffer.clear();
                                     }
-                                    
+
                                     // Now process the intermediate text
                                     // Apply the same sanitization chain as the
                                     // final response path: strip LLM artifacts
@@ -2895,41 +2892,27 @@ pub(crate) async fn handle_message(
                                 }
                             }
                         }
-                        
+
                         // Flush any remaining buffered tools after the loop
                         if !tool_buffer.is_empty() {
-                            let tools_text = {
+                            let tool_details: Vec<(String, String)> = {
                                 let s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                let mut lines = Vec::new();
-                                for &idx in &tool_buffer {
-                                    if let Some(t) = s.tool_msgs.get(idx) {
-                                        let label = format!("**{}**{}", t.name, t.context);
-                                        let status = match t.completed {
-                                            None => "⚙️",
-                                            Some(true) => "✅",
-                                            Some(false) => "❌",
-                                        };
-                                        lines.push(format!("{} {}", status, label));
-                                    }
-                                }
-                                let count = tool_buffer.len();
-                                let summary = if count == 1 {
-                                    lines[0].clone()
-                                } else {
-                                    format!("**{} tool calls**", count)
-                                };
-                                if count == 1 {
-                                    summary
-                                } else {
-                                    format!(
-                                        "<details><summary>{}</summary>\n{}</details>",
-                                        summary,
-                                        lines.join("\n")
-                                    )
-                                }
+                                tool_buffer
+                                    .iter()
+                                    .filter_map(|&idx| {
+                                        s.tool_msgs.get(idx).map(|t| {
+                                            let status = match t.completed {
+                                                None => "⚙️",
+                                                Some(true) => "✅",
+                                                Some(false) => "❌",
+                                            };
+                                            (format!("{} {}", status, t.name), t.context.clone())
+                                        })
+                                    })
+                                    .collect()
                             };
-                            
-                            let html = markdown_to_telegram_html(&tools_text);
+
+                            let html = render_tool_group(&tool_details);
                             if let Ok(mid) = send_html_or_plain(&bot, chat, thread_id, &html).await {
                                 let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
                                 for &idx in &tool_buffer {
@@ -3387,7 +3370,7 @@ pub(crate) async fn handle_message(
     // Send any remaining display items that weren't flushed by the edit loop
     // Buffer consecutive tool calls to group them into collapsible blocks
     let mut tool_buffer: Vec<usize> = Vec::new();
-    
+
     for item in remaining_display {
         match item {
             DisplayItem::NewTool(idx) => {
@@ -3411,10 +3394,12 @@ pub(crate) async fn handle_message(
                             })
                         })
                         .collect();
-                    
+
                     if !tool_details.is_empty() {
                         let grouped = render_tool_group(&tool_details);
-                        if let Ok(mid) = send_tool_group_rich(&bot, msg.chat.id, thread_id, &grouped).await {
+                        if let Ok(mid) =
+                            send_html_or_plain(&bot, msg.chat.id, thread_id, &grouped).await
+                        {
                             let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
                             for &idx in &tool_buffer {
                                 if let Some(tool) = s.tool_msgs.get_mut(idx) {
@@ -3491,7 +3476,7 @@ pub(crate) async fn handle_message(
             }
         }
     }
-    
+
     // Flush any remaining tools in buffer as grouped block
     if !tool_buffer.is_empty() {
         let tool_details: Vec<(String, String)> = tool_buffer
@@ -3508,10 +3493,10 @@ pub(crate) async fn handle_message(
                 })
             })
             .collect();
-        
+
         if !tool_details.is_empty() {
             let grouped = render_tool_group(&tool_details);
-            if let Ok(mid) = send_tool_group_rich(&bot, msg.chat.id, thread_id, &grouped).await {
+            if let Ok(mid) = send_html_or_plain(&bot, msg.chat.id, thread_id, &grouped).await {
                 let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
                 for &idx in &tool_buffer {
                     if let Some(tool) = s.tool_msgs.get_mut(idx) {
@@ -4091,7 +4076,7 @@ pub(crate) async fn resume_session(
                         // Process display items (tools + intermediates)
                         // Buffer consecutive tool calls to group them into collapsible blocks
                         let mut tool_buffer: Vec<usize> = Vec::new();
-                        
+
                         for item in snap.display_items {
                             match item {
                                 DisplayItem::NewTool(idx) => {
@@ -4114,10 +4099,10 @@ pub(crate) async fn resume_session(
                                                 })
                                             })
                                             .collect();
-                                        
+
                                         if !tool_details.is_empty() {
                                             let grouped = render_tool_group(&tool_details);
-                                            if let Ok(mid) = send_tool_group_rich(&bot, chat_id, thread_id, &grouped).await {
+                                            if let Ok(mid) = send_html_or_plain(&bot, chat_id, thread_id, &grouped).await {
                                                 let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
                                                 for &idx in &tool_buffer {
                                                     if let Some(tool) = s.tool_msgs.get_mut(idx) {
@@ -4188,7 +4173,7 @@ pub(crate) async fn resume_session(
                                 }
                             }
                         }
-                        
+
                         // Flush any remaining tools in buffer as grouped block
                         if !tool_buffer.is_empty() {
                             let tool_details: Vec<(String, String)> = tool_buffer
@@ -4205,10 +4190,10 @@ pub(crate) async fn resume_session(
                                     })
                                 })
                                 .collect();
-                            
+
                             if !tool_details.is_empty() {
                                 let grouped = render_tool_group(&tool_details);
-                                if let Ok(mid) = send_tool_group_rich(&bot, chat_id, thread_id, &grouped).await {
+                                if let Ok(mid) = send_html_or_plain(&bot, chat_id, thread_id, &grouped).await {
                                     let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
                                     for &idx in &tool_buffer {
                                         if let Some(tool) = s.tool_msgs.get_mut(idx) {
@@ -4447,7 +4432,7 @@ pub(crate) async fn resume_session(
     // Send remaining display items
     // Buffer consecutive tool calls to group them into collapsible blocks
     let mut tool_buffer: Vec<usize> = Vec::new();
-    
+
     for item in remaining_display {
         match item {
             DisplayItem::NewTool(idx) => {
@@ -4470,10 +4455,12 @@ pub(crate) async fn resume_session(
                             })
                         })
                         .collect();
-                    
+
                     if !tool_details.is_empty() {
                         let grouped = render_tool_group(&tool_details);
-                        if let Ok(mid) = send_tool_group_rich(&bot, chat_id, thread_id, &grouped).await {
+                        if let Ok(mid) =
+                            send_html_or_plain(&bot, chat_id, thread_id, &grouped).await
+                        {
                             let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
                             for &idx in &tool_buffer {
                                 if let Some(tool) = s.tool_msgs.get_mut(idx) {
@@ -4542,7 +4529,7 @@ pub(crate) async fn resume_session(
             }
         }
     }
-    
+
     // Flush any remaining tools in buffer as grouped block
     if !tool_buffer.is_empty() {
         let tool_details: Vec<(String, String)> = tool_buffer
@@ -4559,10 +4546,10 @@ pub(crate) async fn resume_session(
                 })
             })
             .collect();
-        
+
         if !tool_details.is_empty() {
             let grouped = render_tool_group(&tool_details);
-            if let Ok(mid) = send_tool_group_rich(&bot, chat_id, thread_id, &grouped).await {
+            if let Ok(mid) = send_html_or_plain(&bot, chat_id, thread_id, &grouped).await {
                 let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
                 for &idx in &tool_buffer {
                     if let Some(tool) = s.tool_msgs.get_mut(idx) {
@@ -5553,28 +5540,6 @@ async fn try_send_intermediate_rich(
         Err(e) => {
             tracing::warn!("Telegram: intermediate rich send failed, using HTML: {e}");
             None
-        }
-    }
-}
-
-/// Send a tool group as a rich message with collapsible <details> blocks.
-/// Tries the rich API first (which supports <details>), falls back to regular
-/// HTML if the rich API fails or isn't available.
-async fn send_tool_group_rich(
-    bot: &Bot,
-    chat_id: ChatId,
-    thread_id: Option<teloxide::types::ThreadId>,
-    markdown: &str,
-) -> std::result::Result<MessageId, teloxide::RequestError> {
-    // Try rich API first (supports <details> tags)
-    match super::rich::api::send_rich_markdown_id(bot.token(), chat_id.0, thread_id, markdown).await
-    {
-        Ok(id) => Ok(MessageId(id)),
-        Err(e) => {
-            tracing::debug!("Rich API failed for tool group, falling back to HTML: {e}");
-            // Fall back to regular HTML (without <details> tags)
-            let html = markdown_to_telegram_html(markdown);
-            send_html_or_plain(bot, chat_id, thread_id, &html).await
         }
     }
 }

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2208,10 +2208,12 @@ pub(crate) async fn handle_message(
                     })
                     .collect();
                 let keyboard = InlineKeyboardMarkup::new(rows);
-                message_in_thread(&bot, msg.chat.id, thread_id, command_md_to_html(&resp.text))
-                    .parse_mode(ParseMode::Html)
-                    .reply_markup(keyboard)
-                    .await?;
+                send_retrying_rate_limit("command reply", || {
+                    message_in_thread(&bot, msg.chat.id, thread_id, command_md_to_html(&resp.text))
+                        .parse_mode(ParseMode::Html)
+                        .reply_markup(keyboard.clone())
+                })
+                .await?;
                 return Ok(());
             }
             ChannelCommand::NewSession => {
@@ -2278,7 +2280,10 @@ pub(crate) async fn handle_message(
                         let ctx_max = agent.context_limit_for_session(new_session.id);
                         let footer = crate::utils::format_ctx_footer(baseline, ctx_max, None);
                         let msg_text = format!("✅ New session started.\n\n{footer}");
-                        message_in_thread(&bot, msg.chat.id, thread_id, &msg_text).await?;
+                        send_retrying_rate_limit("command reply", || {
+                            message_in_thread(&bot, msg.chat.id, thread_id, &msg_text)
+                        })
+                        .await?;
                         tracing::info!(
                             "Telegram /new: sent ctx footer='{}' (baseline={}, ctx_max={})",
                             footer,
@@ -2288,12 +2293,14 @@ pub(crate) async fn handle_message(
                     }
                     Err(e) => {
                         tracing::error!("Telegram: failed to create session: {}", e);
-                        message_in_thread(
-                            &bot,
-                            msg.chat.id,
-                            thread_id,
-                            "Failed to create session.",
-                        )
+                        send_retrying_rate_limit("command reply", || {
+                            message_in_thread(
+                                &bot,
+                                msg.chat.id,
+                                thread_id,
+                                "Failed to create session.",
+                            )
+                        })
                         .await?;
                     }
                 }
@@ -2316,10 +2323,12 @@ pub(crate) async fn handle_message(
                     })
                     .collect();
                 let keyboard = InlineKeyboardMarkup::new(rows);
-                message_in_thread(&bot, msg.chat.id, thread_id, command_md_to_html(&resp.text))
-                    .parse_mode(ParseMode::Html)
-                    .reply_markup(keyboard)
-                    .await?;
+                send_retrying_rate_limit("command reply", || {
+                    message_in_thread(&bot, msg.chat.id, thread_id, command_md_to_html(&resp.text))
+                        .parse_mode(ParseMode::Html)
+                        .reply_markup(keyboard.clone())
+                })
+                .await?;
                 return Ok(());
             }
             ChannelCommand::Stop => {
@@ -2329,7 +2338,10 @@ pub(crate) async fn handle_message(
                 } else {
                     "No operation in progress."
                 };
-                message_in_thread(&bot, msg.chat.id, thread_id, reply).await?;
+                send_retrying_rate_limit("command reply", || {
+                    message_in_thread(&bot, msg.chat.id, thread_id, reply)
+                })
+                .await?;
                 return Ok(());
             }
             ChannelCommand::ChangeDir(resp) => {
@@ -2345,23 +2357,30 @@ pub(crate) async fn handle_message(
 
                 let rows = build_cd_keyboard(&resp);
                 let keyboard = InlineKeyboardMarkup::new(rows);
-                message_in_thread(&bot, msg.chat.id, thread_id, command_md_to_html(&resp.text))
-                    .parse_mode(ParseMode::Html)
-                    .reply_markup(keyboard)
-                    .await?;
+                send_retrying_rate_limit("command reply", || {
+                    message_in_thread(&bot, msg.chat.id, thread_id, command_md_to_html(&resp.text))
+                        .parse_mode(ParseMode::Html)
+                        .reply_markup(keyboard.clone())
+                })
+                .await?;
                 return Ok(());
             }
             ChannelCommand::Profiles(resp) => {
                 let rows = build_profiles_keyboard(&resp);
                 let keyboard = InlineKeyboardMarkup::new(rows);
-                message_in_thread(&bot, msg.chat.id, thread_id, command_md_to_html(&resp.text))
-                    .parse_mode(ParseMode::Html)
-                    .reply_markup(keyboard)
-                    .await?;
+                send_retrying_rate_limit("command reply", || {
+                    message_in_thread(&bot, msg.chat.id, thread_id, command_md_to_html(&resp.text))
+                        .parse_mode(ParseMode::Html)
+                        .reply_markup(keyboard.clone())
+                })
+                .await?;
                 return Ok(());
             }
             ChannelCommand::Compact => {
-                message_in_thread(&bot, msg.chat.id, thread_id, "⏳ Compacting context...").await?;
+                send_retrying_rate_limit("command reply", || {
+                    message_in_thread(&bot, msg.chat.id, thread_id, "⏳ Compacting context...")
+                })
+                .await?;
                 text = "[SYSTEM: Compact context now. Summarize this conversation for continuity.]"
                     .to_string();
                 // fall through to agent
@@ -2391,14 +2410,16 @@ pub(crate) async fn handle_message(
                     path.display(),
                     resp.text
                 );
-                message_in_thread(
-                    &bot,
-                    msg.chat.id,
-                    thread_id,
-                    command_md_to_html(&success_text),
-                )
-                .parse_mode(ParseMode::Html)
-                .reply_markup(keyboard)
+                send_retrying_rate_limit("command reply", || {
+                    message_in_thread(
+                        &bot,
+                        msg.chat.id,
+                        thread_id,
+                        command_md_to_html(&success_text),
+                    )
+                    .parse_mode(ParseMode::Html)
+                    .reply_markup(keyboard.clone())
+                })
                 .await?;
                 return Ok(());
             }
@@ -2407,7 +2428,10 @@ pub(crate) async fn handle_message(
                     "❌ Failed to create profile: {}\n\nTry again with /profiles",
                     e
                 );
-                message_in_thread(&bot, msg.chat.id, thread_id, &err_text).await?;
+                send_retrying_rate_limit("command reply", || {
+                    message_in_thread(&bot, msg.chat.id, thread_id, &err_text)
+                })
+                .await?;
                 return Ok(());
             }
         }
@@ -5458,6 +5482,47 @@ async fn try_send_intermediate_rich(
         Err(e) => {
             tracing::warn!("Telegram: intermediate rich send failed, using HTML: {e}");
             None
+        }
+    }
+}
+
+/// Run a Telegram send, waiting out `RetryAfter` (429) up to 3 attempts.
+///
+/// Command replies are programmatic: a per-chat rate limit (typically a
+/// streaming turn editing its placeholder into the same chat) must DELAY
+/// them, never drop them. The command branches used a bare `.await?`, so
+/// the 429 propagated out of the handler and the reply vanished with a
+/// single error log line — /models looked "stuck" while a turn streamed
+/// and worked right after it completed (#297). Non-429 errors and
+/// exhausted retries still propagate to the caller.
+pub(crate) async fn send_retrying_rate_limit<T, F, Fut>(
+    what: &str,
+    mut send: F,
+) -> std::result::Result<T, teloxide::RequestError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::IntoFuture<Output = std::result::Result<T, teloxide::RequestError>>,
+{
+    const MAX_RETRIES: u32 = 3;
+    let mut attempt = 0u32;
+    loop {
+        match send().await {
+            Err(teloxide::RequestError::RetryAfter(secs)) if attempt < MAX_RETRIES => {
+                attempt += 1;
+                tracing::warn!(
+                    "Telegram: {what} rate-limited, waiting {}s before retry ({attempt}/{MAX_RETRIES})",
+                    secs.seconds()
+                );
+                tokio::time::sleep(secs.duration()).await;
+            }
+            Err(teloxide::RequestError::RetryAfter(secs)) => {
+                tracing::error!(
+                    "Telegram: {what} still rate-limited after {MAX_RETRIES} retries ({}s) — giving up",
+                    secs.seconds()
+                );
+                return Err(teloxide::RequestError::RetryAfter(secs));
+            }
+            other => return other,
         }
     }
 }

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -63,6 +63,12 @@ pub(crate) struct StreamingState {
     tool_msgs: Vec<ToolMsg>,
     /// Ordered queue of new display items (tools + intermediates in chronological order)
     display_queue: Vec<DisplayItem>,
+    /// Message ID of the currently open tool-call group. Consecutive tool calls
+    /// are appended to this one message (edited in place) so a run of tools
+    /// collapses into a single growing `<blockquote expandable>` block instead
+    /// of one message per flush window. Set when a group is opened, cleared when
+    /// an intermediate text or the final response breaks the run.
+    open_group_msg_id: Option<MessageId>,
     /// Response text from streaming chunks — own message at bottom
     response: String,
     dirty: bool,
@@ -145,6 +151,128 @@ pub(crate) fn render_tool_group(tools: &[(String, String)]) -> String {
         tools.len(),
         body
     )
+}
+
+/// Status glyph for a tool call: running, succeeded, or failed.
+fn tool_status_icon(completed: Option<bool>) -> &'static str {
+    match completed {
+        None => "⚙️",
+        Some(true) => "✅",
+        Some(false) => "❌",
+    }
+}
+
+/// Build `(label, context)` render pairs for the given tool indices.
+fn tool_group_details(
+    streaming: &Arc<std::sync::Mutex<StreamingState>>,
+    indices: &[usize],
+) -> Vec<(String, String)> {
+    let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+    indices
+        .iter()
+        .filter_map(|&idx| {
+            s.tool_msgs.get(idx).map(|t| {
+                (
+                    format!("{} {}", tool_status_icon(t.completed), t.name),
+                    t.context.clone(),
+                )
+            })
+        })
+        .collect()
+}
+
+/// Re-render every tool sharing `group_mid` and edit that message in place.
+/// Used both to grow an open group (append) and to reflect a tool's status
+/// change (⚙️ → ✅/❌) after it completes. A no-op edit ("message is not
+/// modified") and transient errors are ignored: the message already shows the
+/// correct content and the next tick retries.
+async fn refresh_tool_group(
+    bot: &Bot,
+    chat: ChatId,
+    streaming: &Arc<std::sync::Mutex<StreamingState>>,
+    group_mid: MessageId,
+) {
+    let details: Vec<(String, String)> = {
+        let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+        s.tool_msgs
+            .iter()
+            .filter(|t| t.msg_id == Some(group_mid))
+            .map(|t| {
+                (
+                    format!("{} {}", tool_status_icon(t.completed), t.name),
+                    t.context.clone(),
+                )
+            })
+            .collect()
+    };
+    if details.is_empty() {
+        return;
+    }
+    let html = render_tool_group(&details);
+    let _ = bot
+        .edit_message_text(chat, group_mid, html)
+        .parse_mode(ParseMode::Html)
+        .await;
+}
+
+/// Append buffered tool calls to the current open group, editing that message
+/// in place so consecutive tool calls collapse into one growing block. When no
+/// group is open, a new message is sent and becomes the open group. The open
+/// group is closed via `close_tool_group` when an intermediate text or the
+/// final response breaks the run of consecutive tool calls.
+async fn append_tool_group(
+    bot: &Bot,
+    chat: ChatId,
+    thread_id: Option<teloxide::types::ThreadId>,
+    streaming: &Arc<std::sync::Mutex<StreamingState>>,
+    buffer: &[usize],
+) {
+    if buffer.is_empty() {
+        return;
+    }
+    let open = streaming
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .open_group_msg_id;
+    match open {
+        Some(mid) => {
+            {
+                let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+                for &idx in buffer {
+                    if let Some(tool) = s.tool_msgs.get_mut(idx) {
+                        tool.msg_id = Some(mid);
+                    }
+                }
+            }
+            refresh_tool_group(bot, chat, streaming, mid).await;
+        }
+        None => {
+            let details = tool_group_details(streaming, buffer);
+            if details.is_empty() {
+                return;
+            }
+            let html = render_tool_group(&details);
+            if let Ok(mid) = send_html_or_plain(bot, chat, thread_id, &html).await {
+                let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+                for &idx in buffer {
+                    if let Some(tool) = s.tool_msgs.get_mut(idx) {
+                        tool.msg_id = Some(mid);
+                    }
+                }
+                s.open_group_msg_id = Some(mid);
+            }
+        }
+    }
+}
+
+/// Close the current open tool group so the next tool call starts a fresh
+/// message. Called when an intermediate text or the final response interrupts
+/// the run of consecutive tool calls.
+fn close_tool_group(streaming: &Arc<std::sync::Mutex<StreamingState>>) {
+    streaming
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .open_group_msg_id = None;
 }
 
 impl StreamingState {
@@ -2581,6 +2709,7 @@ pub(crate) async fn handle_message(
         thinking: String::new(),
         tool_msgs: Vec::new(),
         display_queue: Vec::new(),
+        open_group_msg_id: None,
         response: String::new(),
         dirty: false,
         recreate: false,
@@ -2739,41 +2868,13 @@ pub(crate) async fn handle_message(
                                     tool_buffer.push(*idx);
                                 }
                                 DisplayItem::Intermediate(text) => {
-                                    // Flush buffered tools as a grouped block
-                                    if !tool_buffer.is_empty() {
-                                        // Render grouped tool calls
-                                        let tool_details: Vec<(String, String)> = {
-                                            let s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                            tool_buffer
-                                                .iter()
-                                                .filter_map(|&idx| {
-                                                    s.tool_msgs.get(idx).map(|t| {
-                                                        let status = match t.completed {
-                                                            None => "⚙️",
-                                                            Some(true) => "✅",
-                                                            Some(false) => "❌",
-                                                        };
-                                                        (
-                                                            format!("{} {}", status, t.name),
-                                                            t.context.clone(),
-                                                        )
-                                                    })
-                                                })
-                                                .collect()
-                                        };
-
-                                        let html = render_tool_group(&tool_details);
-                                        if let Ok(mid) = send_html_or_plain(&bot, chat, thread_id, &html).await {
-                                            // Mark all buffered tools as having messages
-                                            let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                            for &idx in &tool_buffer {
-                                                if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                                                    tool.msg_id = Some(mid);
-                                                }
-                                            }
-                                        }
-                                        tool_buffer.clear();
-                                    }
+                                    // Flush buffered tools into the open group, then
+                                    // close it: an intermediate breaks the run so the
+                                    // next tool call starts a fresh block.
+                                    append_tool_group(&bot, chat, thread_id, &st, &tool_buffer)
+                                        .await;
+                                    close_tool_group(&st);
+                                    tool_buffer.clear();
 
                                     // Now process the intermediate text
                                     // Apply the same sanitization chain as the
@@ -2893,49 +2994,22 @@ pub(crate) async fn handle_message(
                             }
                         }
 
-                        // Flush any remaining buffered tools after the loop
-                        if !tool_buffer.is_empty() {
-                            let tool_details: Vec<(String, String)> = {
-                                let s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                tool_buffer
-                                    .iter()
-                                    .filter_map(|&idx| {
-                                        s.tool_msgs.get(idx).map(|t| {
-                                            let status = match t.completed {
-                                                None => "⚙️",
-                                                Some(true) => "✅",
-                                                Some(false) => "❌",
-                                            };
-                                            (format!("{} {}", status, t.name), t.context.clone())
-                                        })
-                                    })
-                                    .collect()
-                            };
+                        // Flush any remaining buffered tools into the open group.
+                        // No close here: the run may continue on the next tick, in
+                        // which case those tools append to this same message.
+                        append_tool_group(&bot, chat, thread_id, &st, &tool_buffer).await;
 
-                            let html = render_tool_group(&tool_details);
-                            if let Ok(mid) = send_html_or_plain(&bot, chat, thread_id, &html).await {
-                                let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                for &idx in &tool_buffer {
-                                    if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                                        tool.msg_id = Some(mid);
-                                    }
-                                }
+                        // ── Update tool-group messages for tools that changed status ──
+                        // A completed tool shares its group's message with its
+                        // siblings, so re-render the whole group (never a single
+                        // tool line, which would overwrite the block). Refresh each
+                        // distinct group once.
+                        let mut refreshed: Vec<MessageId> = Vec::new();
+                        for (_, _, _, mid) in &snap.tool_edits {
+                            if !refreshed.contains(mid) {
+                                refreshed.push(*mid);
+                                refresh_tool_group(&bot, chat, &st, *mid).await;
                             }
-                        }
-
-                        // ── Edit existing tool messages (status updates) ──
-                        for (idx, label, completed, mid) in &snap.tool_edits {
-                            let _ = idx; // used for identification only
-                            let text = match completed {
-                                None => format!("⚙️ {}", label),
-                                Some(true) => format!("✅ {}", label),
-                                Some(false) => format!("❌ {}", label),
-                            };
-                            let html = markdown_to_telegram_html(&text);
-                            let _ = bot
-                                .edit_message_text(chat, *mid, &html)
-                                .parse_mode(ParseMode::Html)
-                                .await;
                         }
 
                         // ── Rolling context-aware status during processing ──
@@ -3377,39 +3451,11 @@ pub(crate) async fn handle_message(
                 tool_buffer.push(idx);
             }
             DisplayItem::Intermediate(text) => {
-                // Flush tool buffer as grouped block before sending intermediate
-                if !tool_buffer.is_empty() {
-                    let buffer_copy = tool_buffer.clone();
-                    let tool_details: Vec<(String, String)> = buffer_copy
-                        .iter()
-                        .filter_map(|&idx| {
-                            let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                            s.tool_msgs.get(idx).map(|t| {
-                                let status = match t.completed {
-                                    None => "⚙️",
-                                    Some(true) => "✅",
-                                    Some(false) => "❌",
-                                };
-                                (format!("{} {}", status, t.name), t.context.clone())
-                            })
-                        })
-                        .collect();
-
-                    if !tool_details.is_empty() {
-                        let grouped = render_tool_group(&tool_details);
-                        if let Ok(mid) =
-                            send_html_or_plain(&bot, msg.chat.id, thread_id, &grouped).await
-                        {
-                            let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                            for &idx in &tool_buffer {
-                                if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                                    tool.msg_id = Some(mid);
-                                }
-                            }
-                        }
-                    }
-                    tool_buffer.clear();
-                }
+                // Flush tool buffer into the open group, then close it: the
+                // intermediate breaks the run of consecutive tool calls.
+                append_tool_group(&bot, msg.chat.id, thread_id, &streaming, &tool_buffer).await;
+                close_tool_group(&streaming);
+                tool_buffer.clear();
                 let text = crate::utils::sanitize::strip_llm_artifacts(&text);
                 let text = redact_secrets(&text);
                 // Strip <<IMG:path>> markers — see edit-loop site above.
@@ -3477,35 +3523,9 @@ pub(crate) async fn handle_message(
         }
     }
 
-    // Flush any remaining tools in buffer as grouped block
-    if !tool_buffer.is_empty() {
-        let tool_details: Vec<(String, String)> = tool_buffer
-            .iter()
-            .filter_map(|&idx| {
-                let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                s.tool_msgs.get(idx).map(|t| {
-                    let status = match t.completed {
-                        None => "⚙️",
-                        Some(true) => "✅",
-                        Some(false) => "❌",
-                    };
-                    (format!("{} {}", status, t.name), t.context.clone())
-                })
-            })
-            .collect();
-
-        if !tool_details.is_empty() {
-            let grouped = render_tool_group(&tool_details);
-            if let Ok(mid) = send_html_or_plain(&bot, msg.chat.id, thread_id, &grouped).await {
-                let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                for &idx in &tool_buffer {
-                    if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                        tool.msg_id = Some(mid);
-                    }
-                }
-            }
-        }
-    }
+    // Flush any remaining tools into the open group (merges the final batch
+    // into the running collapsible block instead of opening a new message).
+    append_tool_group(&bot, msg.chat.id, thread_id, &streaming, &tool_buffer).await;
 
     tracing::info!(
         "Telegram: agent call completed for session {} — delivering final response",
@@ -4014,6 +4034,7 @@ pub(crate) async fn resume_session(
         thinking: String::new(),
         tool_msgs: Vec::new(),
         display_queue: Vec::new(),
+        open_group_msg_id: None,
         response: String::new(),
         dirty: false,
         recreate: false,
@@ -4083,36 +4104,12 @@ pub(crate) async fn resume_session(
                                     tool_buffer.push(idx);
                                 }
                                 DisplayItem::Intermediate(text) => {
-                                    // Flush tool buffer as grouped block before sending intermediate
-                                    if !tool_buffer.is_empty() {
-                                        let tool_details: Vec<(String, String)> = tool_buffer
-                                            .iter()
-                                            .filter_map(|&idx| {
-                                                let s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                                s.tool_msgs.get(idx).map(|t| {
-                                                    let status = match t.completed {
-                                                        None => "⚙️",
-                                                        Some(true) => "✅",
-                                                        Some(false) => "❌",
-                                                    };
-                                                    (format!("{} {}", status, t.name), t.context.clone())
-                                                })
-                                            })
-                                            .collect();
-
-                                        if !tool_details.is_empty() {
-                                            let grouped = render_tool_group(&tool_details);
-                                            if let Ok(mid) = send_html_or_plain(&bot, chat_id, thread_id, &grouped).await {
-                                                let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                                for &idx in &tool_buffer {
-                                                    if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                                                        tool.msg_id = Some(mid);
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        tool_buffer.clear();
-                                    }
+                                    // Flush tool buffer into the open group, then close
+                                    // it: the intermediate breaks the run.
+                                    append_tool_group(&bot, chat_id, thread_id, &st, &tool_buffer)
+                                        .await;
+                                    close_tool_group(&st);
+                                    tool_buffer.clear();
                                     let text = crate::utils::sanitize::strip_llm_artifacts(&text);
                                     let text = redact_secrets(&text);
                                     // Strip <<IMG:path>> markers — see handle_message.
@@ -4174,35 +4171,9 @@ pub(crate) async fn resume_session(
                             }
                         }
 
-                        // Flush any remaining tools in buffer as grouped block
-                        if !tool_buffer.is_empty() {
-                            let tool_details: Vec<(String, String)> = tool_buffer
-                                .iter()
-                                .filter_map(|&idx| {
-                                    let s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                    s.tool_msgs.get(idx).map(|t| {
-                                        let status = match t.completed {
-                                            None => "⚙️",
-                                            Some(true) => "✅",
-                                            Some(false) => "❌",
-                                        };
-                                        (format!("{} {}", status, t.name), t.context.clone())
-                                    })
-                                })
-                                .collect();
-
-                            if !tool_details.is_empty() {
-                                let grouped = render_tool_group(&tool_details);
-                                if let Ok(mid) = send_html_or_plain(&bot, chat_id, thread_id, &grouped).await {
-                                    let mut s = st.lock().unwrap_or_else(|e| e.into_inner());
-                                    for &idx in &tool_buffer {
-                                        if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                                            tool.msg_id = Some(mid);
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        // Flush any remaining tools into the open group (kept open
+                        // so the next tick's tools append to this same message).
+                        append_tool_group(&bot, chat_id, thread_id, &st, &tool_buffer).await;
 
                         // Response message (streaming)
                         if snap.dirty || snap.recreate {
@@ -4439,38 +4410,11 @@ pub(crate) async fn resume_session(
                 tool_buffer.push(idx);
             }
             DisplayItem::Intermediate(text) => {
-                // Flush tool buffer as grouped block before sending intermediate
-                if !tool_buffer.is_empty() {
-                    let tool_details: Vec<(String, String)> = tool_buffer
-                        .iter()
-                        .filter_map(|&idx| {
-                            let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                            s.tool_msgs.get(idx).map(|t| {
-                                let status = match t.completed {
-                                    None => "⚙️",
-                                    Some(true) => "✅",
-                                    Some(false) => "❌",
-                                };
-                                (format!("{} {}", status, t.name), t.context.clone())
-                            })
-                        })
-                        .collect();
-
-                    if !tool_details.is_empty() {
-                        let grouped = render_tool_group(&tool_details);
-                        if let Ok(mid) =
-                            send_html_or_plain(&bot, chat_id, thread_id, &grouped).await
-                        {
-                            let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                            for &idx in &tool_buffer {
-                                if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                                    tool.msg_id = Some(mid);
-                                }
-                            }
-                        }
-                    }
-                    tool_buffer.clear();
-                }
+                // Flush tool buffer into the open group, then close it: the
+                // intermediate breaks the run of consecutive tool calls.
+                append_tool_group(&bot, chat_id, thread_id, &streaming, &tool_buffer).await;
+                close_tool_group(&streaming);
+                tool_buffer.clear();
                 let text = crate::utils::sanitize::strip_llm_artifacts(&text);
                 let text = redact_secrets(&text);
                 // Strip <<IMG:path>> markers — see handle_message.
@@ -4530,35 +4474,9 @@ pub(crate) async fn resume_session(
         }
     }
 
-    // Flush any remaining tools in buffer as grouped block
-    if !tool_buffer.is_empty() {
-        let tool_details: Vec<(String, String)> = tool_buffer
-            .iter()
-            .filter_map(|&idx| {
-                let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                s.tool_msgs.get(idx).map(|t| {
-                    let status = match t.completed {
-                        None => "⚙️",
-                        Some(true) => "✅",
-                        Some(false) => "❌",
-                    };
-                    (format!("{} {}", status, t.name), t.context.clone())
-                })
-            })
-            .collect();
-
-        if !tool_details.is_empty() {
-            let grouped = render_tool_group(&tool_details);
-            if let Ok(mid) = send_html_or_plain(&bot, chat_id, thread_id, &grouped).await {
-                let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                for &idx in &tool_buffer {
-                    if let Some(tool) = s.tool_msgs.get_mut(idx) {
-                        tool.msg_id = Some(mid);
-                    }
-                }
-            }
-        }
-    }
+    // Flush any remaining tools into the open group (merges the final batch
+    // into the running collapsible block instead of opening a new message).
+    append_tool_group(&bot, chat_id, thread_id, &streaming, &tool_buffer).await;
 
     match result {
         Ok(response) => {

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2720,17 +2720,29 @@ pub(crate) async fn handle_message(
          Do NOT call telegram_send to deliver your answer. Only use telegram_send for: \
          sending to a different chat_id, media, polls, buttons, reactions, or moderation.]\n\
          \n\
-         [Reaction directive: You can react to the user's message using <<react:EMOJI>>. \
-         This is for UTILITARIAN acknowledgment only — not decorative or companion behavior. \
-         Use it sparingly when:\n\
-         - A simple acknowledgment suffices (thumbs up for confirmations, checkmark for completed tasks)\n\
-         - The user shared a link and you have nothing to add (eyes emoji)\n\
-         - A quick yes/no reaction is more appropriate than a text response\n\
+         [Reaction directive: You can react to the user's message using <<react:EMOJI>>.\n\
+         This is for UTILITARIAN acknowledgment only, not decorative or companion behavior.\n\
+         \n\
+         DECISION TREE (apply in order):\n\
+         1. Does this require action (file edit, command, search, fetch)? → respond\n\
+         2. Does this ask a question or request information? → respond\n\
+         3. Is there substantive value to add in text (explanation, analysis, correction)? → respond\n\
+         4. Otherwise (praise, acknowledgment, confirmation, shared link with nothing to add) → react-only\n\
+         \n\
+         REACT-ONLY EXAMPLES:\n\
+         - Praise without action: \"The above is super clean\" / \"Great work\" → <<react:🔥>> or <<react:🎉>>\n\
+         - Confirmation of completed work: \"Done\" / \"Finished\" → <<react:✅>> or <<react:👍>>\n\
+         - Shared link with nothing to add → <<react:👀>>\n\
+         - Simple yes/no approval without follow-up → <<react:👍>> or <<react:✅>>\n\
+         - Acknowledgment of waiting/pausing: \"Let's wait\" / \"Hold\" → <<react:👍>>\n\
+         \n\
          To react-only (no text), output ONLY the directive: <<react:👍>>\n\
          To react AND respond, include the directive at the start: <<react:✅>> Done, uploaded to Drive.\n\
-         The value must be a literal emoji character (👍 ✅ 👀 🔥), never a word or placeholder like 'emoji'.\n\
-         When you MENTION the directive in prose (docs, code discussion, examples) instead of using it, \
+         \n\
+         The value must be a literal emoji character (👍 ✅ 👀 🔥 🎉 👏), never a word or placeholder.\n\
+         When you MENTION the directive in prose (docs, code discussion, examples) instead of using it,\n\
          always wrap it in backticks so it is not executed.\n\
+         \n\
          Do NOT use for: expressing emotions, being cute, filling silence, or replacing substantive answers.]\n\
          {agent_input}"
     );

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -361,6 +361,8 @@ pub mod split_pane_test;
 pub mod subagent_test;
 pub mod subagent_tool_description_test;
 pub mod telegram_resume_test;
+#[cfg(feature = "telegram")]
+pub mod telegram_send_retry_test;
 pub mod telegram_session_resolve_test;
 pub mod template_governance_test;
 pub mod token_tracking_test;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -420,6 +420,7 @@ pub mod telegram_send_input_file_test;
 pub mod telegram_send_thread_id_override_test;
 pub mod telegram_status_message_test;
 pub mod telegram_thread_id_lookup_test;
+pub mod telegram_tool_group_test;
 pub mod telegram_topic_listing_test;
 pub mod text_complete_test;
 pub mod tui_tool_stack_test;

--- a/src/tests/telegram_send_retry_test.rs
+++ b/src/tests/telegram_send_retry_test.rs
@@ -1,0 +1,66 @@
+//! Tests for `send_retrying_rate_limit` (#297): command replies must wait
+//! out Telegram's RetryAfter (429) and retry instead of dropping. A per-chat
+//! rate limit (typically a streaming turn editing its placeholder in the
+//! same chat) may DELAY a programmatic reply, never lose it.
+
+use crate::channels::telegram::handler::send_retrying_rate_limit;
+use std::cell::Cell;
+use teloxide::types::Seconds;
+
+fn rate_limited<T>() -> Result<T, teloxide::RequestError> {
+    // 0 seconds so tests do not sleep for real.
+    Err(teloxide::RequestError::RetryAfter(Seconds::from_seconds(0)))
+}
+
+#[tokio::test]
+async fn waits_out_rate_limits_then_delivers() {
+    let calls = Cell::new(0u32);
+    let out = send_retrying_rate_limit("test send", || {
+        let n = calls.get() + 1;
+        calls.set(n);
+        async move { if n <= 2 { rate_limited() } else { Ok(42u32) } }
+    })
+    .await;
+    assert_eq!(out.unwrap(), 42);
+    assert_eq!(calls.get(), 3, "two rate-limited attempts, then success");
+}
+
+#[tokio::test]
+async fn exhausted_retries_propagate_the_error() {
+    let calls = Cell::new(0u32);
+    let out: Result<(), _> = send_retrying_rate_limit("test send", || {
+        calls.set(calls.get() + 1);
+        async { rate_limited() }
+    })
+    .await;
+    assert!(matches!(out, Err(teloxide::RequestError::RetryAfter(_))));
+    // 1 initial attempt + 3 retries.
+    assert_eq!(calls.get(), 4);
+}
+
+#[tokio::test]
+async fn non_rate_limit_error_propagates_immediately() {
+    let calls = Cell::new(0u32);
+    let out: Result<(), _> = send_retrying_rate_limit("test send", || {
+        calls.set(calls.get() + 1);
+        async { Err(teloxide::RequestError::Api(teloxide::ApiError::BotBlocked)) }
+    })
+    .await;
+    assert!(matches!(
+        out,
+        Err(teloxide::RequestError::Api(teloxide::ApiError::BotBlocked))
+    ));
+    assert_eq!(calls.get(), 1, "no retries for non-429 errors");
+}
+
+#[tokio::test]
+async fn first_try_success_sends_once() {
+    let calls = Cell::new(0u32);
+    let out = send_retrying_rate_limit("test send", || {
+        calls.set(calls.get() + 1);
+        async { Ok::<_, teloxide::RequestError>("ok") }
+    })
+    .await;
+    assert_eq!(out.unwrap(), "ok");
+    assert_eq!(calls.get(), 1);
+}

--- a/src/tests/telegram_tool_group_test.rs
+++ b/src/tests/telegram_tool_group_test.rs
@@ -1,0 +1,63 @@
+//! Tests for `telegram::handler::render_tool_group`.
+//!
+//! Grouped tool calls must render as native Telegram HTML using
+//! `<blockquote expandable>` (Bot API 7.3+), never `<details>` — Telegram's
+//! regular HTML parse mode does not support `<details>`, so that tag leaks
+//! into the chat as literal text.
+
+use crate::channels::telegram::handler::render_tool_group;
+
+fn tool(label: &str, context: &str) -> (String, String) {
+    (label.to_string(), context.to_string())
+}
+
+#[test]
+fn empty_group_renders_nothing() {
+    assert_eq!(render_tool_group(&[]), "");
+}
+
+#[test]
+fn single_tool_renders_plain_line_without_blockquote() {
+    let out = render_tool_group(&[tool("✅ bash", "git status")]);
+    assert_eq!(out, "<b>✅ bash</b> git status");
+    assert!(!out.contains("<blockquote"));
+}
+
+#[test]
+fn single_tool_without_context_omits_trailing_space() {
+    let out = render_tool_group(&[tool("⚙️ web_search", "")]);
+    assert_eq!(out, "<b>⚙️ web_search</b>");
+}
+
+#[test]
+fn multiple_tools_render_expandable_blockquote() {
+    let out = render_tool_group(&[
+        tool("✅ bash", "cargo fmt"),
+        tool("✅ read_file", "handler.rs"),
+        tool("❌ grep", "pattern"),
+    ]);
+    assert!(out.starts_with("<blockquote expandable><b>3 tool calls</b>\n"));
+    assert!(out.ends_with("</blockquote>"));
+    assert!(out.contains("<b>✅ bash</b> cargo fmt"));
+    assert!(out.contains("<b>✅ read_file</b> handler.rs"));
+    assert!(out.contains("<b>❌ grep</b> pattern"));
+}
+
+#[test]
+fn never_emits_details_tags() {
+    let out = render_tool_group(&[tool("✅ a", "x"), tool("✅ b", "y")]);
+    assert!(!out.contains("<details>"));
+    assert!(!out.contains("<summary>"));
+}
+
+#[test]
+fn escapes_html_in_labels_and_context() {
+    let out = render_tool_group(&[
+        tool("✅ bash", "grep '<details>' & \"stuff\""),
+        tool("✅ edit_file", "a < b > c"),
+    ]);
+    assert!(out.contains("grep '&lt;details&gt;' &amp; \"stuff\""));
+    assert!(out.contains("a &lt; b &gt; c"));
+    // No raw angle brackets from content survive outside our own tags
+    assert!(!out.contains("'<details>'"));
+}

--- a/src/tests/telegram_tool_group_test.rs
+++ b/src/tests/telegram_tool_group_test.rs
@@ -5,36 +5,39 @@
 //! regular HTML parse mode does not support `<details>`, so that tag leaks
 //! into the chat as literal text.
 
-use crate::channels::telegram::handler::render_tool_group;
+use crate::channels::telegram::handler::{FlowLine, render_flow_html};
 
-fn tool(label: &str, context: &str) -> (String, String) {
-    (label.to_string(), context.to_string())
+fn tline(label: &str, context: &str) -> FlowLine {
+    FlowLine::Tool {
+        label: label.to_string(),
+        context: context.to_string(),
+    }
 }
 
 #[test]
 fn empty_group_renders_nothing() {
-    assert_eq!(render_tool_group(&[]), "");
+    assert_eq!(render_flow_html(&[]), "");
 }
 
 #[test]
 fn single_tool_renders_plain_line_without_blockquote() {
-    let out = render_tool_group(&[tool("✅ bash", "git status")]);
+    let out = render_flow_html(&[tline("✅ bash", "git status")]);
     assert_eq!(out, "<b>✅ bash</b> git status");
     assert!(!out.contains("<blockquote"));
 }
 
 #[test]
 fn single_tool_without_context_omits_trailing_space() {
-    let out = render_tool_group(&[tool("⚙️ web_search", "")]);
+    let out = render_flow_html(&[tline("⚙️ web_search", "")]);
     assert_eq!(out, "<b>⚙️ web_search</b>");
 }
 
 #[test]
 fn multiple_tools_render_expandable_blockquote() {
-    let out = render_tool_group(&[
-        tool("✅ bash", "cargo fmt"),
-        tool("✅ read_file", "handler.rs"),
-        tool("❌ grep", "pattern"),
+    let out = render_flow_html(&[
+        tline("✅ bash", "cargo fmt"),
+        tline("✅ read_file", "handler.rs"),
+        tline("❌ grep", "pattern"),
     ]);
     assert!(out.starts_with("<blockquote expandable><b>3 tool calls</b>\n"));
     assert!(out.ends_with("</blockquote>"));
@@ -45,19 +48,67 @@ fn multiple_tools_render_expandable_blockquote() {
 
 #[test]
 fn never_emits_details_tags() {
-    let out = render_tool_group(&[tool("✅ a", "x"), tool("✅ b", "y")]);
+    let out = render_flow_html(&[tline("✅ a", "x"), tline("✅ b", "y")]);
     assert!(!out.contains("<details>"));
     assert!(!out.contains("<summary>"));
 }
 
 #[test]
 fn escapes_html_in_labels_and_context() {
-    let out = render_tool_group(&[
-        tool("✅ bash", "grep '<details>' & \"stuff\""),
-        tool("✅ edit_file", "a < b > c"),
+    let out = render_flow_html(&[
+        tline("✅ bash", "grep '<details>' & \"stuff\""),
+        tline("✅ edit_file", "a < b > c"),
     ]);
     assert!(out.contains("grep '&lt;details&gt;' &amp; \"stuff\""));
     assert!(out.contains("a &lt; b &gt; c"));
     // No raw angle brackets from content survive outside our own tags
     assert!(!out.contains("'<details>'"));
+}
+
+// ── Mixed processing-log flow (tool calls + intermediate text) — #300 ──
+
+#[test]
+fn tool_plus_text_folds_into_one_blockquote() {
+    let out = render_flow_html(&[
+        tline("✅ bash", "git status"),
+        FlowLine::Text("Checked the tree, all clean.".to_string()),
+        tline("✅ read_file", "handler.rs"),
+    ]);
+    assert!(out.starts_with("<blockquote expandable><b>2 tool calls</b>\n"));
+    assert!(out.ends_with("</blockquote>"));
+    assert!(out.contains("<b>✅ bash</b> git status"));
+    assert!(out.contains("Checked the tree, all clean."));
+    assert!(out.contains("<b>✅ read_file</b> handler.rs"));
+    assert!(!out.contains("<details>"));
+}
+
+#[test]
+fn text_only_flow_uses_processing_log_header() {
+    let out = render_flow_html(&[FlowLine::Text("Switching provider…".to_string())]);
+    assert!(out.starts_with("<blockquote expandable><b>Processing log</b>\n"));
+    assert!(out.contains("Switching provider…"));
+    assert!(!out.contains("tool calls"));
+}
+
+#[test]
+fn intermediate_text_is_html_escaped_in_flow() {
+    let out = render_flow_html(&[
+        tline("✅ bash", "echo hi"),
+        FlowLine::Text("result: <b>bold</b> & <script>alert(1)</script>".to_string()),
+    ]);
+    assert!(out.contains("&lt;b&gt;bold&lt;/b&gt; &amp; &lt;script&gt;"));
+    // The injected tags must never survive as live HTML.
+    assert!(!out.contains("<script>"));
+}
+
+#[test]
+fn blank_text_entries_are_dropped() {
+    let out = render_flow_html(&[tline("✅ bash", "x"), FlowLine::Text("   ".to_string())]);
+    // A lone tool with only blank text collapses to the one-liner.
+    assert_eq!(out, "<b>✅ bash</b> x");
+}
+
+#[test]
+fn empty_flow_renders_nothing() {
+    assert_eq!(render_flow_html(&[]), "");
 }


### PR DESCRIPTION
Draft for live testing. Closes #300 (Stage 1).

## Context (the new approach)

The old ADR (follow-up to #216) proposed a buffer-and-flush pattern: capture every event and render one rich message at turn end. **That is superseded.** We proved the edit-in-place model with tool-call grouping (#296): one message id that gets edited as events land. This PR extends that same in-place flow to absorb intermediate text, so a turn no longer reads as a noisy stack of separate messages above the answer. Only the final response stays clean at the bottom, mirroring the TUI.

## What changed

- The open group is generalized into an ordered **flow** of entries (`FlowEntry::Tool(index)` | `FlowEntry::Text(String)`), rendered together by one pure `render_flow_html` and edited in place as events arrive.
- Intermediate text folds into that collapsed `<blockquote expandable>` block instead of sending a new message. A single tool call still renders as a plain one-liner; anything else collapses.
- **Dedup interaction (important):** folded intermediates are hidden inside the collapsed log, so they are deliberately **not** recorded in `sent_intermediates`. The final-response dedup therefore does not suppress the visible answer just because it also appears in the collapsed trace. This is the subtle bit worth watching in live testing.
- All four drain sites (edit loop + final flush, in both `handle_message` and `resume_session`) converge on `append_tool_group` + `append_intermediate_to_flow`. The per-event send/dedup/rich blocks and `close_tool_group` are removed. Net **-125 lines**.
- `render_flow_html` is the single tested renderer. Tests cover folding a tool + text into one block, the `Processing log` header for text-only flows, HTML-escaping of intermediate text, blank-entry dropping, and the never-`<details>` guard.

## Staged follow-ups (tracked in #300)

- **Thinking blocks** folded into the same log (reverses the current \"thinking never leaves the placeholder\" invariant, the largest behavioral change, so kept separate).
- The **approval-buttons** intermediate path (`flush_intermediates`) still sends its own message; left untouched here to keep the blast radius small.

## Verification

- `cargo clippy --all-features --lib --bins --tests -- -D warnings` clean.
- `cargo test --all-features`: 4535 passed, 0 failed, 29 ignored.
- Telegram rendering itself needs a live build to confirm (draft): fire a multi-tool + intermediate-text turn in a group and confirm one growing collapsed block, with the final answer clean below, on both rich-enabled and rich-disabled clients.