### PR TITLE
fix(file_extract): add xlsb/xlsm/ods support for channel ingestion (#959)

### DIFF
--- a/src/brain/tools/read.rs
+++ b/src/brain/tools/read.rs
@@ -39,7 +39,7 @@ fn media_tool_redirect(path: &std::path::Path) -> Option<String> {
         "mp4" | "m4v" | "mov" | "webm" | "mkv" | "avi" | "3gp" | "flv" => Some(format!(
             "'{p}' is a video. Call analyze_video(path='{p}', question='...') to view it."
         )),
-        "pdf" | "docx" | "doc" | "pptx" | "xlsx" | "epub" => Some(format!(
+        "pdf" | "docx" | "doc" | "pptx" | "xlsx" | "xlsb" | "xlsm" | "ods" | "epub" => Some(format!(
             "'{p}' is a document. Call parse_document(path='{p}') to read its text\
              {}.",
             if ext == "pdf" {

--- a/src/tests/file_extract_test.rs
+++ b/src/tests/file_extract_test.rs
@@ -163,6 +163,33 @@ fn case_insensitive_ext() {
     assert_eq!(mime_from_ext("image.PNG"), "image/png");
 }
 
+// ── Excel spreadsheet extensions (xlsb/xlsm/ods) ─────────────────────────
+
+#[test]
+fn ext_excel_spreadsheet_all_formats() {
+    assert_eq!(
+        mime_from_ext("data.xlsx"),
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
+    assert_eq!(mime_from_ext("data.xls"), "application/vnd.ms-excel");
+    assert_eq!(
+        mime_from_ext("data.xlsb"),
+        "application/vnd.ms-excel.sheet.binary.macroEnabled.12"
+    );
+    assert_eq!(
+        mime_from_ext("data.xlsm"),
+        "application/vnd.ms-excel.sheet.macroEnabled.12"
+    );
+    assert_eq!(
+        mime_from_ext("data.ods"),
+        "application/vnd.oasis.opendocument.spreadsheet"
+    );
+    // case-insensitive
+    assert_eq!(mime_from_ext("data.XLSB"), "application/vnd.ms-excel.sheet.binary.macroEnabled.12");
+    assert_eq!(mime_from_ext("data.XLSM"), "application/vnd.ms-excel.sheet.macroEnabled.12");
+    assert_eq!(mime_from_ext("data.ODS"), "application/vnd.oasis.opendocument.spreadsheet");
+}
+
 // ── classify_file ───────────────────────────────────────────────
 
 #[test]

--- a/src/tui/app/state.rs
+++ b/src/tui/app/state.rs
@@ -369,7 +369,7 @@ pub(crate) const TEXT_EXTENSIONS: &[&str] = &[
 /// Document extensions for auto-detection (paste a path → the agent is given
 /// the path and told to call `parse_document` / `pdf_to_images`). Binary
 /// formats, so we never inline their bytes — only surface the path.
-pub(crate) const DOC_EXTENSIONS: &[&str] = &[".pdf", ".docx", ".doc", ".pptx", ".xlsx", ".epub"];
+pub(crate) const DOC_EXTENSIONS: &[&str] = &[".pdf", ".docx", ".doc", ".pptx", ".xlsx", ".xlsb", ".xlsm", ".ods", ".epub"];
 
 /// A single tool call entry within a grouped display
 #[derive(Debug, Clone)]

--- a/src/utils/file_extract.rs
+++ b/src/utils/file_extract.rs
@@ -161,6 +161,9 @@ pub fn mime_from_ext(filename: &str) -> &'static str {
         "pdf" => "application/pdf",
         "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "xls" => "application/vnd.ms-excel",
+        "xlsb" => "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+        "xlsm" => "application/vnd.ms-excel.sheet.macroEnabled.12",
+        "ods" => "application/vnd.oasis.opendocument.spreadsheet",
         "zip" => "application/zip",
         "mp4" | "m4v" => "video/mp4",
         "mov" => "video/quicktime",
@@ -378,6 +381,9 @@ pub fn process_file_with_vision(
         effective,
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" // .xlsx
         | "application/vnd.ms-excel" // .xls
+        | "application/vnd.ms-excel.sheet.binary.macroEnabled.12" // .xlsb
+        | "application/vnd.ms-excel.sheet.macroEnabled.12"       // .xlsm
+        | "application/vnd.oasis.opendocument.spreadsheet"       // .ods
         | "application/xlsx"
         | "application/xls"
     ) {


### PR DESCRIPTION
## Summary

Fixes issue #959: .xlsb, .xlsm, and .ods files are rejected at channel ingestion despite parse_document fully supporting them since #955.

## Changes

### src/utils/file_extract.rs
- mime_from_ext(): Added xlsb, xlsm, ods extension mappings
- process_file_with_vision() Excel branch: Added 3 missing MIME types so files reach parse_document instead of FileContent::Unsupported

### src/tui/app/state.rs
- DOC_EXTENSIONS: Added .xlsb, .xlsm, .ods for paste-to-parse_document detection

### src/brain/tools/read.rs
- Redirect arm: Added xlsb/xlsm/ods so agents get parse_document hint instead of raw binary read

### src/tests/file_extract_test.rs
- New test ext_excel_spreadsheet_all_formats covering all 5 Excel MIME types + case-insensitive variants

## MIME types added
| Ext | MIME |
| --- | --- |
| xlsb | application/vnd.ms-excel.sheet.binary.macroEnabled.12 |
| xlsm | application/vnd.ms-excel.sheet.macroEnabled.12 |
| ods | application/vnd.oasis.opendocument.spreadsheet |