### PR TITLE
Force completion tokens config

### DIFF
--- a/src/brain/provider/custom_openai_compatible.rs
+++ b/src/brain/provider/custom_openai_compatible.rs
@@ -2206,6 +2206,8 @@ pub struct OpenAIProvider {
     /// via Arc so clones of this provider (and the FallbackProvider that
     /// wraps it) read the same buffer.
     retry_notices: Arc<std::sync::Mutex<Vec<(u32, u32, String)>>>,
+    /// Force use of max_completion_tokens field instead of max_tokens
+    use_max_completion_tokens: Option<bool>,
 }
 
 impl OpenAIProvider {
@@ -2276,6 +2278,7 @@ impl OpenAIProvider {
             cache_ttl: None,
             reasoning_setting: None,
             retry_notices: Arc::new(std::sync::Mutex::new(Vec::new())),
+            use_max_completion_tokens: None,
         }
     }
 
@@ -2311,6 +2314,7 @@ impl OpenAIProvider {
             cache_ttl: None,
             reasoning_setting: None,
             retry_notices: Arc::new(std::sync::Mutex::new(Vec::new())),
+            use_max_completion_tokens: None,
         }
     }
 
@@ -2346,6 +2350,7 @@ impl OpenAIProvider {
             cache_ttl: None,
             reasoning_setting: None,
             retry_notices: Arc::new(std::sync::Mutex::new(Vec::new())),
+            use_max_completion_tokens: None,
         }
     }
 
@@ -2460,6 +2465,12 @@ impl OpenAIProvider {
     /// Set OpenRouter cache TTL in seconds (1-86400, default 300).
     pub fn with_cache_ttl(mut self, ttl: u32) -> Self {
         self.cache_ttl = Some(ttl);
+        self
+    }
+
+    /// Set whether to force `max_completion_tokens` field usage.
+    pub fn with_use_max_completion_tokens(mut self, value: bool) -> Self {
+        self.use_max_completion_tokens = Some(value);
         self
     }
 
@@ -2839,7 +2850,9 @@ impl OpenAIProvider {
         // Newer OpenAI models (gpt-4.1-*, gpt-5-*, o1-*, o3-*) require
         // max_completion_tokens instead of max_tokens. Use the new field
         // for these models and fall back to max_tokens for everything else.
-        let uses_completion_tokens = uses_max_completion_tokens(&request.model);
+        let uses_completion_tokens = self
+            .use_max_completion_tokens
+            .unwrap_or_else(|| uses_max_completion_tokens(&request.model));
         let (max_tokens, max_completion_tokens) = if uses_completion_tokens {
             (None, request.max_tokens)
         } else {

--- a/src/brain/provider/factory.rs
+++ b/src/brain/provider/factory.rs
@@ -1645,6 +1645,11 @@ fn configure_openai_compatible(
         provider = provider.with_cache_ttl(ttl);
         tracing::info!("OpenRouter cache TTL: {}s", ttl);
     }
+    // Apply use_max_completion_tokens override
+    if let Some(use_completion) = config.use_max_completion_tokens {
+        provider = provider.with_use_max_completion_tokens(use_completion);
+    }
+
     provider
 }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -2166,6 +2166,10 @@ pub struct ProviderConfig {
     /// Default: 300 (5 minutes). Only used when cache_enabled is true.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_ttl: Option<u32>,
+    /// Force use of `max_completion_tokens` field instead of `max_tokens`.
+    /// Useful for providers like Scaleway that require this field for all models.
+    #[serde(default, rename = "use_max_completion_tokens")]
+    pub use_max_completion_tokens: Option<bool>,
 }
 
 fn default_enabled() -> bool {

--- a/src/docs/reference/ADDING_NEW_PROVIDERS.md
+++ b/src/docs/reference/ADDING_NEW_PROVIDERS.md
@@ -27,16 +27,17 @@ pub struct ProviderConfig {
     pub api_key: Option<String>,
     pub base_url: Option<String>,
     pub default_model: Option<String>,
-    pub models: Vec<String>,              // For providers without /models endpoint
-    pub vision_model: Option<String>,     // Vision-capable model override
-    pub generation_model: Option<String>, // Image generation model override
-    pub context_window: Option<u32>,      // Context window size in tokens
-    pub endpoint_type: Option<String>,    // For providers with multiple API modes
-    pub voice: Option<String>,            // TTS voice name (voice providers only)
-    pub model: Option<String>,            // TTS/image model override (voice/image providers)
-    pub enable_thinking: Option<bool>,    // Thinking-mode switch for reasoning models
-    pub cache_enabled: Option<bool>,      // Response caching (OpenRouter)
-    pub cache_ttl: Option<u32>,           // Cache TTL in seconds
+    pub models: Vec<String>,                      // For providers without /models endpoint
+    pub vision_model: Option<String>,             // Vision-capable model override
+    pub generation_model: Option<String>,         // Image generation model override
+    pub context_window: Option<u32>,              // Context window size in tokens
+    pub endpoint_type: Option<String>,            // For providers with multiple API modes
+    pub voice: Option<String>,                    // TTS voice name (voice providers only)
+    pub model: Option<String>,                    // TTS/image model override (voice/image providers)
+    pub enable_thinking: Option<bool>,            // Thinking-mode switch for reasoning models
+    pub cache_enabled: Option<bool>,              // Response caching (OpenRouter)
+    pub cache_ttl: Option<u32>,                   // Cache TTL in seconds
+    pub use_max_completion_tokens: Option<bool>,  // Force max_completion_tokens field
 }
 ```
 
@@ -297,6 +298,15 @@ enabled = true
 base_url = "https://api.yourprovider.com/v1"
 default_model = "your-reasoning-model"
 enable_thinking = true  # Enable hybrid reasoning mode
+```
+
+### With forced use of max_completion_tokens instead of max_tokens:
+```toml
+[providers.yourprovider]
+enabled = true
+base_url = "https://api.yourprovider.com/v1"
+default_model = "your-reasoning-model"
+use_max_completion_tokens = true
 ```
 
 ## Provider Requirements (Mandatory)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -450,6 +450,7 @@ pub mod usage_categorizer_test;
 pub mod usage_dashboard_test;
 pub mod usage_data_test;
 pub mod usage_ledger_attribution_test;
+pub mod use_max_completion_tokens_test;
 pub mod utils_file_extract_test;
 pub mod utils_install_test;
 pub mod utils_retry_test;

--- a/src/tests/use_max_completion_tokens_test.rs
+++ b/src/tests/use_max_completion_tokens_test.rs
@@ -1,0 +1,198 @@
+//! Tests for `use_max_completion_tokens` config field (#<issue-number>)
+//!
+//! Verifies that the config override correctly forces `max_completion_tokens`
+//! field usage regardless of model name detection. Tests serialize the request
+//! to JSON and check which field is present, rather than inspecting private fields.
+
+use crate::brain::provider::custom_openai_compatible::OpenAIProvider;
+use crate::brain::provider::types::{LLMRequest, Message};
+
+// ─── Model-based detection (existing behavior) ──────────────────────────
+
+#[test]
+fn model_detection_gpt41_uses_completion_tokens() {
+    let provider = OpenAIProvider::with_base_url(
+        "test-key".to_string(),
+        "https://api.example.com/v1".to_string(),
+    )
+    .with_name("test");
+
+    let request = LLMRequest::new("gpt-4.1-mini", vec![Message::user("hi")]).with_max_tokens(4096);
+
+    let openai_request = provider.to_openai_request(request);
+    let json = serde_json::to_value(&openai_request).unwrap();
+
+    // Should have max_completion_tokens, not max_tokens
+    assert!(
+        json.get("max_completion_tokens").is_some(),
+        "gpt-4.1-mini should use max_completion_tokens"
+    );
+    assert!(
+        json.get("max_tokens").is_none() || json["max_tokens"].is_null(),
+        "gpt-4.1-mini should not have max_tokens"
+    );
+}
+
+#[test]
+fn model_detection_o_series_uses_completion_tokens() {
+    let provider = OpenAIProvider::with_base_url(
+        "test-key".to_string(),
+        "https://api.example.com/v1".to_string(),
+    )
+    .with_name("test");
+
+    for model in ["o1-mini", "o1-preview", "o3-mini"] {
+        let request = LLMRequest::new(model, vec![Message::user("hi")]).with_max_tokens(4096);
+
+        let openai_request = provider.to_openai_request(request);
+        let json = serde_json::to_value(&openai_request).unwrap();
+
+        assert!(
+            json.get("max_completion_tokens").is_some(),
+            "{} should use max_completion_tokens",
+            model
+        );
+    }
+}
+
+#[test]
+fn model_detection_older_models_use_max_tokens() {
+    let provider = OpenAIProvider::with_base_url(
+        "test-key".to_string(),
+        "https://api.example.com/v1".to_string(),
+    )
+    .with_name("test");
+
+    for model in ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"] {
+        let request = LLMRequest::new(model, vec![Message::user("hi")]).with_max_tokens(4096);
+
+        let openai_request = provider.to_openai_request(request);
+        let json = serde_json::to_value(&openai_request).unwrap();
+
+        assert!(
+            json.get("max_tokens").is_some_and(|v| !v.is_null()),
+            "{} should use max_tokens",
+            model
+        );
+        assert!(
+            json.get("max_completion_tokens").is_none() || json["max_completion_tokens"].is_null(),
+            "{} should not have max_completion_tokens",
+            model
+        );
+    }
+}
+
+// ─── Config override behavior ──────────────────────────────────────────
+
+#[test]
+fn config_override_true_forces_completion_tokens_regardless_of_model() {
+    // Even for models that normally use max_tokens, the override should
+    // force max_completion_tokens
+    let provider = OpenAIProvider::with_base_url(
+        "test-key".to_string(),
+        "https://api.example.com/v1".to_string(),
+    )
+    .with_name("test")
+    .with_use_max_completion_tokens(true);
+
+    let request = LLMRequest::new("gpt-4o", vec![Message::user("hi")]).with_max_tokens(4096);
+
+    let openai_request = provider.to_openai_request(request);
+    let json = serde_json::to_value(&openai_request).unwrap();
+
+    // Should have max_completion_tokens set, max_tokens should be null/absent
+    assert!(
+        json.get("max_completion_tokens")
+            .is_some_and(|v| v.as_u64() == Some(4096)),
+        "Config override=true should force max_completion_tokens for gpt-4o"
+    );
+    assert!(
+        json.get("max_tokens").is_none() || json["max_tokens"].is_null(),
+        "Config override=true should not have max_tokens"
+    );
+}
+
+#[test]
+fn config_override_false_forces_max_tokens_for_newer_models() {
+    // Even for models that normally use max_completion_tokens, setting
+    // the override to false should force max_tokens
+    let provider = OpenAIProvider::with_base_url(
+        "test-key".to_string(),
+        "https://api.example.com/v1".to_string(),
+    )
+    .with_name("test")
+    .with_use_max_completion_tokens(false);
+
+    let request = LLMRequest::new("gpt-4.1", vec![Message::user("hi")]).with_max_tokens(8192);
+
+    let openai_request = provider.to_openai_request(request);
+    let json = serde_json::to_value(&openai_request).unwrap();
+
+    // Should have max_tokens set, max_completion_tokens should be null/absent
+    assert!(
+        json.get("max_tokens")
+            .is_some_and(|v| v.as_u64() == Some(8192)),
+        "Config override=false should force max_tokens for gpt-4.1"
+    );
+    assert!(
+        json.get("max_completion_tokens").is_none() || json["max_completion_tokens"].is_null(),
+        "Config override=false should not have max_completion_tokens"
+    );
+}
+
+#[test]
+fn no_config_override_uses_model_detection() {
+    // Without the override, behavior falls back to model detection
+    let provider = OpenAIProvider::with_base_url(
+        "test-key".to_string(),
+        "https://api.example.com/v1".to_string(),
+    )
+    .with_name("test");
+    // No with_use_max_completion_tokens call - uses default (None)
+
+    // gpt-4o should use max_tokens
+    let request_old = LLMRequest::new("gpt-4o", vec![Message::user("hi")]).with_max_tokens(4096);
+    let openai_request_old = provider.to_openai_request(request_old);
+    let json_old = serde_json::to_value(&openai_request_old).unwrap();
+
+    assert!(
+        json_old.get("max_tokens").is_some_and(|v| !v.is_null()),
+        "gpt-4o without override should use max_tokens"
+    );
+
+    // gpt-4.1 should use max_completion_tokens
+    let request_new = LLMRequest::new("gpt-4.1", vec![Message::user("hi")]).with_max_tokens(4096);
+    let openai_request_new = provider.to_openai_request(request_new);
+    let json_new = serde_json::to_value(&openai_request_new).unwrap();
+
+    assert!(
+        json_new
+            .get("max_completion_tokens")
+            .is_some_and(|v| !v.is_null()),
+        "gpt-4.1 without override should use max_completion_tokens"
+    );
+}
+
+#[test]
+fn scaleway_example_config_works() {
+    // Realistic test: Scaleway-like provider with override enabled
+    let provider = OpenAIProvider::with_base_url(
+        "scaleway-key".to_string(),
+        "https://api.scaleway.ai/v1/chat/completions".to_string(),
+    )
+    .with_name("scaleway")
+    .with_use_max_completion_tokens(true);
+
+    // Test with a model that would normally use max_tokens
+    let request = LLMRequest::new("mistral-large", vec![Message::user("hi")]).with_max_tokens(2048);
+
+    let openai_request = provider.to_openai_request(request);
+    let json = serde_json::to_value(&openai_request).unwrap();
+
+    // Should use max_completion_tokens due to config override
+    assert!(
+        json.get("max_completion_tokens")
+            .is_some_and(|v| v.as_u64() == Some(2048)),
+        "Scaleway config should force max_completion_tokens for all models"
+    );
+}


### PR DESCRIPTION
Possible solution for #1059 

Adds a config key to force all models on a provider to use `max_completion_tokens` instead of `max_tokens`.
Adds tests as well and updates documentation with an example

Also tested to success against the Scaleway API.