### PR TITLE
fix(config): add brain/browser to KNOWN_TOP_LEVEL_KEYS typo whitelist

### DIFF
--- a/src/config/types/loader.rs
+++ b/src/config/types/loader.rs
@@ -446,6 +446,8 @@ impl Config {
         "image",
         "cron",
         "memory",
+        "brain",
+        "browser",
     ];
 
     /// Check for unknown top-level keys and log warnings.


### PR DESCRIPTION
Fixes #1089

## Summary
- `Config::brain: BrainConfig` and `Config::browser: BrowserConfig` (src/config/types.rs:81-92) are real, `#[serde(default)]`-deserialized fields, but `KNOWN_TOP_LEVEL_KEYS` in `src/config/types/loader.rs` never included `"brain"`/`"browser"`.
- Result: any `config.toml` with a valid `[brain]` or `[browser]` section prints a false-positive `⚠️ Unknown keys in config.toml (possible typos): brain, browser` on TUI startup (`src/tui/app/state.rs`), even though the config parses and works correctly.

## Fix
Add `"brain"` and `"browser"` to the whitelist. Two-line change, no behavior change beyond removing the spurious warning.

## Test plan
- [x] `cargo check` passes
- [x] Repro'd locally: a config.toml with `[brain]`/`[browser]` sections no longer appears in `Config::take_typo_warnings()`