### PR TITLE
fix(telegram): flow footer + section cap (#1052, #1053, #1054)

### DIFF
--- a/src/channels/telegram/delivery.rs
+++ b/src/channels/telegram/delivery.rs
@@ -51,6 +51,21 @@ pub(crate) fn is_react_only(text_after_directive: &str) -> bool {
 /// handle_message (#471 phase 2) — the only edit is early
 /// `return Ok(())` becoming `return Ok(false)` so the caller can
 /// preserve handle_message's original control flow exactly.
+/// Background-task indicator for the settled flow footer (#1054): the first
+/// task's label when exactly one is running, a count when several, `None`
+/// when nothing is detached or no manager is wired (#722). A settled turn
+/// that ends with detached work looks identical to a complete one without
+/// this, and the typing indicator staying alive is too easy to miss.
+pub(crate) fn bg_indicator_for(agent: &AgentService, session_id: Uuid) -> Option<String> {
+    let bm = agent.background_manager()?;
+    let tasks = bm.running_tasks(session_id);
+    match tasks.len() {
+        0 => None,
+        1 => Some(format!("{} running", tasks[0].label)),
+        n => Some(format!("{n} tasks running")),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn deliver_final_response(
     bot: &Bot,

--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -127,6 +127,12 @@ pub(crate) struct StreamingState {
     /// (`✅ Finished (N tool calls, 45s)` / `❌ Failed` / `⏱ Timed out`, #480).
     /// `None` while the turn is live.
     pub(crate) flow_outcome: Option<FlowOutcome>,
+    /// Background-work indicator for the settled footer (#1054): computed at
+    /// settle time from `agent.background_manager().running_tasks(session_id)`
+    /// — `Some("<label> running")` for one task, `Some("N tasks running")`
+    /// for several, `None` when nothing is detached. Rendered as the final
+    /// footer segment after the clock.
+    pub(crate) bg_indicator: Option<String>,
     /// Intermediate texts already sent — used to dedup final response
     pub(crate) sent_intermediates: Vec<String>,
     /// Message IDs of every intermediate chunk delivered to Telegram, so a
@@ -357,12 +363,15 @@ pub(crate) fn render_flow_html_chrome(
         sections,
         FOLDED_NARRATION_CAP,
         elapsed_secs,
+        None,
     )
 }
 
 /// Decompose the renderer's header / sections / activity into the merged-footer
 /// inputs (ADR 0005 Decision 12), shared by the classic and rich paths so the
 /// footer join can never drift between surfaces.
+#[allow(clippy::too_many_arguments)] // one primitive per footer input; the
+// decomposition IS the point (ADR 0005 Decision 12)
 fn footer_parts<'a>(
     header: &'a FlowHeader,
     fallback_status: Option<&'a str>,
@@ -371,6 +380,7 @@ fn footer_parts<'a>(
     tool_count: usize,
     has_log: bool,
     elapsed_secs: u64,
+    bg: Option<&'a str>,
 ) -> super::flow_chrome::FooterParts<'a> {
     let outcome = match header {
         FlowHeader::Settled { icon, verb, .. } => Some((*icon, *verb)),
@@ -385,6 +395,7 @@ fn footer_parts<'a>(
         has_log,
         ctx: sections.ctx.as_deref(),
         elapsed_secs,
+        bg,
     }
 }
 
@@ -441,6 +452,7 @@ pub(crate) fn render_flow_html_chrome_pref(
     sections: &super::flow_chrome::FlowSections,
     narration_cap: usize,
     elapsed_secs: u64,
+    bg: Option<&str>,
 ) -> String {
     let (out, tool_count) = flow_body_entries(lines, narration_cap);
     let has_log = !out.is_empty();
@@ -454,6 +466,7 @@ pub(crate) fn render_flow_html_chrome_pref(
             tool_count,
             has_log,
             elapsed_secs,
+            bg,
         ),
         HeaderMarkup::Html,
     );
@@ -527,6 +540,7 @@ pub(crate) fn render_flow_details_chrome(
         sections,
         FOLDED_NARRATION_CAP,
         elapsed_secs,
+        None,
     )
 }
 
@@ -544,6 +558,7 @@ pub(crate) fn render_flow_details_chrome_pref(
     sections: &super::flow_chrome::FlowSections,
     narration_cap: usize,
     elapsed_secs: u64,
+    bg: Option<&str>,
 ) -> String {
     let (out, tool_count) = flow_body_entries(lines, narration_cap);
     let has_log = !out.is_empty();
@@ -557,6 +572,7 @@ pub(crate) fn render_flow_details_chrome_pref(
             tool_count,
             has_log,
             elapsed_secs,
+            bg,
         ),
         HeaderMarkup::Html,
     );
@@ -835,6 +851,7 @@ pub(crate) fn render_flow(s: &StreamingState) -> String {
                 &s.sections,
                 narration_cap,
                 elapsed,
+                s.bg_indicator.as_deref(),
             )
         }
         None => render_flow_html_chrome_pref(
@@ -844,6 +861,7 @@ pub(crate) fn render_flow(s: &StreamingState) -> String {
             &s.sections,
             narration_cap,
             elapsed,
+            s.bg_indicator.as_deref(),
         ),
     }
 }
@@ -868,6 +886,7 @@ pub(crate) fn render_flow_details_state(s: &StreamingState) -> String {
                 &s.sections,
                 narration_cap,
                 elapsed,
+                s.bg_indicator.as_deref(),
             )
         }
         None => render_flow_details_chrome_pref(
@@ -877,6 +896,7 @@ pub(crate) fn render_flow_details_state(s: &StreamingState) -> String {
             &s.sections,
             narration_cap,
             elapsed,
+            s.bg_indicator.as_deref(),
         ),
     }
 }

--- a/src/channels/telegram/flow_chrome.rs
+++ b/src/channels/telegram/flow_chrome.rs
@@ -345,39 +345,43 @@ pub(crate) fn merged_footer(parts: &FooterParts, markup: HeaderMarkup) -> String
     let settled = parts.outcome.is_some();
     let mut segs: Vec<String> = Vec::new();
 
-    // Segment 1 — status: settled outcome, else plan state, else Working-on.
+    // Segment 1 — settled outcome leads; live turns lead with the LATEST
+    // ACTIVITY (what the agent is doing right now) and carry the
+    // reasoning/status second (#1052): the narration is the progress signal,
+    // the thinking excerpt is supplementary context. Strip a leading cog from
+    // the activity so the prefix is never doubled (#509 follow-up).
+    let mut live_activity = String::new();
     if let Some((icon, verb)) = parts.outcome {
         segs.push(format!("{icon} {}", esc(verb)));
-    } else if let Some(ps) = parts.plan_state {
-        segs.push(esc(ps));
-    } else if let Some(w) = parts.working_on {
-        segs.push(esc(w));
-    }
-
-    // Segment 2 — progress-log summary, only when a log exists. Live turns lead
-    // with the cog + activity; settled turns show a bare tool-call count with
-    // no cog (the stale narration is dropped, #498). Strip a leading cog from
-    // the activity so the prefix is never doubled (#509 follow-up).
-    if parts.has_log {
-        let mut seg2 = String::new();
-        if !settled && let Some(act) = parts.activity {
+    } else {
+        if parts.has_log && let Some(act) = parts.activity {
             let act = act.trim_start_matches(['⚙', '\u{fe0f}']).trim_start();
             if !act.is_empty() {
-                seg2 = format!("⚙️ {}", esc(act));
+                live_activity = format!("⚙️ {}", esc(act));
+                segs.push(live_activity.clone());
             }
         }
+        if let Some(ps) = parts.plan_state {
+            segs.push(esc(ps));
+        } else if let Some(w) = parts.working_on {
+            segs.push(esc(w));
+        }
+    }
+
+    // Segment 2 — progress-log summary, only when a log exists. Settled turns
+    // show a bare tool-call count with no cog (the stale narration is dropped,
+    // #498). Live turns show the count alone when the activity segment above
+    // already carries the cog, else the cog rides the count.
+    if parts.has_log {
+        let mut seg2 = String::new();
         if parts.tool_count >= 1 {
             let count = format!("{} tool calls", parts.tool_count);
-            if seg2.is_empty() {
-                seg2 = if settled {
-                    count
-                } else {
-                    format!("⚙️ {count}")
-                };
+            seg2 = if settled || !live_activity.is_empty() {
+                count
             } else {
-                seg2 = format!("{seg2} • {count}");
-            }
-        } else if !settled && seg2.is_empty() {
+                format!("⚙️ {count}")
+            };
+        } else if !settled && live_activity.is_empty() {
             // In-flight log with no tools and no activity preview yet: a bare
             // cog beats an empty segment so the footer still reads as active.
             seg2 = "⚙️".to_string();

--- a/src/channels/telegram/flow_chrome.rs
+++ b/src/channels/telegram/flow_chrome.rs
@@ -18,12 +18,11 @@ use teloxide::prelude::*;
 use uuid::Uuid;
 
 /// Longest plan-title / goal text shown in flow chrome before truncation.
-///
-/// 150, not 60 (#1053): the old cap truncated titles mid-sentence ("Fix
-/// Telegram message flow to display last...") and hid checklist task names
-/// exactly when the user needed them. 150 shows full context in almost all
-/// real titles at negligible height cost; genuinely longer text still gets
-/// cut with an ellipsis.
+/// Raised from 60 to 150 (#1053): 60 clipped meaningful plan titles and
+/// checklist items mid-phrase. 150 shows near-full text for realistic titles
+/// without making the card heavy with many long items. One cap for both
+/// title and checklist rows — a separate per-surface cap was considered and
+/// deferred until a real case asks for it.
 const SECTION_TEXT_CAP: usize = 150;
 
 /// Which plan keyboard the latest flow message owns. Keyboards attach only
@@ -312,14 +311,14 @@ pub(crate) struct FooterParts<'a> {
     /// Settled outcome `(icon, verb)` (e.g. `("✅", "Finished")`) once the turn
     /// ends; `None` while live. Drives segment 1 and drops the in-flight cog.
     pub(crate) outcome: Option<(&'a str, &'a str)>,
-    /// Plan-mode status line (Decision 7) when in Plan mode; leads segment 1
-    /// on a live turn.
+    /// Plan-mode status line (Decision 7) when in Plan mode; second segment on
+    /// a live turn (after the activity, #1052).
     pub(crate) plan_state: Option<&'a str>,
-    /// Non-plan "Working on …" / thinking preview; segment 1 fallback on a live
-    /// turn with no plan status.
+    /// Non-plan "Working on …" / thinking preview; live-turn fallback for the
+    /// reasoning segment (#1052: after the activity, not before it).
     pub(crate) working_on: Option<&'a str>,
-    /// Latest-activity preview for the in-flight progress-log summary
-    /// (segment 2); shown only while live and only when a log exists.
+    /// Latest-activity preview; LEADS the live footer (#1052). Shown only
+    /// while live and only when a log exists.
     pub(crate) activity: Option<&'a str>,
     /// Count of tool entries in the log (`N tool calls` when `>= 1`).
     pub(crate) tool_count: usize,
@@ -329,14 +328,21 @@ pub(crate) struct FooterParts<'a> {
     pub(crate) ctx: Option<&'a str>,
     /// Elapsed wall-clock seconds for the segment-4 clock glyph.
     pub(crate) elapsed_secs: u64,
+    /// Background-work indicator (#1054): `Some(label)` when detached tasks
+    /// are still running at settle time. Renders as the final footer segment
+    /// `🔧 <label> running` (or `🔧 N tasks running`) after the clock.
+    pub(crate) bg: Option<&'a str>,
 }
 
-/// Build the merged flow footer: one ` • `-joined string in the locked order
-/// status → progress-log summary → ctx → clock (ADR 0005 Decision 12). The
-/// renderer wraps it: rich as `<sub>` (plain footer line, or the processing-log
-/// `<summary>`); classic as a plain final line. In-flight the log summary
-/// carries the `⚙️` cog; a settled footer never does (segment 1 carries the
-/// `✅`/`❌` outcome instead).
+/// Build the merged flow footer: one ` • `-joined string (ADR 0005 Decision
+/// 12, amended by #1052). Settled: outcome → tool count → ctx → clock. Live:
+/// latest activity → reasoning/status → tool count → ctx → clock, because the
+/// narration (what the agent is DOING) is the progress signal and the
+/// reasoning excerpt is supplementary (#1052). The renderer wraps it: rich as
+/// `<sub>` (plain footer line, or the processing-log `<summary>`); classic as
+/// a plain final line. In-flight the log summary carries the `⚙️` cog; a
+/// settled footer never does (segment 1 carries the `✅`/`❌` outcome
+/// instead).
 pub(crate) fn merged_footer(parts: &FooterParts, markup: HeaderMarkup) -> String {
     let esc = |s: &str| match markup {
         HeaderMarkup::Html => escape_html(s),
@@ -345,16 +351,16 @@ pub(crate) fn merged_footer(parts: &FooterParts, markup: HeaderMarkup) -> String
     let settled = parts.outcome.is_some();
     let mut segs: Vec<String> = Vec::new();
 
-    // Segment 1 — settled outcome leads; live turns lead with the LATEST
-    // ACTIVITY (what the agent is doing right now) and carry the
-    // reasoning/status second (#1052): the narration is the progress signal,
-    // the thinking excerpt is supplementary context. Strip a leading cog from
+    // Segment 1 — settled outcome leads. LIVE turns lead with the latest
+    // activity (#1052), then the reasoning/status. Strip a leading cog from
     // the activity so the prefix is never doubled (#509 follow-up).
     let mut live_activity = String::new();
     if let Some((icon, verb)) = parts.outcome {
         segs.push(format!("{icon} {}", esc(verb)));
     } else {
-        if parts.has_log && let Some(act) = parts.activity {
+        if parts.has_log
+            && let Some(act) = parts.activity
+        {
             let act = act.trim_start_matches(['⚙', '\u{fe0f}']).trim_start();
             if !act.is_empty() {
                 live_activity = format!("⚙️ {}", esc(act));
@@ -370,8 +376,8 @@ pub(crate) fn merged_footer(parts: &FooterParts, markup: HeaderMarkup) -> String
 
     // Segment 2 — progress-log summary, only when a log exists. Settled turns
     // show a bare tool-call count with no cog (the stale narration is dropped,
-    // #498). Live turns show the count alone when the activity segment above
-    // already carries the cog, else the cog rides the count.
+    // #498). Live turns show the count alone when the activity segment already
+    // carries the cog, else the cog rides the count (#1052 split).
     if parts.has_log {
         let mut seg2 = String::new();
         if parts.tool_count >= 1 {
@@ -396,8 +402,16 @@ pub(crate) fn merged_footer(parts: &FooterParts, markup: HeaderMarkup) -> String
         segs.push(esc(c));
     }
 
-    // Segment 4 — clock, always last.
+    // Segment 4 — clock, always last (the #1054 background-task indicator
+    // appends after it when present).
     segs.push(clock_glyph(parts.elapsed_secs));
+
+    // Segment 5 — background-work indicator (#1054): a settled turn that ends
+    // with detached work looks identical to a complete one without this, and
+    // the typing indicator staying alive is too easy to miss.
+    if let Some(bg) = parts.bg {
+        segs.push(format!("🔧 {}", esc(bg)));
+    }
 
     segs.join(" • ")
 }

--- a/src/channels/telegram/flow_chrome.rs
+++ b/src/channels/telegram/flow_chrome.rs
@@ -18,7 +18,13 @@ use teloxide::prelude::*;
 use uuid::Uuid;
 
 /// Longest plan-title / goal text shown in flow chrome before truncation.
-const SECTION_TEXT_CAP: usize = 60;
+///
+/// 150, not 60 (#1053): the old cap truncated titles mid-sentence ("Fix
+/// Telegram message flow to display last...") and hid checklist task names
+/// exactly when the user needed them. 150 shows full context in almost all
+/// real titles at negligible height cost; genuinely longer text still gets
+/// cut with an ellipsis.
+const SECTION_TEXT_CAP: usize = 150;
 
 /// Which plan keyboard the latest flow message owns. Keyboards attach only
 /// after `plan init` succeeds: Approve + Discard while the design plan is

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -39,7 +39,7 @@ pub(crate) use super::keyboards::*;
 // Crash-recovery resume moved to resume.rs (#471 phase 1).
 pub(crate) use super::resume::resume_session;
 // Final-response delivery moved to delivery.rs (#471 phase 4).
-pub(crate) use super::delivery::{deliver_final_response, drain_remaining_display};
+pub(crate) use super::delivery::{bg_indicator_for, deliver_final_response, drain_remaining_display};
 
 /// Guard that cancels a CancellationToken on drop (used for typing loop).
 pub(crate) struct TypingGuard(pub(crate) CancellationToken);
@@ -3420,6 +3420,7 @@ pub(crate) async fn handle_message(
         tools_started_at: Some(std::time::Instant::now()),
         turn_started_at: std::time::Instant::now(),
         flow_outcome: None,
+        bg_indicator: None,
         sent_intermediates: Vec::new(),
         intermediate_msg_ids: Vec::new(),
         voice_msg_ids: Vec::new(),
@@ -4117,6 +4118,7 @@ pub(crate) async fn handle_message(
     {
         let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
         s.flow_outcome = Some(flow_outcome);
+        s.bg_indicator = bg_indicator_for(&agent, session_id);
     }
     // Recompute sections now that the turn has settled: the plan Approve/Discard
     // keyboard attaches only at turn end (load_plan_state_section keys off

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -141,6 +141,7 @@ pub(crate) async fn resume_session(
         tools_started_at: Some(std::time::Instant::now()),
         turn_started_at: std::time::Instant::now(),
         flow_outcome: None,
+        bg_indicator: None,
         sent_intermediates: Vec::new(),
         intermediate_msg_ids: Vec::new(),
         voice_msg_ids: Vec::new(),
@@ -638,6 +639,7 @@ pub(crate) async fn resume_session(
     {
         let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
         s.flow_outcome = Some(flow_outcome);
+        s.bg_indicator = super::handler::bg_indicator_for(&agent, session_id);
     }
     // Recompute sections at settle so the plan Approve/Discard keyboard, which
     // attaches only at turn end (#571), materializes on the final render — the

--- a/src/tests/telegram_flow_chrome_test.rs
+++ b/src/tests/telegram_flow_chrome_test.rs
@@ -482,6 +482,32 @@ fn footer_shows_both_working_on_status_and_activity_summary() {
 }
 
 #[test]
+fn live_footer_leads_with_activity_before_reasoning() {
+    // #1052: live order is activity → reasoning/status → tool count → ctx →
+    // clock. The narration (what the agent is doing) is the progress signal;
+    // the thinking excerpt is supplementary context.
+    let lines = [
+        tline("✅ bash", "ls"),
+        FlowLine::Text("Now checking the config.".to_string()),
+        tline("⚙️ read_file", "config.toml"),
+    ];
+    let out = render_flow_html_chrome(
+        &lines,
+        &FlowHeader::Live(Some("30s")),
+        Some("Working on: ship it"),
+        &FlowSections::default(),
+        30,
+    );
+    let footer = out.rsplit("</blockquote>\n").next().expect("footer present");
+    assert!(
+        footer.starts_with(
+            "⚙️ Now checking the config. • Working on: ship it • 2 tool calls • ⏱ 0:30"
+        ),
+        "activity must lead the live footer, got: {footer}"
+    );
+}
+
+#[test]
 fn single_tool_gets_its_own_log_block_and_footer() {
     // The lone-tool-plain shortcut is gone under ADR 0005: even one entry sits
     // in its own expandable with the footer below.

--- a/src/tests/telegram_flow_chrome_test.rs
+++ b/src/tests/telegram_flow_chrome_test.rs
@@ -483,9 +483,9 @@ fn footer_shows_both_working_on_status_and_activity_summary() {
 
 #[test]
 fn live_footer_leads_with_activity_before_reasoning() {
-    // #1052: live order is activity → reasoning/status → tool count → ctx →
-    // clock. The narration (what the agent is doing) is the progress signal;
-    // the thinking excerpt is supplementary context.
+    // #1052: live order is latest activity → reasoning/status → tool count →
+    // clock. The narration (what the agent is DOING) is the progress signal;
+    // the reasoning excerpt is supplementary context.
     let lines = [
         tline("✅ bash", "ls"),
         FlowLine::Text("Now checking the config.".to_string()),
@@ -498,12 +498,15 @@ fn live_footer_leads_with_activity_before_reasoning() {
         &FlowSections::default(),
         30,
     );
-    let footer = out.rsplit("</blockquote>\n").next().expect("footer present");
+    let footer = out
+        .rsplit("</blockquote>\n")
+        .next()
+        .expect("footer present");
     assert!(
         footer.starts_with(
             "⚙️ Now checking the config. • Working on: ship it • 2 tool calls • ⏱ 0:30"
         ),
-        "activity must lead the live footer, got: {footer}"
+        "activity leads, reasoning second: got {footer:?}"
     );
 }
 
@@ -553,6 +556,58 @@ fn settled_footer_drops_the_cog() {
     assert!(
         !footer.contains("⚙️"),
         "settled footer never carries the cog"
+    );
+}
+
+#[test]
+fn settled_footer_shows_bg_indicator_when_task_running() {
+    // #1054: a settled turn ending with detached work shows the indicator as
+    // the final segment after the clock; with nothing running the footer is
+    // unchanged (no stray wrench).
+    let lines = [tline("✅ bash", "ls"), tline("✅ grep", "todo")];
+    let header = FlowHeader::Settled {
+        icon: "✅",
+        verb: "Finished",
+        duration: "8:37",
+    };
+    let with_bg = render_flow_html_chrome_pref(
+        &lines,
+        &header,
+        None,
+        &FlowSections::default(),
+        usize::MAX,
+        517,
+        Some("cargo test running"),
+    );
+    assert!(
+        with_bg.ends_with("⏱ 8:37 • 🔧 cargo test running"),
+        "bg indicator rides after the clock: {with_bg:?}"
+    );
+    let without_bg = render_flow_html_chrome_pref(
+        &lines,
+        &header,
+        None,
+        &FlowSections::default(),
+        usize::MAX,
+        517,
+        None,
+    );
+    assert!(
+        without_bg.ends_with("⏱ 8:37") && !without_bg.contains('🔧'),
+        "no indicator when nothing is detached"
+    );
+    let many = render_flow_details_chrome_pref(
+        &lines,
+        &header,
+        None,
+        &FlowSections::default(),
+        usize::MAX,
+        517,
+        Some("3 tasks running"),
+    );
+    assert!(
+        many.contains("🔧 3 tasks running"),
+        "multiple tasks show the count, rich path included: {many:?}"
     );
 }
 
@@ -614,6 +669,7 @@ fn cli_cap_truncates_body_api_keeps_it_full_html() {
         &FlowSections::default(),
         300,
         2,
+        None,
     );
     let api = render_flow_html_chrome_pref(
         &lines,
@@ -622,6 +678,7 @@ fn cli_cap_truncates_body_api_keeps_it_full_html() {
         &FlowSections::default(),
         usize::MAX,
         2,
+        None,
     );
     assert!(
         cli.contains('…'),
@@ -649,6 +706,7 @@ fn cli_cap_truncates_body_api_keeps_it_full_details() {
         &FlowSections::default(),
         300,
         2,
+        None,
     );
     let api = render_flow_details_chrome_pref(
         &lines,
@@ -657,6 +715,7 @@ fn cli_cap_truncates_body_api_keeps_it_full_details() {
         &FlowSections::default(),
         usize::MAX,
         2,
+        None,
     );
     assert!(
         cli.contains('…'),
@@ -684,6 +743,7 @@ fn short_narration_untouched_by_either_cap() {
             &FlowSections::default(),
             cap,
             2,
+            None,
         );
         assert!(out.contains("brief note"));
         assert!(


### PR DESCRIPTION
## Telegram flow chrome fixes (#1052, #1053, #1054)

Three independent UX fixes to the telegram flow footer/header.

### #1053 — raise plan section text cap 60 → 150
`SECTION_TEXT_CAP` bumped so section/checklist text isn't truncated mid-word. Single shared cap for title + checklist (the issue's separate-cap idea was considered and rejected for v1).

### #1052 — lead live footer with activity
Live (streaming) footer reordered so the activity indicator leads, before reasoning state and tool count. Settled footer untouched. Both classic and rich paths share `merged_footer`, so both surfaces are covered in one place.

### #1054 — background-task running indicator
New `StreamingState.bg_indicator` renders `🔧 <label> running` / `🔧 N tasks running` as the final footer segment when background tasks are active. Computed at both settle points (main handler + crash-resume); helper in `delivery.rs`.

**Path note:** #1054's body named `crates/opencrabs-tui/src/flow/flow_chrome.rs` — that crate does not exist here. Implemented in the real file `src/channels/telegram/flow_chrome.rs`.

### Commits
- `ac5e0133` #1053 (cap)
- `ec7c0f95` #1052 (footer reorder + order test)
- `022a3442` #1054 (bg indicator + 3 render tests)

### Verification
- `cargo clippy --all-features --lib --tests`: clean
- telegram flow suite: full green, including new order + render tests
- full suite (6385 tests): green twice (ran against this branch's state)

Closes #1052, #1053, #1054.
