### PR TITLE
feat: extra_headers + base_url support for custom & Anthropic providers

### DIFF
--- a/src/brain/provider/anthropic.rs
+++ b/src/brain/provider/anthropic.rs
@@ -44,6 +44,12 @@ pub struct AnthropicProvider {
     /// User override from `providers.anthropic.context_window` in config.toml.
     /// When set, becomes the compaction budget (overrides agent.context_limit).
     configured_context_window: Option<u32>,
+    /// Custom base URL override (e.g. for AgentRouter gateways).
+    /// When set, replaces `ANTHROPIC_API_URL` and `ANTHROPIC_MODELS_URL`.
+    base_url: Option<String>,
+    /// Extra HTTP headers injected into every request.
+    /// Useful for API gateways that validate client identity (e.g. User-Agent).
+    extra_headers: Vec<(String, String)>,
 }
 
 impl AnthropicProvider {
@@ -63,6 +69,8 @@ impl AnthropicProvider {
             client,
             custom_default_model: None,
             configured_context_window: None,
+            base_url: None,
+            extra_headers: vec![],
         }
     }
 
@@ -73,6 +81,8 @@ impl AnthropicProvider {
             client,
             custom_default_model: None,
             configured_context_window: None,
+            base_url: None,
+            extra_headers: vec![],
         }
     }
 
@@ -86,6 +96,42 @@ impl AnthropicProvider {
     pub fn with_context_window(mut self, context_window: u32) -> Self {
         self.configured_context_window = Some(context_window);
         self
+    }
+
+    /// Set custom base URL (e.g. for API gateways like AgentRouter).
+    /// When set, replaces both the messages endpoint and models endpoint.
+    pub fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = Some(base_url);
+        self
+    }
+
+    /// Inject extra HTTP headers into every request to this provider.
+    /// Useful for API gateways that validate client identity via User-Agent
+    /// or other custom headers.
+    pub fn with_extra_headers(
+        mut self,
+        headers: std::collections::BTreeMap<String, String>,
+    ) -> Self {
+        self.extra_headers = headers.into_iter().collect();
+        self
+    }
+
+    /// Messages API URL, respecting base_url override.
+    /// Defaults to `ANTHROPIC_API_URL` when base_url is not set.
+    fn messages_url(&self) -> String {
+        match &self.base_url {
+            Some(base) => format!("{}/v1/messages", base.trim_end_matches('/')),
+            None => ANTHROPIC_API_URL.to_string(),
+        }
+    }
+
+    /// Models list URL, respecting base_url override.
+    /// Defaults to `ANTHROPIC_MODELS_URL` when base_url is not set.
+    fn models_url(&self) -> String {
+        match &self.base_url {
+            Some(base) => format!("{}/v1/models", base.trim_end_matches('/')),
+            None => ANTHROPIC_MODELS_URL.to_string(),
+        }
     }
 
     /// Build request headers with prompt-caching beta header.
@@ -110,6 +156,17 @@ impl AnthropicProvider {
             reqwest::header::CONTENT_TYPE,
             "application/json".parse().expect("valid content-type"),
         );
+
+        // Inject extra headers (e.g. User-Agent override for API gateways)
+        for (key, value) in &self.extra_headers {
+            if let (Ok(k), Ok(v)) = (
+                key.parse::<reqwest::header::HeaderName>(),
+                value.parse::<reqwest::header::HeaderValue>(),
+            ) {
+                headers.insert(k, v);
+            }
+        }
+
         headers
     }
 
@@ -274,7 +331,7 @@ impl Provider for AnthropicProvider {
                 tracing::debug!("Sending request to Anthropic API");
                 let response = self
                     .client
-                    .post(ANTHROPIC_API_URL)
+                    .post(self.messages_url())
                     .headers(req_headers.clone())
                     .json(&anthropic_request)
                     .send()
@@ -331,7 +388,7 @@ impl Provider for AnthropicProvider {
             || async {
                 let response = self
                     .client
-                    .post(ANTHROPIC_API_URL)
+                    .post(self.messages_url())
                     .headers(req_headers.clone())
                     .json(&anthropic_request)
                     .send()
@@ -458,7 +515,7 @@ impl Provider for AnthropicProvider {
 
         let req = self
             .client
-            .get(ANTHROPIC_MODELS_URL)
+            .get(self.models_url())
             .header("anthropic-version", ANTHROPIC_VERSION)
             .header("x-api-key", &self.api_key)
             .header("anthropic-beta", "prompt-caching-2024-07-31");

--- a/src/brain/provider/factory.rs
+++ b/src/brain/provider/factory.rs
@@ -1560,6 +1560,15 @@ fn configure_openai_compatible(
         provider = provider.with_cache_ttl(ttl);
         tracing::info!("OpenRouter cache TTL: {}s", ttl);
     }
+    // Extra headers from config (e.g. User-Agent for API gateway auth)
+    if let Some(ref extra) = config.extra_headers {
+        let headers: Vec<(String, String)> = extra
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        tracing::info!("Applying {} extra header(s) from config", headers.len());
+        provider = provider.with_extra_headers(headers);
+    }
     provider
 }
 

--- a/src/brain/provider/factory.rs
+++ b/src/brain/provider/factory.rs
@@ -1794,6 +1794,14 @@ fn try_create_anthropic(config: &Config) -> Result<Option<Arc<dyn Provider>>> {
         tracing::info!("Anthropic context window override: {} tokens", cw);
         provider = provider.with_context_window(cw);
     }
+    if let Some(base_url) = &anthropic_config.base_url {
+        tracing::info!("Anthropic base URL override: {}", base_url);
+        provider = provider.with_base_url(base_url.clone());
+    }
+    if let Some(extra) = &anthropic_config.extra_headers {
+        tracing::info!("Anthropic extra headers: {} header(s)", extra.len());
+        provider = provider.with_extra_headers(extra.clone());
+    }
 
     tracing::info!("Using Anthropic provider");
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1870,6 +1870,17 @@ pub struct ProviderConfig {
     /// Default: 300 (5 minutes). Only used when cache_enabled is true.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_ttl: Option<u32>,
+
+    /// Extra HTTP headers injected into every request to this provider.
+    /// Useful for API gateways that validate client identity via User-Agent
+    /// or other headers (e.g. AgentRouter requires `User-Agent: openclaw`).
+    /// Format in TOML:
+    /// ```toml
+    /// [providers.custom.mygateway]
+    /// extra_headers = { User-Agent = "openclaw" }
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_headers: Option<std::collections::BTreeMap<String, String>>,
 }
 
 fn default_enabled() -> bool {


### PR DESCRIPTION
## Summary

Single PR combining both features for API gateway support.

### 1. extra_headers for Custom Providers (OpenAI-compatible)
Adds `extra_headers` field to `ProviderConfig`, enabling custom HTTP headers (e.g. `User-Agent`) for OpenAI-compatible custom providers. API gateways like AgentRouter that validate client identity via User-Agent can now be used directly.

```toml
[providers.custom.agentrouter]
base_url = "https://agentrouter.org/v1"
api_key = "sk-..."
extra_headers = { User-Agent = "openclaw" }
models = ["glm-5.2", "gpt-5.5"]
```

### 2. base_url + extra_headers for Anthropic Provider
Adds `base_url` and `extra_headers` support to the built-in Anthropic (`[providers.anthropic]`) provider. Enables routing Anthropic API calls through gateways.

```toml
[providers.anthropic]
api_key = "sk-..."
base_url = "https://agentrouter.org"
extra_headers = { User-Agent = "openclaw" }
```

## Files Changed
- `src/config/types.rs` — extra_headers field on ProviderConfig
- `src/brain/provider/anthropic.rs` — base_url + extra_headers support
- `src/brain/provider/factory.rs` — read base_url + extra_headers from config