### PR TITLE
fix(db): make migration 33 idempotent for pre-existing provider column (#937)

### DIFF
--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -297,6 +297,41 @@ impl Database {
                     conn.pragma_update(None, "user_version", Self::MIGRATION_COUNT as i64)?;
                 }
 
+                // Defensive check for migration 33 (add_analytics_events):
+                // If tool_executions table already contains provider column from prior schema state,
+                // ensure migration does not fail with duplicate column name error.
+                if user_version < 33 {
+                    let has_provider: bool = conn
+                        .prepare("PRAGMA table_info(tool_executions)")?
+                        .query_map([], |r| r.get::<_, String>(1))?
+                        .filter_map(Result::ok)
+                        .any(|col| col == "provider");
+
+                    if has_provider {
+                        tracing::info!("Pre-existing provider column in tool_executions — safely advancing migration version to 33");
+                        conn.execute_batch(
+                            "CREATE TABLE IF NOT EXISTS phantom_events (
+                                id TEXT PRIMARY KEY, session_id TEXT NOT NULL DEFAULT '', provider TEXT, model TEXT,
+                                detected_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')), resolved INTEGER NOT NULL DEFAULT 0,
+                                retry_count INTEGER NOT NULL DEFAULT 0, tools_after_retry INTEGER NOT NULL DEFAULT 0
+                            );
+                            CREATE INDEX IF NOT EXISTS idx_phantom_events_detected_at ON phantom_events(detected_at);
+                            CREATE INDEX IF NOT EXISTS idx_phantom_events_session ON phantom_events(session_id);
+                            CREATE TABLE IF NOT EXISTS streaming_recoveries (
+                                id TEXT PRIMARY KEY, session_id TEXT NOT NULL DEFAULT '', provider TEXT, model TEXT,
+                                recovered_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')), tool_count INTEGER NOT NULL DEFAULT 1
+                            );
+                            CREATE INDEX IF NOT EXISTS idx_streaming_recoveries_at ON streaming_recoveries(recovered_at);
+                            CREATE TABLE IF NOT EXISTS brain_verify_events (
+                                id TEXT PRIMARY KEY, file_name TEXT NOT NULL, event_type TEXT NOT NULL DEFAULT 'pass',
+                                violations TEXT, created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+                            );
+                            CREATE INDEX IF NOT EXISTS idx_brain_verify_events_at ON brain_verify_events(created_at);",
+                        )?;
+                        conn.pragma_update(None, "user_version", 33i64)?;
+                    }
+                }
+
                 migrations.to_latest(conn)
             })
             .await


### PR DESCRIPTION
## Summary

Fixes #937.

When upgrading or launching OpenCrabs on a database where `tool_executions` already contains the `provider`, `model`, or `duration_ms` columns from a prior build or partial migration attempt, migration `#33` (`20260731000001_add_analytics_events.sql`) fails with:

```text
duplicate column name: provider: Error code 1: SQL logic error
```

## Solution

In `src/db/database.rs`, add a pre-migration probe before `migrations.to_latest(conn)`. If `user_version < 33` and `tool_executions` already contains `provider`, the database runner safely creates the missing Mission Control analytics tables (`phantom_events`, `streaming_recoveries`, `brain_verify_events`) and advances `user_version` to `33` to prevent non-idempotent `ALTER TABLE` crashes.

## Verification

- `cargo check --bin opencrabs` passed cleanly.
- Tested locally on SQLite database with pre-existing columns — successfully advanced migration version to 33 and launched OpenCrabs without errors.