### PR TITLE
fix(brain): char-boundary-safe truncation in dedup scan rationale

### DIFF
--- a/src/brain/dedup_scan.rs
+++ b/src/brain/dedup_scan.rs
@@ -322,7 +322,7 @@ pub fn generate_dedup_proposals(brain_path: &Path) -> Vec<(ProposedBrainDedup, S
             let rationale = format!(
                 "Found '{}' appearing {} times across brain files. \
                  Keeping canonical copy at {}, removing duplicate(s).",
-                &cluster.text[..cluster.text.len().min(80)],
+                &cluster.text[..cluster.text.floor_char_boundary(80)],
                 cluster.total_count,
                 proposal.duplicate_of,
             );

--- a/src/tests/rsi_brain_dedup_test.rs
+++ b/src/tests/rsi_brain_dedup_test.rs
@@ -311,6 +311,35 @@ fn test_scan_finds_duplicates_in_same_file() {
 }
 
 #[test]
+fn test_generate_dedup_proposals_does_not_panic_on_multibyte_char_at_truncation_boundary() {
+    // Regression test for a panic reported in production:
+    //   "byte index 80 is not a char boundary; it is inside '—' (bytes 79..82)"
+    // generate_dedup_proposals() built its rationale string with
+    // `&cluster.text[..cluster.text.len().min(80)]`, a byte-index slice that
+    // ignores UTF-8 char boundaries. A duplicated line with a multi-byte
+    // character (e.g. an em dash '—', 3 bytes in UTF-8) straddling byte 80
+    // made the slice panic. 79 ASCII bytes + '—' puts the dash at exactly
+    // bytes 79..82, reproducing the original crash precisely.
+    let dir = TempDir::new().unwrap();
+    let filler: String = std::iter::repeat('a').take(79).collect();
+    let shared_line = format!("{filler}— duplicated line with a multi-byte dash at the cut");
+    write_brain_file(
+        dir.path(),
+        "SOUL.md",
+        &format!("# SOUL.md\n\n{shared_line}\n\nUnique soul content.\n"),
+    );
+    write_brain_file(
+        dir.path(),
+        "AGENTS.md",
+        &format!("# AGENTS.md\n\n{shared_line}\n\nUnique agents content.\n"),
+    );
+
+    // Must not panic.
+    let proposals = generate_dedup_proposals(dir.path());
+    assert!(!proposals.is_empty(), "should still detect the duplicate");
+}
+
+#[test]
 fn test_scan_finds_duplicates_across_files() {
     let dir = TempDir::new().unwrap();
     let shared_line =


### PR DESCRIPTION
## Root cause

`generate_dedup_proposals()` in `src/brain/dedup_scan.rs` builds a rationale string by slicing `cluster.text` with a raw byte index:

```rust
&cluster.text[..cluster.text.len().min(80)]
```

Rust string slicing requires the index to land on a UTF-8 char boundary. When byte 80 falls inside a multi-byte character (e.g. an em dash `—`, 3 bytes), this panics and takes down the tokio worker running the periodic RSI dedup scan:

```
thread 'tokio-rt-worker' panicked at src/brain/dedup_scan.rs:325:30:
byte index 80 is not a char boundary; it is inside '—' (bytes 79..82)
```

Reported live crash, reproduced and fixed here.

## Fix

Use `str::floor_char_boundary(80)` instead of a raw byte-length min. This is the same pattern already applied at ~90 other truncation call sites in this codebase (a2a/handler/stream.rs, brain/tools/*, brain/provider/*, etc.) following the earlier #885 fix for `clean_auto_title`. This PR was the one spot in `dedup_scan.rs` that missed that pattern.

## Test

Added `test_generate_dedup_proposals_does_not_panic_on_multibyte_char_at_truncation_boundary`, which reproduces the exact byte offset from the panic report (79 ASCII bytes + an em dash lands the multi-byte char at bytes 79..82, matching the crash log precisely) and asserts `generate_dedup_proposals` no longer panics on it.

Fixes #1081