### PR TITLE
Refactor: Drop qmd dependency, own the memory store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,7 +1256,6 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -1406,7 +1405,7 @@ dependencies = [
  "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
- "jni 0.21.1",
+ "jni",
  "js-sys",
  "libc",
  "mach2",
@@ -2731,15 +2730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
-]
-
-[[package]]
 name = "gemm"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3002,10 +2992,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3240,7 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b780635574b3d92f036890d8373433d6f9fc7abb320ee42a5c25897fc8ed732"
 dependencies = [
  "dirs 5.0.1",
- "indicatif 0.17.11",
+ "indicatif",
  "log",
  "native-tls",
  "rand 0.8.7",
@@ -3499,11 +3487,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.5",
- "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -3763,19 +3749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.18.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
-dependencies = [
- "console 0.16.4",
- "portable-atomic",
- "unicode-width",
- "unit-prefix",
- "web-time",
-]
-
-[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,36 +3958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.20",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,7 +4060,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6ea4f7cc50877612c89f3c0f7b5286d08724562234ce2329f6c53415436e74"
 dependencies = [
- "indicatif 0.17.11",
+ "indicatif",
 ]
 
 [[package]]
@@ -4405,12 +4348,6 @@ checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
@@ -5074,7 +5011,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
- "jni 0.21.1",
+ "jni",
  "ndk",
  "ndk-context",
  "num-derive",
@@ -5182,7 +5119,6 @@ dependencies = [
  "printpdf",
  "proptest",
  "pulldown-cmark",
- "qmd",
  "qrcode",
  "quick-xml",
  "rand 0.9.5",
@@ -6113,33 +6049,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
-name = "qmd"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b71274916ea005f0ded217d8e53a984af65735fe0af157df91329f57c08467"
-dependencies = [
- "anyhow",
- "chrono",
- "colored",
- "dirs 6.0.0",
- "fuzzy-matcher",
- "glob",
- "indicatif 0.18.6",
- "llama-cpp-2",
- "regex",
- "reqwest 0.13.4",
- "rusqlite",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tokio",
- "walkdir",
- "zerocopy",
-]
-
-[[package]]
 name = "qrcode"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6168,63 +6077,6 @@ checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "encoding_rs",
  "memchr",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.1.3",
- "rustls",
- "socket2 0.6.5",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash 2.1.3",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.20",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.6.5",
- "tracing",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6332,15 +6184,6 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.5",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6647,7 +6490,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -6666,6 +6509,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.5.0",
@@ -6706,35 +6550,26 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.15",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper 1.11.0",
- "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -7033,36 +6868,8 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
- "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.22.4",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -7455,19 +7262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serenity"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7628,16 +7422,6 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
-
-[[package]]
-name = "simd_cesu8"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
 
 [[package]]
 name = "simdutf8"
@@ -8225,18 +8009,7 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -8244,16 +8017,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -8635,7 +8398,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "indicatif 0.17.11",
+ "indicatif",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
@@ -9338,12 +9101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
-
-[[package]]
 name = "universal-hash"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9352,12 +9109,6 @@ dependencies = [
  "crypto-common 0.2.2",
  "ctutils",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -9826,15 +9577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10101,17 +9843,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clap_complete = "4.6"
 ratatui = { version = "0.30", features = ["all-widgets"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 
-# Database (deadpool-sqlite uses rusqlite 0.38, same as qmd — zero libsqlite3-sys conflicts)
+# Database (deadpool-sqlite uses rusqlite 0.38 — single libsqlite3-sys build)
 deadpool-sqlite = { version = "0.13", features = ["rt_tokio_1"] }
 rusqlite = { version = "0.38", features = ["bundled"] }
 rusqlite_migration = "2.4"
@@ -48,7 +48,7 @@ config = "0.15"
 dirs = "6.0"
 
 # HTTP & LLM Clients
-reqwest = { version = "0.12", features = ["json", "multipart", "native-tls", "stream"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "multipart", "native-tls", "stream", "blocking"], default-features = false }
 
 # A2A Gateway (HTTP Server)
 axum = "0.8"
@@ -162,8 +162,7 @@ tiktoken-rs = "0.9.1"
 flate2 = "1"
 tar = "0.4"
 
-# Memory Search (FTS5 + vector search)
-qmd = "0.3"
+# Memory Search (FTS5 + vector search — store owned in src/memory, #1028)
 llama-cpp-2 = "0.1.137"
 emojis = "0.8.0"
 url = "2.5.8"

--- a/src/benches/memory.rs
+++ b/src/benches/memory.rs
@@ -1,4 +1,4 @@
-//! QMD Memory Store Benchmarks
+//! Memory Store Benchmarks
 //!
 //! Benchmarks for core memory operations:
 //! - Store open (cold start)
@@ -10,7 +10,7 @@
 #![allow(clippy::all)]
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use qmd::Store;
+use opencrabs::memory::Store;
 use tempfile::TempDir;
 
 /// Sample memory log content resembling real compaction summaries.
@@ -19,7 +19,7 @@ const SAMPLE_ENTRIES: &[&str] = &[
     "# Session Summary\n\nRefactored database connection pooling. Replaced manual connection management with sqlx pool. Added retry logic for transient connection failures.\n\n## Key Decisions\n- Using sqlx instead of diesel for async support\n- Pool size set to 10 connections\n- Retry up to 3 times with exponential backoff",
     "# Session Summary\n\nImplemented Discord bot integration. Added message handling, slash commands, and channel management. The bot uses serenity framework with gateway intents for message content.\n\n## Architecture\n- Event handler pattern for incoming messages\n- Command registry for slash commands\n- Rate limiting per user per channel",
     "# Session Summary\n\nDebugged memory leak in TUI rendering. The issue was caused by accumulating terminal buffers that were never freed. Fixed by implementing proper cleanup in the render loop.\n\n## Root Cause\n- Crossterm alternate screen buffers not being dropped\n- Fixed by adding explicit flush and cleanup on exit",
-    "# Session Summary\n\nAdded vector search capability using qmd crate. The FTS5 engine provides BM25 ranking for full-text search. Integrated as a library dependency replacing the CLI subprocess approach.\n\n## Performance\n- Sub-millisecond search latency\n- SHA-256 content hashing for dedup\n- Background reindex on startup",
+    "# Session Summary\n\nAdded vector search capability using the built-in memory store. The FTS5 engine provides BM25 ranking for full-text search. Integrated as an owned module replacing the CLI subprocess approach.\n\n## Performance\n- Sub-millisecond search latency\n- SHA-256 content hashing for dedup\n- Background reindex on startup",
     "# Session Summary\n\nOptimized context compaction algorithm. Reduced token usage by 40% through smarter summarization prompts. The compaction now preserves code snippets and error messages while condensing narrative.\n\n## Changes\n- New compaction prompt template\n- Preserve code blocks during summarization\n- Track token savings metrics",
     "# Session Summary\n\nImplemented Slack integration with OAuth2 flow. Added workspace installation, event subscriptions, and interactive message components. Uses slack-morphism crate.\n\n## Features\n- Slash command /opencrabs for invoking the agent\n- Thread-based conversations\n- File upload support for code review",
     "# Session Summary\n\nFixed CI pipeline failures. Updated GitHub Actions workflow to use latest Rust nightly for portable_simd. Added caching for Cargo dependencies to speed up builds.\n\n## Issues Resolved\n- nightly-2025-12 broke portable_simd API\n- Added wacore-binary patch for compatibility\n- Build time reduced from 12min to 4min",
@@ -282,13 +282,23 @@ fn bench_search_vec(c: &mut Criterion) {
             BenchmarkId::from_parameter(corpus_size),
             &corpus_size,
             |b, &n| {
-                let (store, _dir) = setup_store_with_embeddings(n);
+                let (store, dir) = setup_store_with_embeddings(n);
+                let db_path = dir.path().join("bench.db");
                 let mut query = vec![0.0f32; 768];
                 query[0] = 0.9;
                 query[1] = 0.5;
                 b.iter(|| {
-                    black_box(store.search_vec(&query, 5, Some("memory")).unwrap());
+                    black_box(
+                        opencrabs::memory::vector_search::search_chunks(
+                            &db_path,
+                            &query,
+                            5,
+                            Some("memory"),
+                        )
+                        .unwrap(),
+                    );
                 });
+                drop(store);
             },
         );
     }
@@ -298,9 +308,10 @@ fn bench_search_vec(c: &mut Criterion) {
 
 /// Benchmark: Hybrid search (FTS + vector → RRF) on a corpus with embeddings.
 fn bench_hybrid_rrf(c: &mut Criterion) {
-    use qmd::hybrid_search_rrf;
+    use opencrabs::memory::hybrid_search_rrf;
 
-    let (store, _dir) = setup_store_with_embeddings(50);
+    let (store, dir) = setup_store_with_embeddings(50);
+    let db_path = dir.path().join("bench.db");
     let mut query_emb = vec![0.0f32; 768];
     query_emb[0] = 0.9;
     query_emb[1] = 0.5;
@@ -310,7 +321,13 @@ fn bench_hybrid_rrf(c: &mut Criterion) {
             let fts = store
                 .search_fts("\"authentication\" \"database\"", 10, Some("memory"))
                 .unwrap();
-            let vec = store.search_vec(&query_emb, 10, Some("memory")).unwrap();
+            let vec = opencrabs::memory::vector_search::search_chunks(
+                &db_path,
+                &query_emb,
+                10,
+                Some("memory"),
+            )
+            .unwrap();
 
             let fts_tuples: Vec<_> = fts
                 .iter()
@@ -327,9 +344,9 @@ fn bench_hybrid_rrf(c: &mut Criterion) {
                 .iter()
                 .map(|r| {
                     (
-                        r.doc.path.clone(),
-                        r.doc.path.clone(),
-                        r.doc.title.clone(),
+                        r.path.clone(),
+                        r.path.clone(),
+                        r.title.clone(),
                         String::new(),
                     )
                 })
@@ -338,6 +355,7 @@ fn bench_hybrid_rrf(c: &mut Criterion) {
             black_box(hybrid_search_rrf(fts_tuples, vec_tuples, 60));
         });
     });
+    drop(store);
 }
 
 /// Benchmark: Insert embedding for a single document.

--- a/src/brain/tools/memory_search.rs
+++ b/src/brain/tools/memory_search.rs
@@ -1,6 +1,6 @@
 //! Memory Search Tool
 //!
-//! Searches past conversation compaction logs using the `qmd` crate's FTS5 engine.
+//! Searches past conversation compaction logs using the memory store's FTS5 engine.
 //! Always available — no external dependencies required.
 
 use super::error::Result;
@@ -8,7 +8,7 @@ use super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
 use async_trait::async_trait;
 use serde_json::Value;
 
-/// Memory search tool backed by the `qmd` crate's FTS5 engine.
+/// Memory search tool backed by the memory store's FTS5 engine.
 pub struct MemorySearchTool;
 
 #[async_trait]
@@ -89,7 +89,7 @@ impl Tool for MemorySearchTool {
             .and_then(|v| v.as_str())
             .unwrap_or("memory");
 
-        // Get memory qmd store
+        // Get the memory store
         let store = match crate::memory::get_store() {
             Ok(s) => s,
             Err(e) => {

--- a/src/memory/chunk_fts.rs
+++ b/src/memory/chunk_fts.rs
@@ -16,9 +16,9 @@
 //!   the single place that decides them, so recomputing them from the body
 //!   yields the same pieces the embedder used, and both halves agree without
 //!   storing anything twice.
-//! - qmd owns `documents_fts` through triggers on `documents`. Writing chunk
-//!   rows into it would couple us to a third-party schema, the same coupling
-//!   #998 deliberately avoided.
+//! - `documents_fts` is kept in sync by triggers on `documents`, one FTS row
+//!   per document. Writing chunk rows into it would double-store content and
+//!   fight the trigger-managed rowids.
 //!
 //! Scoring reuses `section_rank`, so chunk-level lexical matching inherits the
 //! stemming and diacritic folding rather than growing a second implementation

--- a/src/memory/chunker.rs
+++ b/src/memory/chunker.rs
@@ -1,15 +1,16 @@
 //! Split a document into overlapping chunks without ever cutting a character
 //! (#1002).
 //!
-//! Replaces `qmd::chunk_document`, which slices by byte index with no boundary
-//! check and panics on any multi-byte character landing near a chunk edge:
+//! The third-party chunker this replaced (qmd, dropped in #1028) sliced by
+//! byte index with no boundary check and panicked on any multi-byte character
+//! landing near a chunk edge:
 //!
 //! ```text
 //! start byte index 2240 is not a char boundary; it is inside '—'
 //! ```
 //!
-//! It applies `max_chars` to `content.len()`, which is bytes, then uses the
-//! result as a string index directly. Its break-point search does the same
+//! It applied `max_chars` to `content.len()`, which is bytes, then used the
+//! result as a string index directly, and its break-point search did the same
 //! with `slice.len() * 7 / 10`. An em dash, an accented letter, Cyrillic or an
 //! emoji anywhere near those offsets is enough, which describes most real
 //! content. The panic surfaced inside a tokio worker during backfill and took

--- a/src/memory/db.rs
+++ b/src/memory/db.rs
@@ -1,0 +1,584 @@
+//! Store — the memory database, owned by OpenCrabs.
+//!
+//! This replaced the `qmd` crate (qntx/qmd 0.3.2), which had not published a
+//! release since Feb 2026 while every defect it ever shipped was found and
+//! fixed on our side: byte-index chunking that panicked on multi-byte chars
+//! (#1002), vector search that only ever saw chunk 0 (#998), doc-level-only
+//! FTS (#1000). The audit (2026-08-12) mapped the entire surface we used —
+//! 13 Store methods — and this file is that surface, nothing more: no rerank,
+//! no generation, no collections admin, no llm_cache.
+//!
+//! The schema is qmd's verbatim on purpose. Every existing `memory.db` in the
+//! wild was created by qmd, and `vector_search.rs` reads these tables
+//! directly, so the DDL below IS the migration story: there isn't one.
+
+use rusqlite::{Connection, OptionalExtension, params};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+/// One indexed document row plus its body when loaded.
+#[derive(Debug, Clone)]
+pub struct DocumentResult {
+    pub collection_name: String,
+    pub path: String,
+    pub display_path: String,
+    pub title: String,
+    pub hash: String,
+    pub modified_at: String,
+    pub body: Option<String>,
+}
+
+/// A scored search hit.
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub doc: DocumentResult,
+    pub score: f64,
+}
+
+/// The database store: one connection per database file, owned by the caller
+/// behind a Mutex (see `super::store`).
+#[derive(Debug)]
+pub struct Store {
+    conn: Connection,
+    db_path: PathBuf,
+}
+
+impl Store {
+    /// Open (or create) the store at `db_path` and initialize the schema.
+    pub fn open(db_path: &Path) -> Result<Self, String> {
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create store dir: {e}"))?;
+        }
+
+        let conn = Connection::open(db_path)
+            .map_err(|e| format!("Failed to open {}: {e}", db_path.display()))?;
+
+        // WAL lets `vector_search` read on its own read-only connection
+        // while this one writes. The busy timeout covers the rare writer/
+        // snapshot overlap without changing any observable behavior.
+        conn.busy_timeout(std::time::Duration::from_secs(5))
+            .map_err(|e| format!("Failed to set busy timeout: {e}"))?;
+
+        let mut store = Self {
+            conn,
+            db_path: db_path.to_path_buf(),
+        };
+        store.initialize()?;
+        Ok(store)
+    }
+
+    /// Database file path.
+    #[must_use]
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    /// Schema DDL, byte-for-byte the one qmd 0.3.2 created. Do not "improve"
+    /// it casually: existing memory.db files and vector_search.rs depend on
+    /// exactly these tables, columns and triggers.
+    fn initialize(&mut self) -> Result<(), String> {
+        self.conn
+            .execute_batch(
+                r"
+            PRAGMA journal_mode = WAL;
+            PRAGMA foreign_keys = ON;
+
+            -- Content-addressable storage
+            CREATE TABLE IF NOT EXISTS content (
+                hash TEXT PRIMARY KEY,
+                doc TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+
+            -- Documents table
+            CREATE TABLE IF NOT EXISTS documents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                collection TEXT NOT NULL,
+                path TEXT NOT NULL,
+                title TEXT NOT NULL,
+                hash TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                modified_at TEXT NOT NULL,
+                active INTEGER NOT NULL DEFAULT 1,
+                FOREIGN KEY (hash) REFERENCES content(hash) ON DELETE CASCADE,
+                UNIQUE(collection, path)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_documents_collection ON documents(collection, active);
+            CREATE INDEX IF NOT EXISTS idx_documents_hash ON documents(hash);
+            CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path, active);
+
+            -- FTS index
+            CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
+                filepath, title, body,
+                tokenize='porter unicode61'
+            );
+
+            -- Content vectors metadata
+            CREATE TABLE IF NOT EXISTS content_vectors (
+                hash TEXT NOT NULL,
+                seq INTEGER NOT NULL DEFAULT 0,
+                pos INTEGER NOT NULL DEFAULT 0,
+                model TEXT NOT NULL,
+                embedded_at TEXT NOT NULL,
+                PRIMARY KEY (hash, seq)
+            );
+            ",
+            )
+            .map_err(|e| format!("Failed to initialize schema: {e}"))?;
+
+        self.create_fts_triggers()
+    }
+
+    /// FTS5 external-content sync triggers. Copied verbatim from qmd: the
+    /// FTS index is keyed by documents.id (rowid) and mirrors active rows.
+    fn create_fts_triggers(&self) -> Result<(), String> {
+        let trigger_exists: bool = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='trigger' AND name='documents_ai'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+
+        if !trigger_exists {
+            self.conn
+                .execute_batch(
+                    r"
+                CREATE TRIGGER IF NOT EXISTS documents_ai AFTER INSERT ON documents
+                WHEN new.active = 1
+                BEGIN
+                    INSERT INTO documents_fts(rowid, filepath, title, body)
+                    SELECT
+                        new.id,
+                        new.collection || '/' || new.path,
+                        new.title,
+                        (SELECT doc FROM content WHERE hash = new.hash)
+                    WHERE new.active = 1;
+                END;
+
+                CREATE TRIGGER IF NOT EXISTS documents_ad AFTER DELETE ON documents BEGIN
+                    DELETE FROM documents_fts WHERE rowid = old.id;
+                END;
+
+                CREATE TRIGGER IF NOT EXISTS documents_au AFTER UPDATE ON documents
+                BEGIN
+                    DELETE FROM documents_fts WHERE rowid = old.id AND new.active = 0;
+                    INSERT OR REPLACE INTO documents_fts(rowid, filepath, title, body)
+                    SELECT
+                        new.id,
+                        new.collection || '/' || new.path,
+                        new.title,
+                        (SELECT doc FROM content WHERE hash = new.hash)
+                    WHERE new.active = 1;
+                END;
+                ",
+                )
+                .map_err(|e| format!("Failed to create FTS triggers: {e}"))?;
+        }
+
+        Ok(())
+    }
+
+    /// Hash content using SHA256. Must stay byte-compatible with hashes
+    /// already stored (they are the foreign keys into `content`).
+    #[must_use]
+    pub fn hash_content(content: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(content.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+
+    /// Extract title from markdown content (first `#` or `##` heading).
+    #[must_use]
+    pub fn extract_title(content: &str) -> String {
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("# ") {
+                return rest.trim().to_string();
+            }
+            if let Some(rest) = trimmed.strip_prefix("## ") {
+                return rest.trim().to_string();
+            }
+        }
+        String::new()
+    }
+
+    /// Insert content into content-addressable storage.
+    pub fn insert_content(&self, hash: &str, content: &str, created_at: &str) -> Result<(), String> {
+        self.conn
+            .execute(
+                "INSERT OR IGNORE INTO content (hash, doc, created_at) VALUES (?1, ?2, ?3)",
+                params![hash, content, created_at],
+            )
+            .map_err(|e| format!("insert_content: {e}"))?;
+        Ok(())
+    }
+
+    /// Insert (or reactivate/update) a document record.
+    pub fn insert_document(
+        &self,
+        collection: &str,
+        path: &str,
+        title: &str,
+        hash: &str,
+        created_at: &str,
+        modified_at: &str,
+    ) -> Result<(), String> {
+        self.conn
+            .execute(
+                r"
+            INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)
+            ON CONFLICT(collection, path) DO UPDATE SET
+                title = excluded.title,
+                hash = excluded.hash,
+                modified_at = excluded.modified_at,
+                active = 1
+            ",
+                params![collection, path, title, hash, created_at, modified_at],
+            )
+            .map_err(|e| format!("insert_document: {e}"))?;
+        Ok(())
+    }
+
+    /// Find an active document by collection and path.
+    pub fn find_active_document(
+        &self,
+        collection: &str,
+        path: &str,
+    ) -> Result<Option<(i64, String, String)>, String> {
+        self.conn
+            .query_row(
+                "SELECT id, hash, title FROM documents WHERE collection = ?1 AND path = ?2 AND active = 1",
+                params![collection, path],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()
+            .map_err(|e| format!("find_active_document: {e}"))
+    }
+
+    /// Deactivate a document (soft delete; the FTS trigger drops the row).
+    pub fn deactivate_document(&self, collection: &str, path: &str) -> Result<(), String> {
+        self.conn
+            .execute(
+                "UPDATE documents SET active = 0 WHERE collection = ?1 AND path = ?2",
+                params![collection, path],
+            )
+            .map_err(|e| format!("deactivate_document: {e}"))?;
+        Ok(())
+    }
+
+    /// All active document paths in a collection.
+    pub fn get_active_document_paths(&self, collection: &str) -> Result<Vec<String>, String> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT path FROM documents WHERE collection = ?1 AND active = 1")
+            .map_err(|e| format!("get_active_document_paths: {e}"))?;
+        let paths = stmt
+            .query_map(params![collection], |row| row.get(0))
+            .map_err(|e| format!("get_active_document_paths: {e}"))?
+            .collect::<Result<Vec<String>, _>>()
+            .map_err(|e| format!("get_active_document_paths: {e}"))?;
+        Ok(paths)
+    }
+
+    /// Load one active document with its full body.
+    pub fn get_document(
+        &self,
+        collection: &str,
+        path: &str,
+    ) -> Result<Option<DocumentResult>, String> {
+        self.conn
+            .query_row(
+                r"
+                SELECT
+                    d.title,
+                    d.hash,
+                    d.modified_at,
+                    c.doc,
+                    LENGTH(c.doc) as body_length
+                FROM documents d
+                JOIN content c ON c.hash = d.hash
+                WHERE d.collection = ?1 AND d.path = ?2 AND d.active = 1
+                ",
+                params![collection, path],
+                |row| {
+                    let title: String = row.get(0)?;
+                    let hash: String = row.get(1)?;
+                    let modified_at: String = row.get(2)?;
+                    let body: String = row.get(3)?;
+
+                    Ok(DocumentResult {
+                        collection_name: collection.to_string(),
+                        path: path.to_string(),
+                        display_path: format!("{collection}/{path}"),
+                        title,
+                        hash,
+                        modified_at,
+                        body: Some(body),
+                    })
+                },
+            )
+            .optional()
+            .map_err(|e| format!("get_document: {e}"))
+    }
+
+    /// Full-text search (BM25) over active documents, optionally restricted
+    /// to one collection. Scores are negated bm25(): higher is better.
+    pub fn search_fts(
+        &self,
+        query: &str,
+        limit: usize,
+        collection: Option<&str>,
+    ) -> Result<Vec<SearchResult>, String> {
+        let sql = if collection.is_some() {
+            r"
+            SELECT
+                d.collection,
+                d.path,
+                d.title,
+                d.hash,
+                d.modified_at,
+                bm25(documents_fts) as score
+            FROM documents_fts fts
+            JOIN documents d ON d.id = fts.rowid
+            JOIN content c ON c.hash = d.hash
+            WHERE documents_fts MATCH ?1
+              AND d.collection = ?2
+              AND d.active = 1
+            ORDER BY score
+            LIMIT ?3
+            "
+        } else {
+            r"
+            SELECT
+                d.collection,
+                d.path,
+                d.title,
+                d.hash,
+                d.modified_at,
+                bm25(documents_fts) as score
+            FROM documents_fts fts
+            JOIN documents d ON d.id = fts.rowid
+            JOIN content c ON c.hash = d.hash
+            WHERE documents_fts MATCH ?1
+              AND d.active = 1
+            ORDER BY score
+            LIMIT ?2
+            "
+        };
+
+        let mut stmt = self
+            .conn
+            .prepare(sql)
+            .map_err(|e| format!("search_fts prepare: {e}"))?;
+
+        let map_row = |row: &rusqlite::Row| -> rusqlite::Result<SearchResult> {
+            let collection_name: String = row.get(0)?;
+            let path: String = row.get(1)?;
+            let title: String = row.get(2)?;
+            let hash: String = row.get(3)?;
+            let modified_at: String = row.get(4)?;
+            let score: f64 = row.get(5)?;
+
+            Ok(SearchResult {
+                doc: DocumentResult {
+                    collection_name: collection_name.clone(),
+                    display_path: format!("{collection_name}/{path}"),
+                    path: path.clone(),
+                    title,
+                    hash,
+                    modified_at,
+                    body: None,
+                },
+                // BM25 returns negative scores; negate so higher is better.
+                score: -score,
+            })
+        };
+
+        let results: Vec<SearchResult> = if let Some(coll) = collection {
+            stmt.query_map(params![query, coll, limit as i64], map_row)
+        } else {
+            stmt.query_map(params![query, limit as i64], map_row)
+        }
+        .map_err(|e| format!("search_fts: {e}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("search_fts: {e}"))?;
+
+        Ok(results)
+    }
+
+    /// Create the vector blob table (only when embeddings are enabled).
+    /// Dimensions are not enforced in the schema; rows carry whatever the
+    /// configured backend produced.
+    pub fn ensure_vector_table(&self, _dimensions: usize) -> Result<(), String> {
+        self.conn
+            .execute(
+                r"
+                CREATE TABLE IF NOT EXISTS vectors_vec (
+                    hash_seq TEXT PRIMARY KEY,
+                    embedding BLOB NOT NULL
+                )
+                ",
+                [],
+            )
+            .map_err(|e| format!("ensure_vector_table: {e}"))?;
+        Ok(())
+    }
+
+    /// Insert (or replace) an embedding for one chunk of a content hash.
+    /// `hash_seq` is `{hash}_{seq}` — the key format `vector_search.rs`
+    /// reads, so it must not change.
+    pub fn insert_embedding(
+        &self,
+        hash: &str,
+        seq: usize,
+        pos: usize,
+        embedding: &[f32],
+        model: &str,
+        embedded_at: &str,
+    ) -> Result<(), String> {
+        self.conn
+            .execute(
+                r"
+            INSERT OR REPLACE INTO content_vectors (hash, seq, pos, model, embedded_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ",
+                params![hash, seq as i64, pos as i64, model, embedded_at],
+            )
+            .map_err(|e| format!("insert_embedding metadata: {e}"))?;
+
+        let hash_seq = format!("{hash}_{seq}");
+        let embedding_bytes: Vec<u8> = embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
+
+        self.conn
+            .execute(
+                "INSERT OR REPLACE INTO vectors_vec (hash_seq, embedding) VALUES (?1, ?2)",
+                params![hash_seq, embedding_bytes],
+            )
+            .map_err(|e| format!("insert_embedding blob: {e}"))?;
+
+        Ok(())
+    }
+
+    /// Active documents with no `seq = 0` vector row yet: (hash, path, body).
+    pub fn get_hashes_needing_embedding(&self) -> Result<Vec<(String, String, String)>, String> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                r"
+            SELECT DISTINCT d.hash, d.path, c.doc
+            FROM documents d
+            JOIN content c ON c.hash = d.hash
+            LEFT JOIN content_vectors v ON d.hash = v.hash AND v.seq = 0
+            WHERE d.active = 1 AND v.hash IS NULL
+            ",
+            )
+            .map_err(|e| format!("get_hashes_needing_embedding: {e}"))?;
+
+        let results = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .map_err(|e| format!("get_hashes_needing_embedding: {e}"))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("get_hashes_needing_embedding: {e}"))?;
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store() -> (Store, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&dir.path().join("memory.db")).unwrap();
+        (store, dir)
+    }
+
+    #[test]
+    fn hash_is_sha256_hex() {
+        // Same input qmd hashed for every existing memory.db row.
+        let h = Store::hash_content("hello");
+        assert_eq!(
+            h,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn roundtrip_document_and_fts() {
+        let (store, _dir) = temp_store();
+        let body = "# Title One\n\nthe quick brown fox jumps over the lazy dog";
+        let hash = Store::hash_content(body);
+
+        store.insert_content(&hash, body, "now").unwrap();
+        store
+            .insert_document("memory", "a.md", "Title One", &hash, "now", "now")
+            .unwrap();
+
+        let found = store.find_active_document("memory", "a.md").unwrap();
+        assert_eq!(found.unwrap().1, hash);
+
+        let hits = store.search_fts("\"fox\"", 10, None).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].doc.path, "a.md");
+        assert!(hits[0].score > 0.0);
+
+        // Collection filter excludes other collections.
+        let brain_hits = store.search_fts("\"fox\"", 10, Some("brain")).unwrap();
+        assert!(brain_hits.is_empty());
+
+        let doc = store.get_document("memory", "a.md").unwrap().unwrap();
+        assert_eq!(doc.body.as_deref(), Some(body));
+    }
+
+    #[test]
+    fn deactivate_removes_from_fts() {
+        let (store, _dir) = temp_store();
+        let body = "uniqueword for deactivation test";
+        let hash = Store::hash_content(body);
+        store.insert_content(&hash, body, "now").unwrap();
+        store
+            .insert_document("memory", "b.md", "", &hash, "now", "now")
+            .unwrap();
+        assert_eq!(store.search_fts("\"uniqueword\"", 10, None).unwrap().len(), 1);
+
+        store.deactivate_document("memory", "b.md").unwrap();
+        assert_eq!(store.search_fts("\"uniqueword\"", 10, None).unwrap().len(), 0);
+        assert!(store.find_active_document("memory", "b.md").unwrap().is_none());
+    }
+
+    #[test]
+    fn embedding_roundtrip_and_backfill_list() {
+        let (store, _dir) = temp_store();
+        let body = "embed me";
+        let hash = Store::hash_content(body);
+        store.insert_content(&hash, body, "now").unwrap();
+        store
+            .insert_document("memory", "c.md", "", &hash, "now", "now")
+            .unwrap();
+
+        // Needs embedding: no seq-0 row yet.
+        let needing = store.get_hashes_needing_embedding().unwrap();
+        assert_eq!(needing.len(), 1);
+        assert_eq!(needing[0].0, hash);
+
+        store.ensure_vector_table(4).unwrap();
+        store
+            .insert_embedding(&hash, 0, 0, &[0.1, 0.2, 0.3, 0.4], "test-model", "now")
+            .unwrap();
+
+        assert!(store.get_hashes_needing_embedding().unwrap().is_empty());
+    }
+
+    #[test]
+    fn title_extraction() {
+        assert_eq!(Store::extract_title("# Hello\nbody"), "Hello");
+        assert_eq!(Store::extract_title("intro\n## Sub\nbody"), "Sub");
+        assert_eq!(Store::extract_title("no heading here"), "");
+    }
+}

--- a/src/memory/embedding.rs
+++ b/src/memory/embedding.rs
@@ -6,8 +6,9 @@
 //!
 //! The API path eliminates the model download and ~2.9GB RAM overhead.
 
+use super::db::Store;
+use super::local_engine::{DEFAULT_EMBED_MODEL_URI, EmbeddingEngine, pull_model};
 use once_cell::sync::OnceCell;
-use qmd::{EmbeddingEngine, Store, pull_model};
 use std::sync::Mutex;
 
 static ENGINE: OnceCell<Mutex<EmbeddingEngine>> = OnceCell::new();
@@ -51,7 +52,7 @@ pub fn get_engine() -> Result<&'static Mutex<EmbeddingEngine>, String> {
         // Progress is still logged via tracing, so no UX regression.
         let _fd_guard = crate::utils::fd_suppress::suppress_stdio();
 
-        let pull = pull_model(qmd::llm::DEFAULT_EMBED_MODEL_URI, false)
+        let pull = pull_model(DEFAULT_EMBED_MODEL_URI, false)
             .map_err(|e| format!("Failed to pull embedding model: {e}"))?;
 
         let engine = EmbeddingEngine::new(&pull.path)
@@ -106,22 +107,21 @@ const MAX_EMBED_BYTES: usize = 32_000;
 /// single averaged vector, so a document covering several topics landed as one
 /// meaningless point in embedding space.
 ///
-/// Chunking itself is ours rather than qmd's: `qmd::chunk_document` slices by
-/// byte index with no boundary check and panics on any multi-byte character
-/// near a chunk edge (#1002), which an em dash is enough to trigger.
+/// Chunking itself is ours: byte-index slicing without a boundary check
+/// panics on any multi-byte character near a chunk edge (#1002), which an
+/// em dash is enough to trigger.
 pub(crate) fn chunks_for(body: &str) -> Vec<super::chunker::Chunk> {
     super::chunker::chunk_document(body, CHUNK_SIZE_CHARS, CHUNK_OVERLAP_CHARS)
 }
 
 /// Target chunk size in characters, and the overlap between neighbours.
 ///
-/// Mirrors qmd's own defaults (800 tokens at roughly 4 characters per token,
-/// with a 15% overlap) but declared here because qmd does not re-export the
-/// character-based constants, and because these are the two numbers a
+/// 800 tokens at roughly 4 characters per token, with a 15% overlap: the
+/// numbers every stored vector was produced with, and the two numbers a
 /// retrieval eval would tune. Overlap exists so a passage split across a
 /// boundary is still wholly present in one chunk.
-const CHUNK_SIZE_CHARS: usize = qmd::CHUNK_SIZE_TOKENS * 4;
-const CHUNK_OVERLAP_CHARS: usize = qmd::CHUNK_OVERLAP_TOKENS * 4;
+const CHUNK_SIZE_CHARS: usize = 3200;
+const CHUNK_OVERLAP_CHARS: usize = 480;
 
 /// Generate and store an embedding for content.
 ///
@@ -365,7 +365,7 @@ pub async fn embed_via_api(text: &str) -> Result<Vec<f32>, String> {
         .ok_or_else(|| "Embedding API returned no data".to_string())
 }
 
-/// Embed content via the API and store in the qmd database.
+/// Embed content via the API and store it in the memory database.
 ///
 /// Async counterpart of `embed_content` for the API path.
 pub async fn embed_content_api(store: &'static Mutex<Store>, body: &str) -> Result<(), String> {

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -1,6 +1,6 @@
-//! Indexing — insert memory/brain files into the qmd store and generate embeddings.
+//! Indexing — insert memory/brain files into the memory store and generate embeddings.
 
-use qmd::Store;
+use super::db::Store;
 use std::path::Path;
 use std::sync::Mutex;
 
@@ -20,7 +20,7 @@ pub const BRAIN_FILES: &[&str] = &[
     "HEARTBEAT.md",
 ];
 
-/// Index a single `.md` file into the qmd store under the `"memory"` collection.
+/// Index a single `.md` file into the memory store under the right collection.
 ///
 /// Skips re-indexing if the file's SHA-256 hash hasn't changed.
 /// Generates an embedding when the engine is already initialized.

--- a/src/memory/local_engine.rs
+++ b/src/memory/local_engine.rs
@@ -1,0 +1,365 @@
+//! Local GGUF embedding engine — llama-cpp-2, owned by OpenCrabs.
+//!
+//! This replaced `qmd::llm` when the qmd crate was dropped (#1028). It is
+//! deliberately the same engine qmd wrapped: same model, same prompt
+//! templates, same context-sizing logic, same HuggingFace cache directory.
+//! A user upgrading from a qmd-built release keeps their ~300MB model
+//! download and gets bit-identical embeddings, so existing vectors in
+//! memory.db stay comparable with new ones.
+//!
+//! What was NOT copied: rerank, generation, query expansion, progress bars
+//! (callers already suppress stdio and log via tracing), session management.
+
+use llama_cpp_2::context::params::LlamaContextParams;
+use llama_cpp_2::llama_backend::LlamaBackend;
+use llama_cpp_2::llama_batch::LlamaBatch;
+use llama_cpp_2::model::params::LlamaModelParams;
+use llama_cpp_2::model::{AddBos, LlamaModel};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Default embedding model file name.
+pub const DEFAULT_EMBED_MODEL: &str = "embeddinggemma-300M-Q8_0.gguf";
+
+/// HuggingFace URI for the default embedding model.
+pub const DEFAULT_EMBED_MODEL_URI: &str =
+    "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+
+/// Result of an embedding operation.
+#[derive(Debug, Clone)]
+pub struct EmbeddingResult {
+    /// The embedding vector.
+    pub embedding: Vec<f32>,
+    /// Model name used.
+    pub model: String,
+}
+
+/// Result of a model pull.
+#[derive(Debug, Clone)]
+pub struct PullResult {
+    /// The model URI requested.
+    pub model: String,
+    /// Local path of the model file.
+    pub path: PathBuf,
+    /// Size on disk in bytes.
+    pub size_bytes: u64,
+}
+
+/// The embedding engine: a loaded GGUF model behind llama.cpp.
+///
+/// Not Send-friendly by itself; callers hold it in a Mutex (see
+/// `super::embedding`). Each embed call creates a context sized for the
+/// input, which is what makes arbitrary-length chunks safe together with
+/// the caller-side byte cap.
+#[derive(Debug)]
+pub struct EmbeddingEngine {
+    backend: LlamaBackend,
+    model: Arc<LlamaModel>,
+    dimensions: Option<usize>,
+}
+
+impl EmbeddingEngine {
+    /// Load a GGUF model from disk.
+    pub fn new(model_path: &Path) -> Result<Self, String> {
+        let backend = LlamaBackend::init().map_err(|e| format!("llama backend init: {e}"))?;
+
+        let model_params = LlamaModelParams::default();
+        let model = LlamaModel::load_from_file(&backend, model_path, &model_params)
+            .map_err(|e| format!("Failed to load model {}: {e}", model_path.display()))?;
+
+        Ok(Self {
+            backend,
+            model: Arc::new(model),
+            dimensions: None,
+        })
+    }
+
+    /// Embed a document chunk, with its title riding along.
+    pub fn embed_document(&mut self, text: &str, title: Option<&str>) -> Result<EmbeddingResult, String> {
+        let formatted = format_doc_for_embedding(text, title);
+        self.embed_raw(&formatted)
+    }
+
+    /// Embed a search query.
+    pub fn embed_query(&mut self, query: &str) -> Result<EmbeddingResult, String> {
+        let formatted = format_query_for_embedding(query);
+        self.embed_raw(&formatted)
+    }
+
+    /// Raw embedding generation.
+    fn embed_raw(&mut self, text: &str) -> Result<EmbeddingResult, String> {
+        // Tokenize first to size the context (n_ubatch must be >= n_tokens
+        // for encoder models).
+        let tokens = self
+            .model
+            .str_to_token(text, AddBos::Always)
+            .map_err(|e| format!("Failed to tokenize text: {e}"))?;
+
+        if tokens.is_empty() {
+            return Err("Empty token sequence".to_string());
+        }
+
+        // Pad for the BOS token and keep a sane floor.
+        let n_ctx = std::cmp::max(tokens.len() + 64, 512);
+        let ctx_params = LlamaContextParams::default()
+            .with_embeddings(true)
+            .with_n_ctx(std::num::NonZero::new(n_ctx as u32))
+            .with_n_batch(n_ctx as u32)
+            .with_n_ubatch(n_ctx as u32);
+
+        let mut ctx = self
+            .model
+            .new_context(&self.backend, ctx_params)
+            .map_err(|e| format!("Failed to create context: {e}"))?;
+
+        let mut batch = LlamaBatch::new(tokens.len(), 1);
+        for (i, token) in tokens.iter().enumerate() {
+            let is_last = i == tokens.len() - 1;
+            batch
+                .add(*token, i as i32, &[0], is_last)
+                .map_err(|e| format!("Failed to add token to batch: {e}"))?;
+        }
+
+        ctx.decode(&mut batch)
+            .map_err(|e| format!("Failed to decode batch: {e}"))?;
+
+        let embeddings = ctx
+            .embeddings_seq_ith(0)
+            .map_err(|e| format!("Failed to get embeddings: {e}"))?;
+
+        if self.dimensions.is_none() {
+            self.dimensions = Some(embeddings.len());
+        }
+
+        Ok(EmbeddingResult {
+            embedding: embeddings.to_vec(),
+            model: DEFAULT_EMBED_MODEL.to_string(),
+        })
+    }
+
+    /// The embedding dimensions, known after the first embed.
+    #[must_use]
+    pub const fn dimensions(&self) -> Option<usize> {
+        self.dimensions
+    }
+}
+
+/// Document template: the title rides with the text so a chunk lifted out of
+/// the middle of a document still knows what it belongs to. Must stay
+/// byte-identical to what produced the existing vectors.
+#[must_use]
+pub fn format_doc_for_embedding(text: &str, title: Option<&str>) -> String {
+    let title_str = title.unwrap_or("none");
+    format!("title: {title_str} | text: {text}")
+}
+
+/// Query template (nomic-style). Must stay byte-identical: queries and
+/// documents live in the same embedding space only if both sides keep the
+/// template.
+#[must_use]
+pub fn format_query_for_embedding(query: &str) -> String {
+    format!("task: search result | query: {query}")
+}
+
+// ---------------------------------------------------------------------------
+// Model download
+// ---------------------------------------------------------------------------
+
+/// Model cache directory. Deliberately qmd's path: installs upgrading from a
+/// qmd-built release already have the ~300MB model here, and re-downloading
+/// it would be pure waste.
+fn model_cache_dir() -> PathBuf {
+    let cache_dir = dirs::cache_dir().unwrap_or_else(|| PathBuf::from("."));
+    let model_dir = cache_dir.join("qmd").join("models");
+    let _ = std::fs::create_dir_all(&model_dir);
+    model_dir
+}
+
+struct HfRef {
+    repo: String,
+    file: String,
+}
+
+/// Parse a HuggingFace URI like "hf:user/repo/file.gguf".
+fn parse_hf_uri(uri: &str) -> Option<HfRef> {
+    let without_prefix = uri.strip_prefix("hf:")?;
+    let parts: Vec<&str> = without_prefix.splitn(3, '/').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    Some(HfRef {
+        repo: format!("{}/{}", parts[0], parts[1]),
+        file: parts[2].to_string(),
+    })
+}
+
+/// Remote ETag for cache validation.
+fn get_remote_etag(hf: &HfRef) -> Option<String> {
+    let url = format!("https://huggingface.co/{}/resolve/main/{}", hf.repo, hf.file);
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .ok()?;
+
+    let resp = client.head(&url).send().ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+
+    resp.headers()
+        .get("etag")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim_matches('"').to_string())
+}
+
+/// Download a model file from HuggingFace, streaming to disk.
+fn download_from_hf(hf: &HfRef, local_path: &Path, etag_path: &Path) -> Result<(), String> {
+    use std::io::{Read, Write};
+
+    let url = format!("https://huggingface.co/{}/resolve/main/{}", hf.repo, hf.file);
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(3600))
+        .build()
+        .map_err(|e| format!("Failed to build download client: {e}"))?;
+
+    let mut resp = client
+        .get(&url)
+        .send()
+        .map_err(|e| format!("Failed to download {url}: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("Failed to download {url}: HTTP {}", resp.status()));
+    }
+
+    let total_size = resp.content_length().unwrap_or(0);
+    tracing::info!("Downloading {} ({} MB)", hf.file, total_size / 1_048_576);
+
+    let mut file = std::fs::File::create(local_path)
+        .map_err(|e| format!("Failed to create {}: {e}", local_path.display()))?;
+    let mut downloaded: u64 = 0;
+    let mut buffer = [0u8; 8192];
+    let mut last_log_mb: u64 = 0;
+
+    loop {
+        let bytes_read = resp
+            .read(&mut buffer)
+            .map_err(|e| format!("Download read failed: {e}"))?;
+        if bytes_read == 0 {
+            break;
+        }
+        file.write_all(&buffer[..bytes_read])
+            .map_err(|e| format!("Download write failed: {e}"))?;
+        downloaded += bytes_read as u64;
+
+        // Progress via tracing every 25 MB; stdio is suppressed by the
+        // caller while the TUI owns the terminal.
+        let mb = downloaded / 1_048_576;
+        if mb / 25 > last_log_mb / 25 {
+            last_log_mb = mb;
+            if total_size > 0 {
+                tracing::info!(
+                    "Model download: {} / {} MB",
+                    mb,
+                    total_size / 1_048_576
+                );
+            }
+        }
+    }
+
+    // Save ETag for cache validation on next pull.
+    if let Some(etag) = resp.headers().get("etag")
+        && let Ok(etag_str) = etag.to_str()
+    {
+        let _ = std::fs::write(etag_path, etag_str.trim_matches('"'));
+    }
+
+    tracing::info!("Downloaded {} ({} MB)", hf.file, downloaded / 1_048_576);
+    Ok(())
+}
+
+/// Pull a model: download if missing or if the remote ETag moved.
+///
+/// `refresh = true` forces a re-download. Returns the local path either way.
+pub fn pull_model(model_uri: &str, refresh: bool) -> Result<PullResult, String> {
+    let cache_dir = model_cache_dir();
+
+    let hf_ref = parse_hf_uri(model_uri);
+    let filename = match hf_ref {
+        Some(ref hf) => hf.file.clone(),
+        None => model_uri.to_string(),
+    };
+
+    let local_path = cache_dir.join(&filename);
+    let etag_path = cache_dir.join(format!("{filename}.etag"));
+
+    let should_download = refresh
+        || !local_path.exists()
+        || matches!(&hf_ref, Some(hf) if {
+            // Check ETag for updates.
+            let remote_etag = get_remote_etag(hf);
+            let local_etag = std::fs::read_to_string(&etag_path).ok();
+            remote_etag.is_some() && remote_etag != local_etag
+        });
+
+    if should_download {
+        match hf_ref {
+            Some(ref hf) => download_from_hf(hf, &local_path, &etag_path)?,
+            None => {
+                return Err(format!(
+                    "Model not found and no HuggingFace URI provided: {model_uri}"
+                ))
+            }
+        }
+    }
+
+    let size_bytes = std::fs::metadata(&local_path).map_or(0, |m| m.len());
+
+    Ok(PullResult {
+        model: model_uri.to_string(),
+        path: local_path,
+        size_bytes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doc_template_is_stable() {
+        // These exact bytes produced every vector currently stored.
+        assert_eq!(
+            format_doc_for_embedding("hello world", Some("Test Title")),
+            "title: Test Title | text: hello world"
+        );
+        assert_eq!(
+            format_doc_for_embedding("hello world", None),
+            "title: none | text: hello world"
+        );
+    }
+
+    #[test]
+    fn query_template_is_stable() {
+        assert_eq!(
+            format_query_for_embedding("test query"),
+            "task: search result | query: test query"
+        );
+    }
+
+    #[test]
+    fn parse_hf_uri_shapes() {
+        let r = parse_hf_uri(DEFAULT_EMBED_MODEL_URI).unwrap();
+        assert_eq!(r.repo, "ggml-org/embeddinggemma-300M-GGUF");
+        assert_eq!(r.file, DEFAULT_EMBED_MODEL);
+        assert!(parse_hf_uri("not-a-uri").is_none());
+        assert!(parse_hf_uri("hf:only/two").is_none());
+    }
+
+    #[test]
+    fn cache_dir_is_qmds() {
+        // Upgrading installs must NOT re-download the model.
+        let dir = model_cache_dir();
+        assert!(dir.ends_with("qmd/models"), "got {}", dir.display());
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,14 +1,17 @@
 //! Memory Module
 //!
-//! Provides long-term memory search via the `qmd` crate's FTS5 engine and
-//! vector semantic search (embeddinggemma-300M). Hybrid RRF when the model
-//! is available, FTS-only fallback otherwise.
+//! Provides long-term memory search via our own SQLite FTS5 store
+//! (`db.rs`) and vector semantic search (embeddinggemma-300M, local GGUF
+//! via `local_engine.rs` or an OpenAI-compatible embedding API). Hybrid
+//! RRF when embeddings are available, FTS-only fallback otherwise.
 //!
 //! When `config.memory.vector_enabled` is false, all vector/embedding code
 //! is skipped — no model download, no llama.cpp init, FTS5-only search.
 
+pub(crate) mod db;
 pub(crate) mod embedding;
 pub mod index;
+pub(crate) mod local_engine;
 pub(crate) mod search;
 pub(crate) mod store;
 
@@ -20,8 +23,9 @@ pub(crate) mod chunker;
 pub mod vector_search;
 
 pub mod freshness;
+pub use db::Store;
 pub use index::{BRAIN_FILES, index_file, index_file_fts_only, reindex};
-pub use search::{search, search_brain};
+pub use search::{RrfResult, hybrid_search_rrf, search, search_brain};
 pub use store::get_store;
 
 /// Whether vector embeddings are enabled in the current config.

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -1,6 +1,6 @@
 //! Search — hybrid FTS5 + vector search via Reciprocal Rank Fusion.
 
-use qmd::{SearchResult, Store, hybrid_search_rrf};
+use super::db::{SearchResult, Store};
 use std::path::Path;
 use std::sync::Mutex;
 
@@ -66,9 +66,9 @@ pub async fn search(
 
         // Hybrid path: combine FTS + vector results via Reciprocal Rank Fusion
         if let Some(ref query_emb) = query_embedding {
-            // Chunk-aware (#998). qmd's own `search_vec` joins on `hash || '_0'`
-            // and therefore only ever sees a document's first chunk, which would
-            // make chunked embeddings write-only.
+            // Chunk-aware (#998): a vector search that joins on
+            // `hash || '_0'` only ever sees a document's first chunk, which
+            // would make chunked embeddings write-only.
             let db_path = super::store::memory_dir().join("memory.db");
             let vec_hits = super::vector_search::search_chunks(&db_path, query_emb, n, None)
                 .unwrap_or_default();
@@ -287,4 +287,117 @@ pub(crate) fn extract_snippet(body: &str, query: &str, max_len: usize) -> String
     }
 
     snippet
+}
+
+// ---------------------------------------------------------------------------
+// Reciprocal Rank Fusion
+// ---------------------------------------------------------------------------
+
+/// One fused hybrid-search hit.
+pub struct RrfResult {
+    pub file: String,
+    pub display_path: String,
+    pub title: String,
+    pub body: String,
+    pub score: f64,
+}
+
+/// Combine two ranked lists (FTS, vector) with Reciprocal Rank Fusion.
+///
+/// RRF score = sum(weight / (k + rank + 1)) across the lists a document
+/// appears in; k=60 is the standard balance between top and lower ranks.
+/// Position-aware bonuses protect top retrieval results from disagreement
+/// between the two halves: rank 1-3 get 0.08, rank 4-10 get 0.04, rank
+/// 11-20 get 0.01. These numbers are ranking behavior, not decoration —
+/// they shipped with the first hybrid search and stayed.
+pub fn hybrid_search_rrf(
+    fts_results: Vec<(String, String, String, String)>,
+    vec_results: Vec<(String, String, String, String)>,
+    k: usize,
+) -> Vec<RrfResult> {
+    use std::collections::HashMap;
+
+    let mut scores: HashMap<String, (f64, String, String, String, usize)> = HashMap::new();
+
+    for results in [fts_results, vec_results] {
+        for (rank, (file, display_path, title, body)) in results.iter().enumerate() {
+            let rrf_score = 1.0 / (k + rank + 1) as f64;
+
+            scores
+                .entry(file.clone())
+                .and_modify(|(score, _, _, _, best_rank)| {
+                    *score += rrf_score;
+                    *best_rank = (*best_rank).min(rank);
+                })
+                .or_insert((
+                    rrf_score,
+                    display_path.clone(),
+                    title.clone(),
+                    body.clone(),
+                    rank,
+                ));
+        }
+    }
+
+    let mut results: Vec<RrfResult> = scores
+        .into_iter()
+        .map(|(file, (score, display_path, title, body, best_rank))| {
+            let bonus = match best_rank {
+                0..=2 => 0.08,   // Top 3: high protection
+                3..=9 => 0.04,   // Rank 4-10: medium protection
+                10..=19 => 0.01, // Rank 11-20: low protection
+                _ => 0.0,
+            };
+
+            RrfResult {
+                file,
+                display_path,
+                title,
+                body,
+                score: score + bonus,
+            }
+        })
+        .collect();
+
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}
+
+#[cfg(test)]
+mod rrf_tests {
+    use super::*;
+
+    fn hit(file: &str) -> (String, String, String, String) {
+        (
+            file.to_string(),
+            file.to_string(),
+            format!("title of {file}"),
+            format!("body of {file}"),
+        )
+    }
+
+    #[test]
+    fn rrf_prefers_docs_in_both_lists() {
+        let fts = vec![hit("a.md"), hit("b.md")];
+        let vec = vec![hit("b.md"), hit("c.md")];
+        let fused = hybrid_search_rrf(fts, vec, 60);
+
+        // b.md appears in both lists, so it outranks single-list hits.
+        assert_eq!(fused[0].file, "b.md");
+        assert!(fused[0].score > fused[1].score);
+    }
+
+    #[test]
+    fn rrf_keeps_bodies_stable() {
+        let fused = hybrid_search_rrf(vec![hit("a.md")], vec![], 60);
+        assert_eq!(fused.len(), 1);
+        assert_eq!(fused[0].body, "body of a.md");
+        // Rank-1 bonus applies.
+        assert!(fused[0].score > 0.08);
+    }
 }

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -1,4 +1,4 @@
-//! Store — per-profile qmd Stores for the memory database.
+//! Store — per-profile memory Stores for the memory database.
 //!
 //! Keyed by resolved database path, NOT a single global (#999). This was one
 //! `OnceCell` that captured `opencrabs_home()` on the first call and cached the
@@ -12,7 +12,7 @@
 //! Profiles are the isolation boundary in this codebase, so the component
 //! holding indexed content has to respect it.
 
-use qmd::Store;
+use super::db::Store;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
@@ -25,7 +25,7 @@ use std::sync::{LazyLock, Mutex};
 static STORES: LazyLock<Mutex<HashMap<PathBuf, &'static Mutex<Store>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Get (or create) the memory qmd Store for the ACTIVE profile.
+/// Get (or create) the memory Store for the ACTIVE profile.
 ///
 /// The database lives at `<profile home>/memory/memory.db`, resolved on every
 /// call so a profile switch reaches the right file. First use of a given path
@@ -82,7 +82,7 @@ fn build_store(db_path: &Path) -> Result<Store, String> {
         }
 
         tracing::info!(
-            "Memory qmd store ready at {} (vector: {})",
+            "Memory store ready at {} (vector: {})",
             db_path.display(),
             if super::vector_enabled() {
                 "enabled"
@@ -111,7 +111,7 @@ pub(crate) fn memory_dir() -> PathBuf {
 /// invisible to backfill forever.
 ///
 /// Idempotent: deletes nothing once the sweep has run. Uses its own read-write
-/// connection because `qmd::Store` exposes no raw statement access; WAL plus a
+/// connection because `Store` exposes no raw statement access; WAL plus a
 /// busy timeout makes that safe alongside the store's own connection.
 pub(crate) fn clear_skipped_placeholders() -> Result<usize, String> {
     let db_path = memory_dir().join("memory.db");

--- a/src/memory/vector_search.rs
+++ b/src/memory/vector_search.rs
@@ -1,24 +1,23 @@
 //! Chunk-aware vector search over the memory store (#998).
 //!
-//! `qmd::Store::search_vec` joins `vectors_vec` on `d.hash || '_0'`, so it can
-//! only ever see a document's FIRST chunk. Once documents are chunked, every
+//! A vector search that joins `vectors_vec` on `d.hash || '_0'` can only
+//! ever see a document's FIRST chunk. Once documents are chunked, every
 //! chunk past the first would be embedded, stored, and then never queried,
 //! which is the worst of both worlds: the cost of chunking with none of the
-//! benefit.
+//! benefit. This was written as a shim around that bug in the then-qmd
+//! store and became the real implementation when qmd was dropped (#1028).
 //!
-//! qmd is a third-party crate and 0.3.2 is its latest release, so this reads
-//! the same tables directly rather than waiting on an upstream change. It is
-//! deliberately a read-only, additive shim:
+//! It reads on its own connection rather than through `Store`:
 //!
-//! - Its own SQLite connection, opened read-only. The database runs in WAL
-//!   mode, so a reader never blocks qmd's writer and vice versa.
-//! - No schema of its own. It queries what qmd already writes, so nothing here
-//!   has to be migrated if qmd's search gains chunk support later and this is
-//!   deleted.
+//! - The connection is opened read-only. The database runs in WAL mode, so
+//!   this reader never blocks the store's writer and vice versa, and the
+//!   search path can run it while holding the store lock.
+//! - No schema of its own. It queries what `db.rs` writes.
 //!
-//! Scoring matches qmd's: cosine similarity computed in Rust over f32 vectors
-//! stored as little-endian bytes. `vectors_vec` is a plain table, not a
-//! vector-index extension, so this is the same linear scan qmd performs.
+//! Scoring: cosine similarity computed in Rust over f32 vectors stored as
+//! little-endian bytes. `vectors_vec` is a plain table, not a vector-index
+//! extension, so this is a linear scan — the right trade at memory-index
+//! scale (hundreds to low thousands of chunks).
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -47,12 +46,30 @@ pub struct ChunkHit {
 /// result slot.
 const SKIPPED_MODEL: &str = "skipped-too-large";
 
-/// Decode a little-endian f32 blob, the encoding qmd writes.
+/// Decode a little-endian f32 blob, the encoding `db.rs` writes.
 fn decode_embedding(bytes: &[u8]) -> Vec<f32> {
     bytes
         .chunks_exact(4)
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
         .collect()
+}
+
+/// Cosine similarity between two f32 vectors. 0.0 on length mismatch or
+/// zero norms (a degenerate vector must not score).
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
+
+    dot / (norm_a * norm_b)
 }
 
 /// Best-scoring chunk per document, ranked, for `query_embedding`.
@@ -125,7 +142,7 @@ pub fn search_chunks(
             continue;
         }
 
-        let score = qmd::cosine_similarity(query_embedding, &embedding);
+        let score = cosine_similarity(query_embedding, &embedding);
         let key = (collection.clone(), path.clone());
         let better = best.get(&key).is_none_or(|prev| score > prev.score);
         if better {

--- a/src/tests/memory_chunk_vector_test.rs
+++ b/src/tests/memory_chunk_vector_test.rs
@@ -6,9 +6,9 @@
 //!    one averaged vector, and anything past 32 KB got a `skipped-too-large`
 //!    placeholder and no vector at all. On a real workspace that was 25% of all
 //!    vector rows, including the long-term memory file.
-//! 2. Chunks past the first must be searchable. `qmd::Store::search_vec` joins
-//!    on `hash || '_0'`, so writing chunk 1..N through qmd's own search would
-//!    store data nothing ever queries.
+//! 2. Chunks past the first must be searchable. The old store's vector search
+//!    joined on `hash || '_0'`, so writing chunk 1..N through it would store
+//!    data nothing ever queries.
 //!
 //! These tests use the store schema directly rather than the embedding engine,
 //! which needs a ~300 MB model download and AVX. What is under test is the
@@ -67,10 +67,10 @@ fn store_with_chunks(dir: &TempDir, n_chunks: usize, distinct_at: usize) -> std:
 
 /// The regression: a match in a chunk other than the first must be found.
 ///
-/// This is the whole reason the search was reimplemented. Under qmd's
-/// `search_vec` the join is `hash || '_0'`, so this document would score on
-/// chunk 0 (which points away from the query) and the real answer at chunk 4
-/// would be invisible.
+/// This is the whole reason the search was reimplemented. Under the old
+/// store's `search_vec` the join is `hash || '_0'`, so this document would
+/// score on chunk 0 (which points away from the query) and the real answer at
+/// chunk 4 would be invisible.
 #[test]
 fn a_match_in_a_later_chunk_is_found() {
     use crate::memory::vector_search::search_chunks;

--- a/src/tests/memory_chunker_test.rs
+++ b/src/tests/memory_chunker_test.rs
@@ -145,19 +145,3 @@ fn a_paragraph_break_is_preferred() {
         &chunks[0].text[chunks[0].text.len().saturating_sub(40)..]
     );
 }
-
-/// Canary: the dependency defect that made this module necessary still exists.
-///
-/// If this stops panicking, qmd has fixed `chunk_document` and
-/// `memory::chunker` could be reconsidered in favour of the upstream one. A
-/// failure here is therefore good news, not a regression, and this comment is
-/// the note explaining that to whoever hits it.
-///
-/// Verified against the real content that crashed a running binary: qmd panics
-/// at `llm.rs:627` on the same input our chunker handles above.
-#[test]
-#[should_panic(expected = "char boundary")]
-fn upstream_chunker_still_panics_on_multibyte_input() {
-    let content = "abcdefghij—".repeat(400);
-    let _ = qmd::chunk_document(&content, 100, 12);
-}

--- a/src/tests/memory_store_profile_test.rs
+++ b/src/tests/memory_store_profile_test.rs
@@ -69,7 +69,7 @@ async fn content_written_under_one_profile_is_invisible_from_another() {
         let store = get_store().expect("store A");
         let guard = store.lock().expect("lock A");
         let body = format!("# Note\n\nThis body contains {marker} exactly once.\n");
-        let hash = qmd::Store::hash_content(&body);
+        let hash = crate::memory::db::Store::hash_content(&body);
         let now = crate::utils::string::utc_timestamp();
         guard.insert_content(&hash, &body, &now).expect("content");
         guard

--- a/src/tests/memory_store_test.rs
+++ b/src/tests/memory_store_test.rs
@@ -1,5 +1,5 @@
+use crate::memory::db::Store;
 use crate::memory::store::*;
-use qmd::Store;
 
 #[test]
 fn test_memory_dir() {
@@ -64,9 +64,10 @@ fn test_vector_search_returns_results() {
     query_emb[0] = 0.9;
     query_emb[1] = 0.6;
 
-    let results = store.search_vec(&query_emb, 5, None).unwrap();
+    let results =
+        crate::memory::vector_search::search_chunks(&db_path, &query_emb, 5, None).unwrap();
     assert!(!results.is_empty());
-    assert_eq!(results[0].doc.title, "Debug");
+    assert_eq!(results[0].title, "Debug");
 }
 
 #[test]
@@ -88,7 +89,8 @@ fn test_vector_search_empty_when_no_embeddings() {
 
     // Vector search with no embeddings stored — should return empty
     let query_emb = vec![0.1f32; 768];
-    let results = store.search_vec(&query_emb, 5, None).unwrap();
+    let results =
+        crate::memory::vector_search::search_chunks(&db_path, &query_emb, 5, None).unwrap();
     assert!(results.is_empty());
 }
 
@@ -201,13 +203,14 @@ fn test_rrf_merges_fts_and_vector() {
     // Vector search close to emb_a finds doc A first
     let mut q = vec![0.0f32; 768];
     q[0] = 0.9;
-    let vec_results = store.search_vec(&q, 5, Some("memory")).unwrap();
+    let vec_results =
+        crate::memory::vector_search::search_chunks(&db_path, &q, 5, Some("memory")).unwrap();
     assert!(!vec_results.is_empty());
-    assert_eq!(vec_results[0].doc.title, "Auth Fix");
+    assert_eq!(vec_results[0].title, "Auth Fix");
 
     // RRF combines both — doc A should rank highest (appears in both lists)
 
-    use qmd::hybrid_search_rrf;
+    use crate::memory::search::hybrid_search_rrf;
     let fts_tuples: Vec<_> = fts
         .iter()
         .map(|r| {
@@ -222,15 +225,15 @@ fn test_rrf_merges_fts_and_vector() {
     let vec_tuples: Vec<_> = vec_results
         .iter()
         .map(|r| {
-            let body = if r.doc.title == "Auth Fix" {
+            let body = if r.title == "Auth Fix" {
                 body_a
             } else {
                 body_b
             };
             (
-                r.doc.path.clone(),
-                r.doc.path.clone(),
-                r.doc.title.clone(),
+                r.path.clone(),
+                r.path.clone(),
+                r.title.clone(),
                 body.to_string(),
             )
         })


### PR DESCRIPTION
Closes #1028

Drops the `qmd` crate entirely. Every defect qmd ever shipped we hit in production and fixed on our side (#998 chunk-0-only vector search, #1002 char-boundary chunker panic, #1003 FTS doc-vs-chunk mismatch, #999 cross-profile store leak, #1018 stale index); upstream hasn't published since Feb 3 and its unreleased 0.5.0 rewrite still byte-slices the chunker. Our shims had already outgrown ~70% of the crate. Now we own the rest.

## What changed

**New: `src/memory/db.rs`** — native Store over rusqlite (already a direct dep). Verbatim qmd schema (`content`, `documents`, `documents_fts` + all 3 FTS triggers, `content_vectors`, `vectors_vec`): zero migration for existing `memory.db` files, and the existing read-only WAL shim keeps working untouched. SHA-256 hashing stays byte-identical so old embeddings stay valid.

**New: `src/memory/local_engine.rs`** — local GGUF embeddings on `llama-cpp-2` direct (already a direct dep), verbatim templates (`document: ...` / `query: ...`) and `pull_model` download logic. Same model cache dir (`cache_dir()/qmd/models`) so nobody re-downloads 300MB. API embeddings path unchanged.

**Rewired:** `embedding.rs`, `index.rs`, `store.rs`, `search.rs`, `vector_search.rs`, `mod.rs`. RRF fusion (including qmd's position-aware bonus) and cosine similarity inlined with tests.

**Tests/bench:** ported to the native store; deleted the `upstream_chunker_still_panics_on_multibyte_input` canary test (existed only to prove qmd's bug). Bench now runs through `opencrabs::memory::Store` via lib.rs re-exports.

**Cargo.toml:** `qmd` removed, reqwest gains `blocking` (for the model download). Cargo.lock −277 lines.

## Kept intentionally
- Local GGUF engine (config opt-in, API embeddings remain the alternative)
- Same FTS5 BM25 ranking (identical SQL), same RRF semantics, same embedding templates

## Verification
- `cargo check --all-features --tests --benches` clean
- `cargo test --all-features --lib memory::` 11/11 + integration memory_store/chunk/chunker suites
- `cargo clippy --locked --lib --bins --tests --all-features` (CI command)
- Schema parity diffed line-by-line against qmd-0.3.2 registry source
