### PR TITLE
feat(compaction): pre-compaction context-pressure nudge (#909)

### DIFF
--- a/src/brain/agent/service/builder.rs
+++ b/src/brain/agent/service/builder.rs
@@ -238,6 +238,13 @@ pub struct AgentService {
     /// description in `push_commands_and_skills` is all that survives.
     pub(super) active_skills: std::sync::RwLock<HashMap<Uuid, HashSet<String>>>,
 
+    /// Per-session flag: has the pre-compaction context-pressure warning
+    /// (#909) already been emitted for the current band entry? Set true when
+    /// the warning fires (usage in 55-64% band), cleared when usage drops
+    /// below 55% so a fresh entry into the band warns again. Keeps the
+    /// transient nudge to once-per-entry instead of every turn.
+    pub(super) session_pressure_warned: std::sync::RwLock<HashMap<Uuid, bool>>,
+
     /// Service context for database operations
     pub(super) context: ServiceContext,
 
@@ -366,6 +373,7 @@ impl AgentService {
             session_context_limits: std::sync::RwLock::new(HashMap::new()),
             session_primary_failure_streak: std::sync::RwLock::new(HashMap::new()),
             active_skills: std::sync::RwLock::new(HashMap::new()),
+            session_pressure_warned: std::sync::RwLock::new(HashMap::new()),
             context,
             tool_registry: Arc::new(ToolRegistry::new()),
             max_tool_iterations: 0, // 0 = unlimited (loop detection is the safety net)

--- a/src/brain/agent/service/compaction.rs
+++ b/src/brain/agent/service/compaction.rs
@@ -117,13 +117,17 @@ impl AgentService {
             );
         }
 
-        // ── Tier 1: soft trigger at 65% — LLM compaction ──
+        // ── Tier 1: soft trigger at 65% - LLM compaction ──
         let usage_pct = if effective_max > 0 {
             (context.token_count as f64 / effective_max as f64) * 100.0
         } else {
             100.0
         };
         if usage_pct <= 65.0 {
+            // Below the compaction trigger. Try to emit the pre-compaction
+            // pressure warning if usage is in the 55-64% band (#909), and
+            // re-arm the throttle when usage has dropped below the floor.
+            self.maybe_emit_pressure_warning(session_id, context, usage_pct);
             return None;
         }
 
@@ -222,5 +226,62 @@ impl AgentService {
         }
 
         summary_result
+    }
+
+    /// Pre-compaction pressure-warning gate (#909).
+    ///
+    /// Called from `enforce_context_budget` when usage is at or below 65% (i.e.
+    /// compaction is NOT firing this turn). Decides whether to append the
+    /// behavioural "persist your state" nudge to the system brain:
+    ///
+    /// - usage **below** the 55% floor: clear the per-session throttle flag so
+    ///   the next entry into the band warns again. No nudge.
+    /// - usage **in** the 55-64% band AND not yet emitted this entry: append the
+    ///   nudge to `system_brain`, count its tokens, set the throttle flag.
+    /// - usage **in** the band but already emitted: no-op (once-per-entry).
+    ///
+    /// The nudge is transient: `system_brain` is rebuilt from disk every turn
+    /// (`live_system_brain_for_session`), so the suffix never persists to the
+    /// DB and cannot compound across turns.
+    pub(super) fn maybe_emit_pressure_warning(
+        &self,
+        session_id: Uuid,
+        context: &mut AgentContext,
+        usage_pct: f64,
+    ) {
+        use super::nudge::should_emit_pressure_warning;
+
+        // Re-arm the throttle once usage drops below the band floor so the
+        // next climb back into the band warns again.
+        if usage_pct < super::nudge::PRESSURE_WARN_FLOOR {
+            if let Ok(mut map) = self.session_pressure_warned.write() {
+                map.insert(session_id, false);
+            }
+            return;
+        }
+
+        let already_emitted = self
+            .session_pressure_warned
+            .read()
+            .ok()
+            .and_then(|map| map.get(&session_id).copied())
+            .unwrap_or(false);
+
+        if let Some(warning) = should_emit_pressure_warning(usage_pct, already_emitted) {
+            if let Some(ref mut brain) = context.system_brain {
+                tracing::info!(
+                    "Context at {:.0}% - emitting pre-compaction pressure warning",
+                    usage_pct
+                );
+                brain.push_str(warning);
+                context.token_count += AgentContext::estimate_tokens(warning);
+            }
+            // Mark emitted regardless of whether a brain existed, so a
+            // missing brain doesn't retry every turn until the band ends.
+            if let Ok(mut map) = self.session_pressure_warned.write() {
+                map.insert(session_id, true);
+            }
+        }
+        // else: in-band but already emitted -> no-op (once-per-entry).
     }
 }

--- a/src/brain/agent/service/nudge.rs
+++ b/src/brain/agent/service/nudge.rs
@@ -76,3 +76,62 @@ pub fn no_tool_calls_nudge(local_model: bool) -> String {
          now.{FINISHED_ESCAPE}]"
     )
 }
+
+// ── Pre-compaction context-pressure warning (#909) ──
+//
+// Compaction is reactive today: Tier-1 fires at 65% and clips the conversation
+// with no prior warning. The model never gets a chance to deliberately finish
+// its current sub-task and persist critical state before the clip.
+//
+// These helpers define a warning band (55-64%) just below the trigger. When
+// usage enters the band, a behavioural nudge is appended to the system brain
+// telling the model to persist state to disk NOW. It is a nudge, not a number,
+// because `context.token_count` is a tiktoken estimate for all providers at
+// the point this runs - a precise percentage would repeat the units-confusion
+// that caused #896, and the model can't trigger compaction anyway, so the only
+// useful signal is the instruction itself.
+//
+// The nudge is transient: it rides on `system_brain`, which is rebuilt from
+// disk every turn, so it never lands in the DB. A per-session throttle flag
+// (held on AgentService) suppresses repeat warnings while usage lingers in the
+// band and re-arms when it drops below the band floor.
+
+/// Lower edge of the warning band (inclusive). Below this the throttle re-arms
+/// so a fresh entry into the band warns again.
+pub(crate) const PRESSURE_WARN_FLOOR: f64 = 55.0;
+
+/// Upper edge of the warning band (exclusive). At 65% Tier-1 compaction fires
+/// (see `compaction.rs`), so the warning band runs right up to the trigger.
+pub(crate) const PRESSURE_WARN_CEILING: f64 = 65.0;
+
+/// The behavioural nudge text appended to the system brain when usage is in the
+/// warning band. Public to the crate so the wiring site and tests can reference
+/// the exact wording.
+pub fn context_pressure_warning() -> &'static str {
+    "\n\n[SYSTEM WARNING - Context is filling up and auto-compaction will trigger soon. \
+     If you have critical state - active plan, key findings, partial work, decisions made - \
+     persist it to disk NOW (MEMORY.md, plan JSON, or a project file) so it survives the \
+     upcoming compaction. Do NOT stop or change task; just checkpoint your state.]"
+}
+
+/// Whether the current usage percentage is inside the warning band.
+/// Pure - testable without a provider or a full AgentService.
+pub fn in_pressure_warning_band(usage_pct: f64) -> bool {
+    (PRESSURE_WARN_FLOOR..PRESSURE_WARN_CEILING).contains(&usage_pct)
+}
+
+/// Decide whether to emit the pressure warning this turn.
+///
+/// Returns `Some(warning)` when usage is in the band AND the warning has not
+/// already been emitted for this band entry, `None` otherwise. The caller owns
+/// the `already_emitted` flag and must set it true on emit, false when usage
+/// drops below the floor (so the next band entry warns again).
+///
+/// Pure - testable in isolation.
+pub fn should_emit_pressure_warning(usage_pct: f64, already_emitted: bool) -> Option<&'static str> {
+    if in_pressure_warning_band(usage_pct) && !already_emitted {
+        Some(context_pressure_warning())
+    } else {
+        None
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -215,6 +215,7 @@ pub mod phantom_unbacked_evidence_test;
 pub mod phantom_uncalled_command_test;
 pub mod phantom_unsent_file_test;
 pub mod phantom_work_announcement_test;
+pub mod pressure_warning_test;
 pub mod pricing_fallback_test;
 pub mod profile_pid_lock_test;
 pub mod profile_preempt_test;

--- a/src/tests/pressure_warning_test.rs
+++ b/src/tests/pressure_warning_test.rs
@@ -1,0 +1,124 @@
+//! Tests for the pre-compaction context-pressure warning (#909).
+//!
+//! Covers the pure decision logic in `nudge.rs` (band boundaries, once-per-entry
+//! throttle, re-arm below floor) and the end-to-end wiring on `AgentContext`
+//! (nudge appends to system_brain, token count rises).
+
+use crate::brain::agent::context::AgentContext;
+use crate::brain::agent::service::nudge::{
+    PRESSURE_WARN_CEILING, PRESSURE_WARN_FLOOR, context_pressure_warning, in_pressure_warning_band,
+    should_emit_pressure_warning,
+};
+use uuid::Uuid;
+
+// ── Band boundary tests ──
+
+#[test]
+fn just_below_floor_is_not_in_band() {
+    assert!(!in_pressure_warning_band(54.9));
+    assert!(!in_pressure_warning_band(54.0));
+    assert!(!in_pressure_warning_band(0.0));
+}
+
+#[test]
+fn at_floor_is_in_band() {
+    // 55.0 is the inclusive lower edge.
+    assert!(in_pressure_warning_band(55.0));
+}
+
+#[test]
+fn mid_band_is_in_band() {
+    assert!(in_pressure_warning_band(60.0));
+    assert!(in_pressure_warning_band(63.9));
+}
+
+#[test]
+fn just_below_ceiling_is_in_band() {
+    // 64.9 is still inside; 65.0 is where compaction fires (excluded).
+    assert!(in_pressure_warning_band(64.9));
+    assert!(!in_pressure_warning_band(65.0));
+    assert!(!in_pressure_warning_band(90.0));
+    assert!(!in_pressure_warning_band(100.0));
+}
+
+#[test]
+fn band_edges_match_constants() {
+    assert_eq!(PRESSURE_WARN_FLOOR, 55.0);
+    assert_eq!(PRESSURE_WARN_CEILING, 65.0);
+}
+
+// ── should_emit_pressure_warning: emission + throttle ──
+
+#[test]
+fn emits_on_first_entry_into_band() {
+    assert_eq!(
+        should_emit_pressure_warning(60.0, false),
+        Some(context_pressure_warning())
+    );
+}
+
+#[test]
+fn does_not_emit_when_already_emitted() {
+    // Once-per-entry: second turn in the band is suppressed.
+    assert_eq!(should_emit_pressure_warning(60.0, true), None);
+    assert_eq!(should_emit_pressure_warning(64.0, true), None);
+}
+
+#[test]
+fn does_not_emit_outside_band() {
+    assert_eq!(should_emit_pressure_warning(40.0, false), None);
+    assert_eq!(should_emit_pressure_warning(54.9, false), None);
+    assert_eq!(should_emit_pressure_warning(65.0, false), None);
+    assert_eq!(should_emit_pressure_warning(80.0, false), None);
+}
+
+#[test]
+fn re_arms_when_usage_drops_below_floor() {
+    // Simulate the once-per-entry lifecycle across turns.
+    // Turn 1: enter band at 58%, not yet emitted -> emits.
+    assert!(should_emit_pressure_warning(58.0, false).is_some());
+
+    // Turn 2: still in band, already emitted -> suppressed.
+    assert!(should_emit_pressure_warning(58.0, true).is_none());
+
+    // Usage drops to 40% (below floor). Caller clears the flag.
+    // Turn 3: re-enters band at 61%, flag cleared -> emits again.
+    assert!(should_emit_pressure_warning(61.0, false).is_some());
+}
+
+// ── Warning text content ──
+
+#[test]
+fn warning_text_mentions_persist_and_compaction() {
+    let w = context_pressure_warning();
+    assert!(w.contains("compaction"));
+    assert!(w.contains("persist"));
+    assert!(w.contains("disk"));
+    // Must not contain a numeric percentage (nudge-not-number design, #896 guard).
+    assert!(!w.contains('%'));
+}
+
+// ── AgentContext wiring (nudge appends to system_brain + counts tokens) ──
+
+#[test]
+fn appending_warning_to_brain_raises_token_count() {
+    let session_id = Uuid::new_v4();
+    let mut context = AgentContext::new(session_id, 100_000);
+    let brain = "You are a helpful agent.".to_string();
+    context.system_brain = Some(brain.clone());
+    context.token_count = AgentContext::estimate_tokens(&brain);
+
+    let tokens_before = context.token_count;
+    let warning = context_pressure_warning();
+    context.system_brain.as_mut().unwrap().push_str(warning);
+    context.token_count += AgentContext::estimate_tokens(warning);
+
+    assert!(context.token_count > tokens_before);
+    assert!(
+        context
+            .system_brain
+            .as_ref()
+            .unwrap()
+            .contains("SYSTEM WARNING")
+    );
+}


### PR DESCRIPTION
## Summary

Injects a transient, behavioral pre-compaction nudge into the model so it can checkpoint critical state to disk *before* auto-compaction fires, instead of being blindsided by it.

Resolves the gap flagged in the group: OpenCrabs hands the model a continuation brief only *after* compaction clips it. This adds a heads-up in the 55-64% band (just below the 65% Tier-1 trigger).

## Design

- **Nudge, not a number.** The warning is a behavioral instruction (`persist state NOW`), not a live percentage. This is robust to token-accounting drift — `token_count` at injection time is a tiktoken estimate for all providers, so a precise "%" could be off by 30% and panic the model early. The model can't trigger compaction anyway, so a bare meter only induces anxiety.
- **Transient.** The nudge is a suffix appended to `system_brain`, which is rebuilt fresh from disk + active skills every turn. It never lands in `context.messages`, never persists to the DB, and can't compound across turns.
- **Once-per-entry throttle.** A `RwLock<HashMap<Uuid, bool>>` on `AgentService` ensures the nudge fires once per session entry into the band, not on every turn while inside it.
- **55-64% band.** Fixed constants (`PRESSURE_WARN_FLOOR = 55.0`, `PRESSURE_WARN_CEILING = 65.0`) in `nudge.rs`, exclusive range = 55-64.9%. Single knob if the edges need retuning later.

## Changes

- `nudge.rs` — pure helpers (`should_emit_pressure_warning`, `PRESSURE_WARN_*` constants)
- `builder.rs` — throttle flag field on `AgentService`
- `compaction.rs` — injection seam in `enforce_context_budget` + `maybe_emit_pressure_warning`
- `tests/pressure_warning_test.rs` — 11 unit tests on the pure helpers

## Validation

`cargo fmt` clean, `cargo clippy --all-features` zero warnings, 11 tests pass.

Closes #909
