### PR TITLE
feat(memory): external index paths (#1051)

### DIFF
--- a/src/brain/tools/memory_search.rs
+++ b/src/brain/tools/memory_search.rs
@@ -54,8 +54,8 @@ impl Tool for MemorySearchTool {
                 },
                 "scope": {
                     "type": "string",
-                    "enum": ["memory", "brain", "all"],
-                    "description": "Which corpus to search: \"memory\" (daily logs, the default) for history, \"brain\" for rules and policy in your brain files, \"all\" for both.",
+                    "enum": ["memory", "brain", "external", "all"],
+                    "description": "Which corpus to search: \"memory\" (daily logs, the default) for history, \"brain\" for rules and policy in your brain files, \"external\" for the user-configured external index paths, \"all\" for everything.",
                     "default": "memory"
                 }
             },
@@ -71,7 +71,7 @@ impl Tool for MemorySearchTool {
         false
     }
 
-    async fn execute(&self, input: Value, _context: &ToolExecutionContext) -> Result<ToolResult> {
+    async fn execute(&self, input: Value, context: &ToolExecutionContext) -> Result<ToolResult> {
         let query = input
             .get("query")
             .and_then(|v| v.as_str())
@@ -102,20 +102,52 @@ impl Tool for MemorySearchTool {
             }
         };
 
+        // External session gate (#1051, ADR-003): external content is
+        // default-deny in shared/group sessions. The gate — not the exclude
+        // patterns — is the security boundary.
+        let external_blocked = crate::memory::is_session_shared(context.session_id)
+            && !crate::memory::external_allowed_in_shared();
+
         let searched = match scope {
             "brain" => crate::memory::search_brain(store, &query, n).await,
+            "external" => {
+                if external_blocked {
+                    return Ok(ToolResult::error(
+                        "scope=\"external\" is not available in this shared/group session. \
+                         External index content stays private to the owner's sessions by \
+                         default (ADR-003). Set [memory] external_allowed_in_shared = true \
+                         to allow it here."
+                            .to_string(),
+                    ));
+                }
+                crate::memory::search_external(store, &query, n).await
+            }
             "all" => match crate::memory::search_brain(store, &query, n).await {
-                Ok(mut brain) => match crate::memory::search(store, &query, n).await {
+                Ok(mut brain) => match crate::memory::search_memory(store, &query, n).await {
                     // Brain hits lead: a rule outranks a note mentioning it.
                     Ok(mem) => {
                         brain.extend(mem);
-                        Ok(brain)
+                        if external_blocked {
+                            Ok(brain)
+                        } else {
+                            match crate::memory::search_external(store, &query, n).await {
+                                // External hits land last: brain > memory > external (Q10).
+                                Ok(ext) => {
+                                    brain.extend(ext);
+                                    Ok(brain)
+                                }
+                                Err(e) => Err(e),
+                            }
+                        }
                     }
                     Err(e) => Err(e),
                 },
                 Err(e) => Err(e),
             },
-            _ => crate::memory::search(store, &query, n).await,
+            // Default "memory" searches the memory corpus only (#1051):
+            // external content never leaks into the default scope, and rules
+            // live in scope="brain" (the empty-result hint below says so).
+            _ => crate::memory::search_memory(store, &query, n).await,
         };
 
         match searched {

--- a/src/channels/discord/handler.rs
+++ b/src/channels/discord/handler.rs
@@ -391,6 +391,12 @@ pub(crate) async fn handle_message(
         }
     };
 
+    // Session gate (#1051, ADR-003): mark group sessions so memory_search
+    // keeps external index content out of them by default.
+    if !is_dm {
+        crate::memory::mark_session_shared(session_id);
+    }
+
     // Fast-cancel: any recognised stop intent, in any supported language (#965).
     //
     // Cancellation is scoped to explicit stop requests and genuine follow-up

--- a/src/channels/slack/handler.rs
+++ b/src/channels/slack/handler.rs
@@ -1035,6 +1035,12 @@ async fn handle_message(
         }
     };
 
+    // Session gate (#1051, ADR-003): mark group sessions so memory_search
+    // keeps external index content out of them by default.
+    if !is_dm {
+        crate::memory::mark_session_shared(session_id);
+    }
+
     // The user sent their own message — any follow-up suggestion buttons from
     // the previous turn are stale now (#599).
     state.slack_state.clear_pending_followups(session_id).await;

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2384,6 +2384,12 @@ pub(crate) async fn handle_message(
         }
     };
 
+    // Session gate (#1051, ADR-003): mark group sessions so memory_search
+    // keeps external index content out of them by default.
+    if !is_dm {
+        crate::memory::mark_session_shared(session_id);
+    }
+
     // Keep "typing" alive past the end of the turn while this session still has
     // detached work (#812). Spawning a long background command ENDS the turn, so
     // the loop above stops at the exact moment the user most needs a sign that

--- a/src/channels/whatsapp/handler.rs
+++ b/src/channels/whatsapp/handler.rs
@@ -737,6 +737,12 @@ pub(crate) async fn handle_message(
         }
     };
 
+    // Session gate (#1051, ADR-003): mark group sessions so memory_search
+    // keeps external index content out of them by default.
+    if info.source.is_group {
+        crate::memory::mark_session_shared(session_id);
+    }
+
     // Remember which chat this session is handled in, so a finished background
     // task can resume the right chat (#731).
     wa_state

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -333,6 +333,10 @@ async fn cmd_chat_inner(
             Ok(Err(e)) => tracing::info!("Embedding engine init skipped: {e}"),
             Err(e) => tracing::warn!("Embedding engine warmup failed: {e}"),
         }
+        // Tier-2 external sweep (#1051): periodic incremental walk of the
+        // configured extra paths. Boot reindex above is sweep #0; this loop
+        // keeps the external collection current afterwards (ADR-002).
+        crate::memory::freshness::spawn_external_sweep();
     });
 
     // Preload local whisper model before the TUI starts so candle's

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1261,6 +1261,89 @@ pub struct MemoryConfig {
     /// via API instead of the local GGUF model. Eliminates ~300MB download + ~2.9GB RAM.
     #[serde(default)]
     pub embedding: Option<EmbeddingConfig>,
+
+    /// External filesystem paths indexed into the `external` collection (#1051).
+    /// Entries are bare path strings or `{ path, pattern }` tables. Relative
+    /// paths resolve against the OpenCrabs home, not the session cwd, so the
+    /// index stays stable across `/cd` and profile switches.
+    #[serde(default)]
+    pub extra_paths: Vec<ExtraPath>,
+
+    /// Glob patterns excluded from external indexing (#1051), global for all
+    /// extra paths. Defaults cover VCS/build dirs and common secret files;
+    /// the session gate is the real security boundary, this is defense in
+    /// depth.
+    #[serde(default = "default_external_excludes")]
+    pub exclude: Vec<String>,
+
+    /// Allow `scope="external"` results in shared/group sessions (#1051).
+    /// Default-deny: external content inherits memory_search's exposure
+    /// surface, so it stays main/owner-session-only unless opted in.
+    #[serde(default)]
+    pub external_allowed_in_shared: bool,
+
+    /// Seconds between external-path freshness sweeps (#1051). The sweep
+    /// discovers added/removed files and reconciles config changes; modified
+    /// files are caught lazily at search time regardless.
+    #[serde(default = "default_sweep_interval_secs")]
+    pub sweep_interval_secs: u64,
+}
+
+/// One external index path (#1051): a bare string or `{ path, pattern }`.
+/// Untagged so both forms parse from the same TOML array.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ExtraPath {
+    /// Bare path: indexed with the default pattern `**/*.md`.
+    Simple(String),
+    /// Path with an explicit glob, matched against root-relative paths.
+    WithPattern {
+        path: String,
+        #[serde(default = "default_extra_pattern")]
+        pattern: String,
+    },
+}
+
+impl ExtraPath {
+    /// The configured path, either form.
+    pub fn path(&self) -> &str {
+        match self {
+            ExtraPath::Simple(p) | ExtraPath::WithPattern { path: p, .. } => p,
+        }
+    }
+
+    /// The glob pattern, defaulting to `**/*.md` for bare entries.
+    pub fn pattern(&self) -> &str {
+        match self {
+            ExtraPath::Simple(_) => "**/*.md",
+            ExtraPath::WithPattern { pattern, .. } => pattern,
+        }
+    }
+}
+
+fn default_extra_pattern() -> String {
+    "**/*.md".to_string()
+}
+
+const fn default_sweep_interval_secs() -> u64 {
+    300
+}
+
+fn default_external_excludes() -> Vec<String> {
+    vec![
+        ".git".to_string(),
+        "node_modules".to_string(),
+        "target".to_string(),
+        "dist".to_string(),
+        "build".to_string(),
+        "vendor".to_string(),
+        "__pycache__".to_string(),
+        ".env*".to_string(),
+        "*.key".to_string(),
+        "*.pem".to_string(),
+        ".ssh/**".to_string(),
+        "*credential*".to_string(),
+    ]
 }
 
 const fn default_vector_enabled() -> bool {
@@ -1272,6 +1355,10 @@ impl Default for MemoryConfig {
         Self {
             vector_enabled: default_vector_enabled(),
             embedding: None,
+            extra_paths: Vec::new(),
+            exclude: default_external_excludes(),
+            external_allowed_in_shared: false,
+            sweep_interval_secs: default_sweep_interval_secs(),
         }
     }
 }
@@ -2258,3 +2345,87 @@ pub use io::*;
 pub(crate) use io::{load_keys_from_file, merge_channel_keys};
 mod loader;
 pub use loader::*;
+
+#[cfg(test)]
+mod memory_external_config_tests {
+    use super::{ExtraPath, MemoryConfig};
+
+    fn parse(s: &str) -> MemoryConfig {
+        toml::from_str(s).expect("valid [memory] TOML")
+    }
+
+    #[test]
+    fn bare_string_entry_parses_with_default_md_pattern() {
+        let cfg = parse(r#"extra_paths = ["/home/u/notes"]"#);
+        assert_eq!(cfg.extra_paths.len(), 1);
+        assert_eq!(cfg.extra_paths[0].path(), "/home/u/notes");
+        assert_eq!(cfg.extra_paths[0].pattern(), "**/*.md");
+        assert!(matches!(cfg.extra_paths[0], ExtraPath::Simple(_)));
+    }
+
+    #[test]
+    fn table_entry_parses_with_explicit_pattern() {
+        let cfg = parse(
+            r#"[[extra_paths]]
+path = "/home/u/docs"
+pattern = "**/*.txt"
+"#,
+        );
+        assert_eq!(cfg.extra_paths.len(), 1);
+        assert_eq!(cfg.extra_paths[0].path(), "/home/u/docs");
+        assert_eq!(cfg.extra_paths[0].pattern(), "**/*.txt");
+        assert!(matches!(cfg.extra_paths[0], ExtraPath::WithPattern { .. }));
+    }
+
+    #[test]
+    fn table_entry_without_pattern_defaults_to_md() {
+        let cfg = parse(
+            r#"[[extra_paths]]
+path = "/home/u/docs"
+"#,
+        );
+        assert_eq!(cfg.extra_paths[0].pattern(), "**/*.md");
+    }
+
+    #[test]
+    fn mixed_forms_parse_together() {
+        let cfg = parse(
+            r#"extra_paths = ["/a", { path = "/b", pattern = "**/*.org" }]"#,
+        );
+        assert_eq!(cfg.extra_paths.len(), 2);
+        assert_eq!(cfg.extra_paths[0].path(), "/a");
+        assert_eq!(cfg.extra_paths[1].path(), "/b");
+        assert_eq!(cfg.extra_paths[1].pattern(), "**/*.org");
+    }
+
+    #[test]
+    fn defaults_are_secure_and_sane() {
+        let cfg = parse("");
+        assert!(cfg.extra_paths.is_empty(), "no paths by default");
+        assert!(
+            !cfg.external_allowed_in_shared,
+            "session gate must default to DENY (#1051 security boundary)"
+        );
+        assert_eq!(cfg.sweep_interval_secs, 300);
+        let excl = &cfg.exclude;
+        for secret in [".env*", "*.key", "*.pem", ".ssh/**", "*credential*"] {
+            assert!(excl.iter().any(|e| e == secret), "missing secret exclude {secret}");
+        }
+        for noise in [".git", "node_modules", "target", "dist", "build", "vendor", "__pycache__"] {
+            assert!(excl.iter().any(|e| e == noise), "missing noise exclude {noise}");
+        }
+    }
+
+    #[test]
+    fn explicit_exclude_overrides_defaults() {
+        let cfg = parse(r#"exclude = ["*.md"]"#);
+        assert_eq!(cfg.exclude, vec!["*.md".to_string()]);
+    }
+
+    #[test]
+    fn gate_and_interval_are_overridable() {
+        let cfg = parse("external_allowed_in_shared = true\nsweep_interval_secs = 60");
+        assert!(cfg.external_allowed_in_shared);
+        assert_eq!(cfg.sweep_interval_secs, 60);
+    }
+}

--- a/src/memory/external.rs
+++ b/src/memory/external.rs
@@ -1,0 +1,351 @@
+//! External index paths (#1051) — user-configured directories outside
+//! `~/.opencrabs`, indexed into the `external` collection.
+//!
+//! Design decisions are grilled in issue #1051 and its ADRs; the ones that
+//! shape this file:
+//!
+//! - Documents are keyed by ABSOLUTE CANONICAL PATH. Brain/memory key by
+//!   basename because their corpora are single flat dirs; external trees are
+//!   not, and two `CLAUDE.md` files must not collide.
+//! - The configured root is canonicalized (symlink resolved); symlinks
+//!   INSIDE the tree are skipped entirely — no cycles, no escapes, no
+//!   duplicate documents via aliased paths (Q8).
+//! - No filesystem watcher. Discovery of added/removed files rides the
+//!   periodic freshness sweep; this module just walks and reconciles (ADR-002).
+//! - Nothing here is silent: missing roots, unreadable roots and skipped
+//!   nested paths all surface in the returned report so callers can warn
+//!   (OpenClaw lesson #1 via #1051).
+
+use super::db::Store;
+use super::{COLLECTION_EXTERNAL, external_excludes, extra_paths_config};
+use std::path::PathBuf;
+
+/// One configured extra path after resolution.
+#[derive(Debug)]
+pub(crate) struct ResolvedRoot {
+    /// Canonical absolute path of the root (its own symlink resolved).
+    pub root: PathBuf,
+    /// Include glob, matched against root-relative paths.
+    pub pattern: glob::Pattern,
+}
+
+/// What happened during resolve + walk + prune. Callers turn this into
+/// warnings/status — never into silence (Q6).
+#[derive(Debug, Default)]
+pub(crate) struct ExternalReport {
+    /// Documents newly indexed or re-indexed this pass.
+    pub indexed: usize,
+    /// Configured paths that do not exist.
+    pub missing_roots: Vec<String>,
+    /// Configured paths that exist but could not be canonicalized/read.
+    pub unreadable_roots: Vec<String>,
+    /// Configured paths nested inside another configured path (skipped).
+    pub skipped_nested: Vec<String>,
+    /// Invalid glob patterns (skipped with the default instead).
+    pub bad_patterns: Vec<String>,
+    /// Documents pruned because they fell out of the configured roots.
+    pub pruned: usize,
+    /// Total matching files on disk across all roots.
+    pub on_disk: usize,
+}
+
+impl ExternalReport {
+    /// Log every problem in the report. Warn for problems, info for counts.
+    pub fn log(&self) {
+        for p in &self.missing_roots {
+            tracing::warn!("memory: extra path does not exist, not indexed: {p}");
+        }
+        for p in &self.unreadable_roots {
+            tracing::warn!("memory: extra path unreadable, not indexed: {p}");
+        }
+        for p in &self.skipped_nested {
+            tracing::warn!("memory: extra path nested inside another extra path, skipped: {p}");
+        }
+        for p in &self.bad_patterns {
+            tracing::warn!("memory: invalid glob pattern in extra path, using **/*.md: {p}");
+        }
+        if self.indexed > 0 || self.pruned > 0 || self.on_disk > 0 {
+            tracing::info!(
+                "memory: external paths — {} on disk, {} indexed, {} pruned",
+                self.on_disk,
+                self.indexed,
+                self.pruned
+            );
+        }
+    }
+}
+
+/// Expand `~/` against the OpenCrabs home and resolve relative paths against
+/// it too (NOT the session cwd — that moves with `/cd` and profiles; the
+/// index must stay stable).
+fn expand_path(raw: &str) -> PathBuf {
+    let home = crate::config::opencrabs_home();
+    if let Some(rest) = raw.strip_prefix("~/") {
+        return home.join(rest);
+    }
+    let p = PathBuf::from(raw);
+    if p.is_absolute() {
+        p
+    } else {
+        home.join(p)
+    }
+}
+
+/// Resolve all configured extra paths into canonical roots.
+///
+/// Nested roots are detected AFTER canonicalization and the nested one is
+/// skipped with a warning — indexing `/a` and `/a/b` would double-index
+/// everything under `/a/b`.
+pub(crate) fn resolve_roots() -> (Vec<ResolvedRoot>, ExternalReport) {
+    let mut report = ExternalReport::default();
+    let mut resolved: Vec<(String, ResolvedRoot)> = Vec::new();
+
+    for entry in extra_paths_config() {
+        let raw = entry.path().to_string();
+        let expanded = expand_path(&raw);
+        let root = match std::fs::canonicalize(&expanded) {
+            Ok(r) if r.is_dir() => r,
+            Ok(_) => {
+                // Exists but is a file, not a directory.
+                report.missing_roots.push(raw);
+                continue;
+            }
+            Err(_) => {
+                if expanded.exists() {
+                    report.unreadable_roots.push(raw);
+                } else {
+                    report.missing_roots.push(raw);
+                }
+                continue;
+            }
+        };
+
+        let pattern = match glob::Pattern::new(entry.pattern()) {
+            Ok(p) => p,
+            Err(_) => {
+                report.bad_patterns.push(raw.clone());
+                glob::Pattern::new("**/*.md").expect("static pattern is valid")
+            }
+        };
+
+        resolved.push((raw, ResolvedRoot { root, pattern }));
+    }
+
+    // Nested-path detection: skip any root whose canonical path is inside an
+    // earlier root. Order of appearance wins, matching config order.
+    let mut kept: Vec<ResolvedRoot> = Vec::new();
+    for (raw, cand) in resolved {
+        let nested = kept.iter().any(|k| cand.root.starts_with(&k.root) && cand.root != k.root);
+        if nested {
+            report.skipped_nested.push(raw);
+        } else {
+            kept.push(cand);
+        }
+    }
+
+    (kept, report)
+}
+
+/// Does an exclude pattern cover this entry? For directories we also test a
+/// synthetic child so subtree patterns like `.ssh/**` exclude the dir itself.
+pub(crate) fn excluded(rel: &str, name: &str, is_dir: bool, excludes: &[glob::Pattern]) -> bool {
+    excludes.iter().any(|p| {
+        if p.matches(name) || p.matches(rel) {
+            return true;
+        }
+        is_dir && p.matches(&format!("{rel}/x"))
+    })
+}
+
+/// Recursive walk of one root. Returns absolute paths of matching files.
+///
+/// Symlinks inside the tree are skipped (Q8): the root itself was already
+/// canonicalized by the caller. Walking is iterative with an explicit stack,
+/// no recursion depth limits to worry about.
+fn walk_root(root: &ResolvedRoot, excludes: &[glob::Pattern]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![root.root.clone()];
+
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // Symlinks inside the tree are skipped entirely — cycles, escapes
+            // and duplicate-via-alias all die here (Q8).
+            if path.is_symlink() {
+                continue;
+            }
+            let Ok(rel) = path.strip_prefix(&root.root) else {
+                continue;
+            };
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            let name = entry.file_name().to_string_lossy().to_string();
+
+            if path.is_dir() {
+                if !excluded(&rel_str, &name, true, excludes) {
+                    stack.push(path);
+                }
+            } else if path.is_file()
+                && !excluded(&rel_str, &name, false, excludes)
+                && root.pattern.matches(&rel_str)
+            {
+                files.push(path);
+            }
+        }
+    }
+
+    files.sort();
+    files
+}
+
+/// Walk all resolved roots, index matching files into COLLECTION_EXTERNAL
+/// keyed by absolute path, and prune documents that fell out of the current
+/// root set (deleted files AND removed config paths in one motion — this is
+/// also how extra_paths config changes reconcile, Q15).
+///
+/// FTS only: embeddings ride the existing backfill, so search works
+/// immediately and vectors come online incrementally (Q12).
+pub(crate) fn reindex_external(store: &Store) -> ExternalReport {
+    let (roots, mut report) = resolve_roots();
+    let excludes: Vec<glob::Pattern> = external_excludes()
+        .iter()
+        .filter_map(|s| glob::Pattern::new(s).ok())
+        .collect();
+
+    let mut on_disk: Vec<String> = Vec::new();
+    for root in &roots {
+        for path in walk_root(root, &excludes) {
+            let key = path.to_string_lossy().to_string();
+            on_disk.push(key.clone());
+            match std::fs::read_to_string(&path) {
+                Ok(body) if !body.trim().is_empty() => {
+                    match super::index::index_file_sync_keyed(
+                        store,
+                        COLLECTION_EXTERNAL,
+                        &key,
+                        &body,
+                    ) {
+                        Ok(true) => report.indexed += 1,
+                        Ok(false) => {}
+                        Err(e) => {
+                            tracing::warn!("memory: failed to index external file {key}: {e}")
+                        }
+                    }
+                }
+                Ok(_) => {
+                    // Empty file: drop it from the on-disk set so a stale
+                    // index entry gets pruned instead of preserved.
+                    on_disk.pop();
+                }
+                Err(e) => {
+                    tracing::warn!("memory: unreadable external file {key}: {e}");
+                    on_disk.pop();
+                }
+            }
+        }
+    }
+
+    // Prune anything in the external collection that is no longer on disk
+    // under a configured root.
+    if let Ok(db_paths) = store.get_active_document_paths(COLLECTION_EXTERNAL) {
+        for db_path in &db_paths {
+            if !on_disk.contains(db_path) {
+                let _ = store.deactivate_document(COLLECTION_EXTERNAL, db_path);
+                report.pruned += 1;
+                tracing::debug!("memory: pruned external document {db_path}");
+            }
+        }
+    }
+
+    report.on_disk = on_disk.len();
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pats(strs: &[&str]) -> Vec<glob::Pattern> {
+        strs.iter().map(|s| glob::Pattern::new(s).unwrap()).collect()
+    }
+
+    #[test]
+    fn expand_handles_tilde_relative_and_absolute() {
+        let home = crate::config::opencrabs_home();
+        assert_eq!(expand_path("~/notes"), home.join("notes"));
+        assert_eq!(expand_path("notes"), home.join("notes"));
+        assert_eq!(expand_path("/abs/path"), PathBuf::from("/abs/path"));
+    }
+
+    #[test]
+    fn excludes_match_names_paths_and_subtrees() {
+        let excludes = pats(&[".git", "*.key", ".ssh/**"]);
+        // Dir-name match anywhere in the tree.
+        assert!(excluded(".git", ".git", true, &excludes));
+        assert!(excluded("deep/.git", ".git", true, &excludes));
+        // File-name match.
+        assert!(excluded("server.key", "server.key", false, &excludes));
+        // Subtree pattern excludes the dir itself AND its contents.
+        assert!(excluded(".ssh", ".ssh", true, &excludes));
+        assert!(excluded(".ssh/id_rsa", "id_rsa", false, &excludes));
+        // Non-matches pass through.
+        assert!(!excluded("notes.md", "notes.md", false, &excludes));
+        assert!(!excluded("src", "src", true, &excludes));
+    }
+
+    #[test]
+    fn walk_finds_matching_files_skips_excludes_and_symlinks() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("a/b")).unwrap();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+        std::fs::write(root.join("top.md"), "# top").unwrap();
+        std::fs::write(root.join("a/b/deep.md"), "# deep").unwrap();
+        std::fs::write(root.join("a/skip.txt"), "nope").unwrap();
+        std::fs::write(root.join(".git/config"), "nope").unwrap();
+        std::fs::write(root.join("node_modules/x.md"), "nope").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(root.join("top.md"), root.join("link.md")).unwrap();
+
+        let resolved = ResolvedRoot {
+            root: root.to_path_buf(),
+            pattern: glob::Pattern::new("**/*.md").unwrap(),
+        };
+        let excludes = pats(&[".git", "node_modules"]);
+        let found = walk_root(&resolved, &excludes);
+        let names: Vec<String> = found
+            .iter()
+            .map(|p| p.strip_prefix(root).unwrap().to_string_lossy().replace('\\', "/"))
+            .collect();
+
+        assert!(names.contains(&"top.md".to_string()), "top-level md: {names:?}");
+        assert!(names.contains(&"a/b/deep.md".to_string()), "nested md: {names:?}");
+        assert!(!names.contains(&"a/skip.txt".to_string()), "pattern mismatch");
+        assert!(!names.contains(&".git/config".to_string()), "excluded dir");
+        assert!(!names.iter().any(|n| n.contains("node_modules")), "excluded dir");
+        assert!(!names.contains(&"link.md".to_string()), "symlink must be skipped");
+    }
+
+    #[test]
+    fn nested_roots_are_skipped_with_report() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let outer = tmp.path().join("outer");
+        let inner = outer.join("inner");
+        std::fs::create_dir_all(&inner).unwrap();
+
+        // Resolve manually via the same logic: canonicalize + nest check.
+        let outer_c = std::fs::canonicalize(&outer).unwrap();
+        let inner_c = std::fs::canonicalize(&inner).unwrap();
+        assert!(inner_c.starts_with(&outer_c), "test setup: inner nested");
+
+        let kept = [ResolvedRoot {
+            root: outer_c.clone(),
+            pattern: glob::Pattern::new("**/*.md").unwrap(),
+        }];
+        let nested = kept.iter().any(|k| inner_c.starts_with(&k.root) && inner_c != k.root);
+        assert!(nested, "nested root must be detected");
+    }
+}

--- a/src/memory/external_sweep.rs
+++ b/src/memory/external_sweep.rs
@@ -1,0 +1,302 @@
+//! Tier-2 external sweep (#1051 / ADR-002).
+//!
+//! A periodic incremental walk over the configured external roots that
+//! discovers additions, prunes deletions, and reconciles config changes —
+//! without a filesystem watcher. Directory mtimes are the pruning signal:
+//! adding or removing an entry bumps the parent directory's mtime, so a
+//! subtree whose mtime is unchanged keeps its prior file list without a
+//! single file read. Modified-file content that does not change the dir
+//! mtime is tier-1's job at search time, not the sweep's.
+
+use super::db::Store;
+use super::external::{excluded, resolve_roots, ResolvedRoot};
+use super::{external_excludes, COLLECTION_EXTERNAL};
+use std::collections::{BTreeSet, HashMap};
+use std::path::PathBuf;
+use std::sync::Mutex as StdMutex;
+use std::time::SystemTime;
+
+/// Process-local sweep state. `None` = cold: the next sweep treats every
+/// directory as changed (a full pass), which is exactly boot behaviour.
+struct SweepState {
+    dir_mtimes: HashMap<PathBuf, SystemTime>,
+}
+
+static SWEEP_STATE: StdMutex<Option<SweepState>> = StdMutex::new(None);
+
+/// Outcome of one sweep pass.
+#[derive(Debug, Default)]
+pub(crate) struct SweepReport {
+    /// Documents newly indexed (content hash changed or new).
+    pub indexed: usize,
+    /// Documents deactivated (deleted on disk or config path removed).
+    pub pruned: usize,
+    /// Matching files currently on disk across all roots.
+    pub on_disk: usize,
+    /// Files actually read this pass (only under changed dirs).
+    pub reads: usize,
+}
+
+impl SweepReport {
+    pub fn log(&self) {
+        tracing::info!(
+            "Memory external sweep: indexed={} pruned={} on_disk={} reads={}",
+            self.indexed,
+            self.pruned,
+            self.on_disk,
+            self.reads
+        );
+    }
+}
+
+/// Incremental sweep over one root. Walks every directory (metadata only),
+/// reads files ONLY under directories whose mtime moved, records on-disk
+/// keys, and indexes changed files (FTS-only; embeddings ride the backfill).
+#[allow(clippy::too_many_arguments)]
+fn sweep_root(
+    store: &Store,
+    root: &ResolvedRoot,
+    excludes: &[glob::Pattern],
+    prior_dirs: &HashMap<PathBuf, SystemTime>,
+    new_dirs: &mut HashMap<PathBuf, SystemTime>,
+    on_disk: &mut BTreeSet<String>,
+    report: &mut SweepReport,
+) {
+    let mut stack = vec![root.root.clone()];
+    while let Some(dir) = stack.pop() {
+        let mtime = std::fs::metadata(&dir).and_then(|m| m.modified()).ok();
+        if let Some(t) = mtime {
+            new_dirs.insert(dir.clone(), t);
+        }
+        // A dir is "changed" when its mtime moved or it is new. Unchanged
+        // dirs keep their prior file list with zero file reads.
+        let dir_changed = match (mtime, prior_dirs.get(&dir)) {
+            (Some(now), Some(prev)) => now > *prev,
+            (Some(_), None) => true,
+            (None, _) => false,
+        };
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_symlink() {
+                continue;
+            }
+            let Ok(rel) = path.strip_prefix(&root.root) else {
+                continue;
+            };
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            let name = entry.file_name().to_string_lossy().to_string();
+            if path.is_dir() {
+                if !excluded(&rel_str, &name, true, excludes) {
+                    stack.push(path);
+                }
+            } else if path.is_file()
+                && !excluded(&rel_str, &name, false, excludes)
+                && root.pattern.matches(&rel_str)
+            {
+                let key = path.to_string_lossy().to_string();
+                on_disk.insert(key.clone());
+                if dir_changed {
+                    report.reads += 1;
+                    match std::fs::read_to_string(&path) {
+                        Ok(body) if !body.trim().is_empty() => {
+                            match super::index::index_file_sync_keyed(
+                                store,
+                                COLLECTION_EXTERNAL,
+                                &key,
+                                &body,
+                            ) {
+                                Ok(true) => report.indexed += 1,
+                                Ok(false) => {}
+                                Err(e) => {
+                                    tracing::warn!("memory sweep: index failed {key}: {e}")
+                                }
+                            }
+                        }
+                        Ok(_) => {
+                            on_disk.remove(&key);
+                        }
+                        Err(e) => {
+                            tracing::warn!("memory sweep: unreadable {key}: {e}");
+                            on_disk.remove(&key);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Pure, testable sweep core. Runs over the given roots with an explicit
+/// prior-dir-mtime snapshot (`None` = cold/full pass) and returns the report
+/// plus the fresh dir-mtime snapshot for the next pass. Touches no global
+/// state, so tests run concurrently without clobbering each other.
+pub(crate) fn sweep_external_with(
+    store: &Store,
+    roots: &[ResolvedRoot],
+    excludes: &[glob::Pattern],
+    prior_dirs: Option<&HashMap<PathBuf, SystemTime>>,
+) -> (SweepReport, HashMap<PathBuf, SystemTime>) {
+    let empty = HashMap::new();
+    let prior = prior_dirs.unwrap_or(&empty);
+    let mut new_dirs = HashMap::new();
+    let mut on_disk = BTreeSet::new();
+    let mut report = SweepReport::default();
+
+    for root in roots {
+        sweep_root(
+            store,
+            root,
+            excludes,
+            prior,
+            &mut new_dirs,
+            &mut on_disk,
+            &mut report,
+        );
+    }
+
+    // Prune anything indexed that is no longer on disk under a configured
+    // root: deleted files, removed config paths, repointed root symlinks.
+    if let Ok(db_paths) = store.get_active_document_paths(COLLECTION_EXTERNAL) {
+        for db_path in &db_paths {
+            if !on_disk.contains(db_path) {
+                let _ = store.deactivate_document(COLLECTION_EXTERNAL, db_path);
+                report.pruned += 1;
+                tracing::debug!("memory sweep: pruned external document {db_path}");
+            }
+        }
+    }
+
+    report.on_disk = on_disk.len();
+    (report, new_dirs)
+}
+
+/// Config-driven sweep: resolves roots fresh from `[memory].extra_paths`
+/// (live-read, so config changes reconcile within one interval — Q15),
+/// manages the process-local dir-mtime state, and returns the report.
+pub(crate) fn sweep_external(store: &Store) -> SweepReport {
+    let (roots, resolve_report) = resolve_roots();
+    resolve_report.log();
+    let excludes: Vec<glob::Pattern> = external_excludes()
+        .iter()
+        .filter_map(|s| glob::Pattern::new(s).ok())
+        .collect();
+
+    let prior = SWEEP_STATE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .take();
+    let prior_dirs = prior.map(|s| s.dir_mtimes);
+
+    let (report, new_dirs) = sweep_external_with(store, &roots, &excludes, prior_dirs.as_ref());
+
+    {
+        let mut g = SWEEP_STATE.lock().unwrap_or_else(|e| e.into_inner());
+        *g = Some(SweepState {
+            dir_mtimes: new_dirs,
+        });
+    }
+
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glob::Pattern;
+    use std::path::Path;
+
+    fn md_root(path: &Path) -> ResolvedRoot {
+        ResolvedRoot {
+            root: path.to_path_buf(),
+            pattern: Pattern::new("**/*.md").unwrap(),
+        }
+    }
+
+    #[test]
+    fn cold_sweep_indexes_then_warm_sweep_reads_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().to_path_buf();
+        std::fs::write(root.join("a.md"), "# a").unwrap();
+        let store = Store::open(&tmp.path().join("mem.db")).expect("store");
+
+        let roots = vec![md_root(&root)];
+        let excludes = vec![];
+
+        let (r1, dirs1) = sweep_external_with(&store, &roots, &excludes, None);
+        assert_eq!(r1.indexed, 1, "cold pass indexes the one file");
+        assert_eq!(r1.on_disk, 1);
+        assert_eq!(r1.pruned, 0);
+
+        let (r2, _dirs2) = sweep_external_with(&store, &roots, &excludes, Some(&dirs1));
+        assert_eq!(r2.reads, 0, "quiet tree reads nothing");
+        assert_eq!(r2.indexed, 0, "quiet tree indexes nothing");
+        assert_eq!(r2.pruned, 0);
+        assert_eq!(r2.on_disk, 1);
+    }
+
+    #[test]
+    fn warm_sweep_discovers_additions_and_prunes_deletions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().to_path_buf();
+        std::fs::write(root.join("a.md"), "# a").unwrap();
+        let store = Store::open(&tmp.path().join("mem.db")).expect("store");
+
+        let roots = vec![md_root(&root)];
+        let excludes = vec![];
+
+        let (_r1, dirs1) = sweep_external_with(&store, &roots, &excludes, None);
+
+        // Add b.md and delete a.md — both bump the root dir's mtime.
+        std::fs::write(root.join("b.md"), "# b").unwrap();
+        std::fs::remove_file(root.join("a.md")).unwrap();
+
+        let (r2, _dirs2) = sweep_external_with(&store, &roots, &excludes, Some(&dirs1));
+        assert_eq!(r2.indexed, 1, "b.md discovered and indexed");
+        assert_eq!(r2.pruned, 1, "deleted a.md pruned");
+        assert_eq!(r2.on_disk, 1);
+    }
+
+    #[test]
+    fn removing_a_config_path_prunes_its_documents() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root_a = tmp.path().join("a");
+        let root_b = tmp.path().join("b");
+        std::fs::create_dir_all(&root_a).unwrap();
+        std::fs::create_dir_all(&root_b).unwrap();
+        std::fs::write(root_a.join("x.md"), "# x").unwrap();
+        std::fs::write(root_b.join("y.md"), "# y").unwrap();
+        let store = Store::open(&tmp.path().join("mem.db")).expect("store");
+
+        let excludes = vec![];
+        let both = vec![md_root(&root_a), md_root(&root_b)];
+
+        let (r1, dirs1) = sweep_external_with(&store, &both, &excludes, None);
+        assert_eq!(r1.indexed, 2, "both roots indexed cold");
+
+        // Config now only lists root_a: root_b's doc must be pruned.
+        let only_a = vec![md_root(&root_a)];
+        let (r2, _dirs2) = sweep_external_with(&store, &only_a, &excludes, Some(&dirs1));
+        assert_eq!(r2.pruned, 1, "root_b doc pruned after config removal");
+        assert_eq!(r2.on_disk, 1);
+    }
+
+    #[test]
+    fn excludes_are_respected_by_the_sweep() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+        std::fs::write(root.join("keep.md"), "# keep").unwrap();
+        std::fs::write(root.join("node_modules/skip.md"), "# skip").unwrap();
+        let store = Store::open(&tmp.path().join("mem.db")).expect("store");
+
+        let roots = vec![md_root(&root)];
+        let excludes = vec![Pattern::new("node_modules").unwrap()];
+
+        let (r1, _dirs) = sweep_external_with(&store, &roots, &excludes, None);
+        assert_eq!(r1.indexed, 1, "only keep.md indexed");
+        assert_eq!(r1.on_disk, 1);
+    }
+}

--- a/src/memory/freshness.rs
+++ b/src/memory/freshness.rs
@@ -38,6 +38,7 @@
 //! finish, and a search served against a one-call-old index is a far smaller
 //! problem than the crash.
 
+use super::db::Store;
 use std::collections::HashMap;
 use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -130,5 +131,181 @@ async fn index_one(path: &std::path::Path, name: &str) -> bool {
             tracing::warn!("Memory freshness: failed to reindex {name}: {e}");
             false
         }
+    }
+}
+
+/// mtime of each EXTERNAL file the last time THIS process indexed it (#1051,
+/// ADR-002 tier 1). Keyed by absolute path — external documents are keyed by
+/// absolute path, unlike brain files which use basenames. Same honesty rule as
+/// LAST_INDEXED: track what this process actually indexed, not the DB timestamp.
+static EXTERNAL_LAST_INDEXED: StdMutex<Option<HashMap<String, SystemTime>>> = StdMutex::new(None);
+
+/// Set while an external refresh is running, so a concurrent search skips
+/// instead of double-indexing (mirrors REFRESHING).
+static EXTERNAL_REFRESHING: AtomicBool = AtomicBool::new(false);
+
+/// Tier-1 external freshness (#1051, ADR-002): reindex the external files
+/// behind search hits whose mtime moved. The tier-2 sweep catches additions
+/// and deletions via directory mtimes, but an in-place edit does not bump the
+/// parent dir's mtime — that is exactly what this check catches, lazily, only
+/// for files that actually surfaced as hits. FTS-only: embedding stays off the
+/// search path (#1021).
+///
+/// Returns the number of files reindexed. Never fails the caller: a search
+/// must still run against a stale index rather than error.
+pub async fn refresh_stale_external(paths: &[String]) -> usize {
+    if paths.is_empty() {
+        return 0;
+    }
+    if EXTERNAL_REFRESHING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        tracing::debug!("Memory external freshness: refresh already in flight, skipping");
+        return 0;
+    }
+    let refreshed = refresh_external_inner(paths).await;
+    EXTERNAL_REFRESHING.store(false, Ordering::Release);
+    refreshed
+}
+
+async fn refresh_external_inner(paths: &[String]) -> usize {
+    let store = match super::get_store() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("Memory external freshness: store unavailable: {e}");
+            return 0;
+        }
+    };
+    let mut refreshed = 0usize;
+
+    for key in paths {
+        let path = std::path::Path::new(key);
+        // External documents are keyed by absolute path; anything else is not
+        // an external hit.
+        if !path.is_absolute() {
+            continue;
+        }
+        let disk_mtime = match std::fs::metadata(path).and_then(|m| m.modified()) {
+            Ok(t) => t,
+            // Deleted on disk: the tier-2 sweep prunes it, nothing to refresh.
+            Err(_) => continue,
+        };
+        let seen = {
+            let guard = EXTERNAL_LAST_INDEXED.lock().unwrap_or_else(|e| e.into_inner());
+            guard.as_ref().and_then(|m| m.get(key).copied())
+        };
+        let changed = match seen {
+            Some(t) => disk_mtime > t,
+            // Not yet seen by this process: check it once. Hash-skip inside
+            // index_file_sync_keyed dedupes if the content is unchanged.
+            None => true,
+        };
+        if !changed {
+            continue;
+        }
+        if index_external_one(store, key, path).await {
+            refreshed += 1;
+            let mut guard = EXTERNAL_LAST_INDEXED.lock().unwrap_or_else(|e| e.into_inner());
+            guard
+                .get_or_insert_with(HashMap::new)
+                .insert(key.clone(), disk_mtime);
+        }
+    }
+
+    if refreshed > 0 {
+        tracing::info!("Memory external freshness: reindexed {refreshed} stale external file(s)");
+    }
+    refreshed
+}
+
+/// Index one external file by its absolute key. FTS-only (no embedding).
+async fn index_external_one(
+    store: &'static StdMutex<Store>,
+    key: &str,
+    path: &std::path::Path,
+) -> bool {
+    let body = match tokio::fs::read_to_string(path).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("Memory external freshness: unreadable {key}: {e}");
+            return false;
+        }
+    };
+    let key = key.to_string();
+    let log_key = key.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let s = store
+            .lock()
+            .map_err(|e| format!("Store lock poisoned: {e}"))?;
+        super::index::index_file_sync_keyed(&s, super::COLLECTION_EXTERNAL, &key, &body)
+    })
+    .await;
+    match result {
+        Ok(Ok(_)) => true,
+        Ok(Err(e)) => {
+            tracing::warn!("Memory external freshness: failed to reindex {log_key}: {e}");
+            false
+        }
+        Err(e) => {
+            tracing::warn!("Memory external freshness: join failed for {log_key}: {e}");
+            false
+        }
+    }
+}
+
+/// Spawned-once guard for the sweep loop.
+static SWEEP_SPAWNED: AtomicBool = AtomicBool::new(false);
+/// Set while a sweep tick is running, so an overlapping tick is skipped.
+static SWEEP_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Spawn the background tier-2 external sweep (#1051, ADR-002).
+///
+/// Re-reads `[memory].sweep_interval_secs` every loop so a config change
+/// applies live (Q15 — the sweep IS the reconciliation loop). Single-flight:
+/// a tick that finds a sweep still running is skipped, not queued. No watcher,
+/// no reload handler, no new concurrency surface — just a timer and a
+/// metadata walk (ADR-002).
+pub fn spawn_external_sweep() {
+    if SWEEP_SPAWNED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    tokio::spawn(async {
+        loop {
+            let secs = super::sweep_interval_secs().max(10);
+            tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+            if SWEEP_RUNNING
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                continue;
+            }
+            sweep_once().await;
+            SWEEP_RUNNING.store(false, Ordering::Release);
+        }
+    });
+}
+
+/// One sweep tick: run the incremental external walk under the store lock.
+async fn sweep_once() {
+    let store = match super::get_store() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("Memory external sweep: store unavailable: {e}");
+            return;
+        }
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let s = match store.lock() {
+            Ok(s) => s,
+            Err(e) => return Err(format!("Store lock poisoned: {e}")),
+        };
+        Ok::<_, String>(super::external_sweep::sweep_external(&s))
+    })
+    .await;
+    match result {
+        Ok(Ok(report)) => report.log(),
+        Ok(Err(e)) => tracing::warn!("Memory external sweep failed: {e}"),
+        Err(e) => tracing::warn!("Memory external sweep join failed: {e}"),
     }
 }

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -123,14 +123,30 @@ fn index_file_sync(
     path: &Path,
     body: &str,
 ) -> Result<bool, String> {
-    let hash = Store::hash_content(body);
     let rel_path = path
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| path.to_string_lossy().to_string());
+    index_file_sync_keyed(store, collection, &rel_path, body)
+}
+
+/// Index one document under an explicit key.
+///
+/// Brain/memory use the basename (their corpora are single flat dirs); the
+/// external collection uses absolute canonical paths so identically-named
+/// files in different directories never collide (#1051).
+///
+/// Returns `true` if new content was indexed, `false` if hash-skipped.
+pub(crate) fn index_file_sync_keyed(
+    store: &Store,
+    collection: &str,
+    doc_key: &str,
+    body: &str,
+) -> Result<bool, String> {
+    let hash = Store::hash_content(body);
 
     if let Ok(Some((_id, existing_hash, _title))) =
-        store.find_active_document(collection, &rel_path)
+        store.find_active_document(collection, doc_key)
         && existing_hash == hash
     {
         return Ok(false);
@@ -143,16 +159,16 @@ fn index_file_sync(
     // insert_document fires a plain INSERT into documents_fts (not OR REPLACE,
     // which SQLite FTS5 rejects with "constraint failed").
     // Safe for new documents: deactivate_document matches 0 rows → no-op.
-    let _ = store.deactivate_document(collection, &rel_path);
+    let _ = store.deactivate_document(collection, doc_key);
 
     store
         .insert_content(&hash, body, &now)
         .map_err(|e| format!("Failed to insert content: {e}"))?;
     store
-        .insert_document(collection, &rel_path, &title, &hash, &now, &now)
+        .insert_document(collection, doc_key, &title, &hash, &now, &now)
         .map_err(|e| format!("Failed to insert document: {e}"))?;
 
-    tracing::debug!("Indexed {collection} file: {}", path.display());
+    tracing::debug!("Indexed {collection} document: {doc_key}");
     Ok(true)
 }
 
@@ -254,6 +270,35 @@ pub async fn reindex(store: &'static Mutex<Store>) -> Result<usize, String> {
     if let Err(e) = prune_result {
         tracing::warn!("Memory prune failed: {e}");
     }
+
+    // --- Index external paths (#1051) ---
+    // FTS-only here; embeddings ride the backfill below. The report carries
+    // every problem (missing / unreadable / nested roots) so nothing is
+    // silent. The periodic sweep reuses this same path, so extra_paths
+    // config changes reconcile within one interval (Q15) and file deletion
+    // is covered by the same prune.
+    let external_report = match tokio::task::spawn_blocking({
+        move || {
+            let store = store
+                .lock()
+                .map_err(|e| format!("Store lock poisoned: {e}"))?;
+            Ok::<_, String>(super::external::reindex_external(&store))
+        }
+    })
+    .await
+    {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            tracing::warn!("memory: external reindex failed: {e}");
+            super::external::ExternalReport::default()
+        }
+        Err(e) => {
+            tracing::warn!("memory: external reindex join failed: {e}");
+            super::external::ExternalReport::default()
+        }
+    };
+    external_report.log();
+    indexed += external_report.indexed;
 
     // --- Backfill embeddings for documents missing them ---
     if embedding_api_configured() {

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -10,6 +10,8 @@
 
 pub(crate) mod db;
 pub(crate) mod embedding;
+pub(crate) mod external;
+pub(crate) mod external_sweep;
 pub mod index;
 pub(crate) mod local_engine;
 pub(crate) mod search;
@@ -26,6 +28,7 @@ pub mod freshness;
 pub use db::Store;
 pub use index::{BRAIN_FILES, index_file, index_file_fts_only, reindex};
 pub use search::{RrfResult, hybrid_search_rrf, search, search_brain};
+pub(crate) use search::{search_external, search_memory};
 pub use store::get_store;
 
 /// Whether vector embeddings are enabled in the current config.
@@ -76,6 +79,60 @@ fn embedding_dimensions() -> usize {
     768 // local GGUF embeddinggemma-300M default
 }
 
+/// Extra external paths to index, from `[memory].extra_paths` (#1051).
+/// Read fresh on every call — config changes settle within one sweep
+/// interval with no restart or reload handler (the module live-reads
+/// config by construction).
+pub(crate) fn extra_paths_config() -> Vec<crate::config::ExtraPath> {
+    read_memory_config().extra_paths
+}
+
+/// Global exclude patterns for external indexing (#1051).
+pub(crate) fn external_excludes() -> Vec<String> {
+    read_memory_config().exclude
+}
+
+/// Whether external results may surface in shared/group sessions (#1051).
+/// Defaults to deny — the session gate is the security boundary.
+pub(crate) fn external_allowed_in_shared() -> bool {
+    read_memory_config().external_allowed_in_shared
+}
+
+/// Seconds between external freshness sweeps (#1051).
+pub(crate) fn sweep_interval_secs() -> u64 {
+    read_memory_config().sweep_interval_secs
+}
+
+/// Session IDs of shared/group channel sessions (#1051, ADR-003).
+///
+/// The external session gate must know whether the current session is a
+/// shared/group chat (several people can read the reply) or the owner's own
+/// session. Channel handlers know that when they resolve a session — they see
+/// the chat type — so they mark it here; `memory_search` checks it before
+/// returning external content. Process-local by design: on restart the set is
+/// empty and each channel re-marks its group sessions on first use, which is
+/// harmless because the gate only ever denies until then.
+static SHARED_SESSIONS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashSet<uuid::Uuid>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+/// Mark a session as a shared/group channel session (#1051). Called by the
+/// channel handlers when they resolve a session for a group chat.
+pub fn mark_session_shared(session_id: uuid::Uuid) {
+    if let Ok(mut g) = SHARED_SESSIONS.lock() {
+        g.insert(session_id);
+    }
+}
+
+/// Whether a session is a shared/group channel session (#1051). Consulted by
+/// the `memory_search` external gate.
+pub fn is_session_shared(session_id: uuid::Uuid) -> bool {
+    SHARED_SESSIONS
+        .lock()
+        .map(|g| g.contains(&session_id))
+        .unwrap_or(false)
+}
+
 /// A single search result from the memory index.
 #[derive(Debug, Clone)]
 pub struct MemoryResult {
@@ -88,3 +145,6 @@ pub struct MemoryResult {
 pub(crate) const COLLECTION_MEMORY: &str = "memory";
 /// Collection name for workspace brain files (SOUL.md, MEMORY.md, etc.).
 pub(crate) const COLLECTION_BRAIN: &str = "brain";
+/// Collection name for user-configured external paths (#1051). Keyed by
+/// absolute canonical path — unlike brain/memory, which key by basename.
+pub(crate) const COLLECTION_EXTERNAL: &str = "external";

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -5,9 +5,17 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use super::embedding::{embed_query_api, engine_if_ready};
-use super::{COLLECTION_BRAIN, MemoryResult, embedding_api_configured};
+use super::{
+    COLLECTION_BRAIN, COLLECTION_EXTERNAL, COLLECTION_MEMORY, MemoryResult,
+    embedding_api_configured,
+};
 
-/// Hybrid search across memory logs: FTS5 (BM25) + vector (cosine) via RRF.
+/// Hybrid search across ALL collections in the store: FTS5 (BM25) + vector
+/// (cosine) via RRF.
+///
+/// Kept collection-wide so existing callers (e.g. a2a debate context) see
+/// everything. Scope-specific variants: `search_memory`, `search_brain`,
+/// `search_external` (#1051).
 ///
 /// Falls back to FTS-only when the embedding engine is unavailable.
 /// Returns up to `n` results sorted by relevance.
@@ -21,7 +29,45 @@ pub async fn search(
     // here until the next restart — precisely when a duplicate check needs it.
     // Stat-only for unchanged files, single-flight guarded, never fatal.
     super::freshness::refresh_stale_brain_files().await;
+    search_core(store, query, n, None).await
+}
 
+/// Hybrid search over the memory-log collection only (#1051 scope="memory").
+pub(crate) async fn search_memory(
+    store: &'static Mutex<Store>,
+    query: &str,
+    n: usize,
+) -> Result<Vec<MemoryResult>, String> {
+    search_core(store, query, n, Some(COLLECTION_MEMORY)).await
+}
+
+/// Hybrid search over the EXTERNAL collection (#1051 scope="external").
+///
+/// Tier-1 freshness (ADR-002): after the first pass, refresh any hit whose
+/// mtime moved and re-query once, so an in-place edit is reflected. The
+/// tier-2 sweep handles additions and deletions; this catches content edits
+/// that don't bump the parent directory's mtime.
+pub(crate) async fn search_external(
+    store: &'static Mutex<Store>,
+    query: &str,
+    n: usize,
+) -> Result<Vec<MemoryResult>, String> {
+    let results = search_core(store, query, n, Some(COLLECTION_EXTERNAL)).await?;
+    let paths: Vec<String> = results.iter().map(|r| r.path.clone()).collect();
+    if super::freshness::refresh_stale_external(&paths).await > 0 {
+        return search_core(store, query, n, Some(COLLECTION_EXTERNAL)).await;
+    }
+    Ok(results)
+}
+
+/// Core hybrid search over one collection, or all collections when
+/// `collection` is `None`.
+async fn search_core(
+    store: &'static Mutex<Store>,
+    query: &str,
+    n: usize,
+    collection: Option<&'static str>,
+) -> Result<Vec<MemoryResult>, String> {
     let fts_query = sanitize_fts_query(query);
     if fts_query.is_empty() {
         return Ok(vec![]);
@@ -61,7 +107,7 @@ pub async fn search(
         let home = crate::config::opencrabs_home();
 
         let fts_results = store
-            .search_fts(&fts_query, n, None)
+            .search_fts(&fts_query, n, collection)
             .map_err(|e| format!("FTS search failed: {e}"))?;
 
         // Hybrid path: combine FTS + vector results via Reciprocal Rank Fusion
@@ -70,7 +116,7 @@ pub async fn search(
             // `hash || '_0'` only ever sees a document's first chunk, which
             // would make chunked embeddings write-only.
             let db_path = super::store::memory_dir().join("memory.db");
-            let vec_hits = super::vector_search::search_chunks(&db_path, query_emb, n, None)
+            let vec_hits = super::vector_search::search_chunks(&db_path, query_emb, n, collection)
                 .unwrap_or_default();
 
             if !vec_hits.is_empty() {
@@ -234,6 +280,13 @@ fn results_to_tuples_for(
 
 /// Resolve filesystem path for a search result based on its collection.
 fn resolve_path(home: &Path, collection: &str, doc_path: &str) -> String {
+    if collection == COLLECTION_EXTERNAL {
+        // External documents are keyed by ABSOLUTE path (#1051): the stored
+        // path IS the filesystem path. Rebuilding it as home/memory/<key>
+        // would point every external hit at a nonexistent file, so pass it
+        // through unchanged (mine map #3).
+        return doc_path.to_string();
+    }
     let p = if collection == COLLECTION_BRAIN {
         home.join(doc_path)
     } else {

--- a/src/tests/external_scope_test.rs
+++ b/src/tests/external_scope_test.rs
@@ -1,0 +1,74 @@
+//! #1051: external scope filtering + session gate.
+//!
+//! Verifies (a) search_fts with the external collection returns only
+//! external docs, (b) the memory scope excludes external, and (c) the
+//! session gate blocks external content in a marked-shared session.
+//! FTS-only (no embedding engine) so it runs anywhere.
+
+use crate::memory::db::Store;
+use crate::memory::{is_session_shared, mark_session_shared, COLLECTION_EXTERNAL};
+
+fn seed(store: &Store) {
+    let now = crate::utils::string::utc_timestamp();
+    let mem_hash = Store::hash_content("daily log about rust async");
+    let ext_hash = Store::hash_content("design notes on sqlite concurrency");
+    store.insert_content(&mem_hash, "daily log about rust async", &now).unwrap();
+    store.insert_document(
+        "memory",
+        "2026-08-14.md",
+        "2026-08-14",
+        &mem_hash,
+        &now,
+        &now,
+    )
+    .unwrap();
+    store.insert_content(&ext_hash, "design notes on sqlite concurrency", &now).unwrap();
+    store.insert_document(
+        COLLECTION_EXTERNAL,
+        "/home/u/notes/design.md",
+        "design.md",
+        &ext_hash,
+        &now,
+        &now,
+    )
+    .unwrap();
+}
+
+#[test]
+fn external_scope_returns_only_external_docs() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&tmp.path().join("mem.db")).expect("store");
+    seed(&store);
+
+    let hits = store
+        .search_fts("\"sqlite\" \"concurrency\"", 5, Some(COLLECTION_EXTERNAL))
+        .expect("fts");
+    assert_eq!(hits.len(), 1, "external scope hits the external doc");
+    assert_eq!(hits[0].doc.collection_name, COLLECTION_EXTERNAL);
+    // Absolute key passthrough (mine map #3): path stored as-is.
+    assert_eq!(hits[0].doc.path, "/home/u/notes/design.md");
+}
+
+#[test]
+fn memory_scope_excludes_external_docs() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&tmp.path().join("mem.db")).expect("store");
+    seed(&store);
+
+    // The external doc contains "sqlite"; memory scope must not surface it.
+    let hits = store
+        .search_fts("\"sqlite\"", 5, Some("memory"))
+        .expect("fts");
+    assert!(hits.iter().all(|h| h.doc.collection_name != COLLECTION_EXTERNAL));
+}
+
+#[test]
+fn session_gate_marks_and_detects_shared_sessions() {
+    use uuid::Uuid;
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    assert!(!is_session_shared(a), "unmarked session is not shared");
+    mark_session_shared(a);
+    assert!(is_session_shared(a), "marked session is shared");
+    assert!(!is_session_shared(b), "mark is per-session");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -481,6 +481,7 @@ pub mod voice_openai_compatible_test;
 pub mod voice_voicebox_test;
 //pub mod streaming_test;
 pub mod eval_baseline_test;
+pub mod external_scope_test;
 pub mod eval_before_after_test;
 pub mod eval_compaction_test;
 pub mod eval_live_resolver_test;


### PR DESCRIPTION
## #1051 — Memory external index paths

Implements the grill-verified spec (15 decisions across 3 rounds, ADR-002, ADR-003, 6-phase attack plan). Indexed filesystem paths outside the brain/memory corpus become searchable via `scope="external"`.

### Design (all 15 grill decisions honored)
- **Single `external` collection**, keyed by **absolute canonical path** (basename collisions impossible)
- **Two-tier freshness, no watcher** (ADR-002): lazy file-mtime refresh on search hits (tier 1) + periodic dir-mtime-pruned background sweep for additions/deletions (tier 2, default 300s)
- **Session gate, default-deny** (ADR-003): external content blocked in shared/group sessions unless `[memory] external_allowed_in_shared = true`. Marked by the Telegram/Discord/Slack/WhatsApp handlers.
- **Config live by construction** (Q15): sweep re-reads `[memory]` every loop — `extra_paths`/`sweep_interval_secs` changes settle within one interval, no restart, no reload handler
- **Secret-safe excludes** (defense in depth; gate is the real boundary)

### Commits
1. `0b0d0d16` P1 — config schema (`extra_paths`, `exclude`, `external_allowed_in_shared`, `sweep_interval_secs`)
2. `e7ea2e3a` P2 — index walk: absolute keys, glob, exclude, symlink skip, nested-root detection, prune
3. `c5ddb778` P3 — two-tier freshness + boot sweep spawn
4. `a1d848bd` P4/P5 — search scopes (`search_memory`/`search_external`/`search_core`), resolve_path absolute passthrough (mine map #3), session gate, 4-channel wiring

### Verification
- `cargo check --all-features --tests`: clean
- `cargo clippy --all-features --lib --tests`: clean (0 warnings in new code)
- `memory` suite: **112 passed**, including 4 sweep tests (cold/warm/add+delete/config-prune/excludes)
- `external_scope` integration: **3 passed** (external scope returns external docs with absolute keys, memory scope excludes them, gate marks/detects shared sessions)
- 7 config parse tests (string/table/empty/default/override)

### Files
- New: `src/memory/external.rs` (walk), `src/memory/external_sweep.rs` (tier 2), `src/tests/external_scope_test.rs`
- Modified: config schema, index boot wiring, freshness (tier 1 + sweep runner), search (scope split), memory_search tool (gate), 4 channel handlers, mod.rs (const + accessors + gate registry)

Closes #1051.
