### PR TITLE
fix(session_context): atomic write to eliminate trailing-characters corruption

### DIFF
--- a/src/brain/tools/context.rs
+++ b/src/brain/tools/context.rs
@@ -12,6 +12,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
+/// Monotonic counter for unique context-store temp-file names, so concurrent
+/// `session_context` saves never race on the same temp path.
+static CONTEXT_TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Session context management tool
 pub struct ContextTool;
 
@@ -70,11 +74,29 @@ impl ContextStore {
             .map_err(|e| ToolError::Execution(format!("Failed to serialize context: {}", e)))?;
 
         // Ensure parent directory exists
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await.map_err(ToolError::Io)?;
-        }
+        let parent = path.parent().ok_or_else(|| {
+            ToolError::Execution("context store path has no parent directory".to_string())
+        })?;
+        fs::create_dir_all(parent).await.map_err(ToolError::Io)?;
 
-        fs::write(path, content).await.map_err(ToolError::Io)?;
+        // Atomic, race-free write. `fs::write` truncates per call, but two
+        // concurrent `session_context` saves in one turn (e.g. several `set`
+        // ops fired together) don't serialize: a shorter write landing over a
+        // longer one leaves the longer object's tail bytes in place, producing
+        // "trailing characters" parse failures on the next read. Write a
+        // uniquely-named temp file in the same directory, then atomically
+        // rename it over the target — the store is always either the previous
+        // complete object or the new one, never a mix. The unique temp name
+        // (pid + monotonic counter) prevents two saves from racing on the temp
+        // file itself.
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("context_store.json");
+        let seq = CONTEXT_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = parent.join(format!("{}.{}.{}.tmp", file_name, std::process::id(), seq));
+        fs::write(&tmp, content).await.map_err(ToolError::Io)?;
+        fs::rename(&tmp, path).await.map_err(ToolError::Io)?;
         Ok(())
     }
 }


### PR DESCRIPTION
# fix(session_context): write context store atomically

Target branch: `v0.3.77` (commit `90adbd3`). Patch commit: `8a114c4`.
Files: `src/brain/tools/context.rs` (+23/−5). No new deps, no feature flags.

## Problem

`session_context`'s `save()` wrote the per-session store with `fs::write(path, content)` directly. `fs::write` truncates on open, but **two concurrent `save()` calls do not serialize**. When several `session_context set` ops fire in one turn (load → mutate → save), their writes interleave at the syscall level: a shorter write landing over a longer one leaves the longer object's tail bytes in place. The file becomes `{valid shorter object}{leftover tail}` and the next read fails:

```
Failed to parse context store: trailing characters at line N column 2
```

## Impact

This was the **single largest source of tool failures** in the instance's feedback ledger — ~57% of all logged `tool_failure` events over weeks (4,465 identical "trailing characters" errors). Corruption is transient (a later clean write repairs it), so it shows as a high-but-not-permanent rate, with hard on-disk evidence frozen in repair snapshots:

| Snapshot | Valid object | File size | Trailing garbage |
|---|---|---|---|
| `context_<id>.json.bak.<ts>` | 7124 B | 7372 B | 248 B of a prior longer write |
| `context_<id>.json.workbak` | 42335 B | 42336 B | 1 trailing `}` |

## Root cause

`fs::write` is not atomic and provides no mutual exclusion across concurrent writers to the same path.

## Fix

Write to a **uniquely-named temp file** in the same directory, then **atomically rename** it over the target:

- Unique temp name (`pid` + monotonic counter) → two concurrent saves never race on the temp file itself.
- `rename` is atomic on the same filesystem → the store is always either the previous complete object or the new one, never a mix.

## Out of scope

- **Lost-update semantics:** atomic rename makes last-writer-wins — two concurrent `set` calls could still drop one update (no corruption, but a lost change). A per-session `Mutex` around load→mutate→save would close that; intentionally left out to keep the patch minimal and reviewable. The trigger (dense concurrent `session_context` bursts) is also addressed operationally via agent discipline.

## Testing

- `cargo check` (see background run).
- Suggested regression test: spawn N concurrent `save()` calls with varying payload sizes, then assert every `load()` returns a valid, complete object.