### PR TITLE
fix: hard-gate self_improve/feedback to autonomous RSI only + pdfium single-bind (hotfix v0.3.81)

### DIFF
--- a/src/brain/prompt_builder.rs
+++ b/src/brain/prompt_builder.rs
@@ -213,18 +213,24 @@ RESPONSE FORMATTING (your Markdown renders as native rich blocks on Telegram, an
 - Put code, commands, file paths, and identifiers in ``` fenced blocks (and `inline code`); these stay copyable and monospaced.
 - Keep it proportionate: structure aids scanning, but do not manufacture headings or tables for a one-line answer.
 
-RECURSIVE SELF-IMPROVEMENT:
+RECURSIVE SELF-IMPROVEMENT (AUTONOMOUS-ONLY — NEVER IN USER RESPONSES):
 You have three tools for improving yourself over time:
 - feedback_analyze: Query your performance history (tool success rates, failure patterns, recent events). Call with query='summary' or query='tool_stats' or query='failures'.
 - feedback_record: Manually log observations — user corrections, patterns you notice, strategies that work well.
 - self_improve: Propose or apply changes to your brain files (SOUL.md, TOOLS.md, etc.). Runs autonomously — no human approval needed. Changes are logged to `rsi/improvements.md` and archived under `rsi/history/` in your OpenCrabs home (see Known paths — profile-scoped).
 
-Your tool executions are automatically tracked. When you notice recurring failures, user frustration, or repeated corrections:
-1. Call feedback_analyze with query='failures' to understand what's going wrong
-2. Call feedback_record to log the pattern you observed
-3. Call self_improve with action='apply' to apply a concrete improvement — brain file is edited, improvement is logged to rsi/improvements.md, and a daily archive entry is created
+=== HARD GATE — DO NOT CROSS ===
+These three tools are EXCLUSIVELY for the autonomous RSI cron cycle (configured via [agent] self_improvement_provider in the profile's config.toml). They are invoked by a separate, isolated agent on a schedule — NOT by the main responding agent.
 
-Do NOT call these tools every turn. Use them when you notice a pattern across multiple interactions, or when a user explicitly corrects you in a way that could apply to future conversations. Report significant improvements to the TUI or connected channels so the user knows what changed.
+DO NOT call feedback_analyze / feedback_record / self_improve in response to a user message. Ever.
+- It burns hundreds of thousands of tokens (each call can read a 200K improvements.md and 121K event log).
+- The main session is a real-time chat interface — users will abandon it if every "bre" triggers a 5-hour rabbit hole.
+- The autonomous RSI cron (separate agent, separate budget, no user waiting) already runs every 6h and will surface any real improvements.
+- If you genuinely spot a recurring problem the user should know about RIGHT NOW, say it in ONE plain-text sentence ("FYI: I keep hitting X when you ask Y, want me to log it via the next RSI cycle?") — do NOT call the tools.
+
+This is a real bug observed on 2026-08-17: a knowledge-specialist profile kept firing self_improve on every user question, burning 700K+ tokens and 5 hours to reply "Bre apa?". The fix above is a hard block on the main session calling these tools.
+
+If a user EXPLICITLY says "run self_improve now" or "self_improve apply X", that is a direct command — you may call it. Otherwise: hands off.
 
 LONG TASKS RUN IN THE BACKGROUND — don't block, don't hand-roll polling:
 Genuinely long shell commands (`cargo test`, `cargo build`, `npx remotion render`, `gh run watch`, and similar) are run DETACHED automatically: bash returns "running in the background" immediately, and THIS session resumes itself the moment the task finishes — the result is injected at your next tool-call boundary if you're still working, or starts a fresh turn if you've gone idle. So: run the command normally, then either do other independent work or wrap up — do NOT sit in a wait loop, do NOT re-run it to "check", and do NOT hand-roll a poll loop. When the background result comes back it will say so explicitly; report it to the user and continue whatever was waiting on it. (Ordinary quick commands still run inline and return their output directly, as before.)

--- a/src/brain/self_update.rs
+++ b/src/brain/self_update.rs
@@ -200,7 +200,10 @@ impl SelfUpdater {
         tracing::info!("Building OpenCrabs at {}", self.project_root.display());
 
         let mut child = Command::new("cargo")
-            .args(["build", "--release"])
+            // `pdfium` is NOT a default feature (see Cargo.toml [features]),
+            // yet the shipped binary is built with it — without this flag a
+            // `/rebuild` would silently produce a poppler-only binary.
+            .args(["build", "--release", "--features", "pdfium"])
             .env("RUSTFLAGS", "-C target-cpu=native")
             .current_dir(&self.project_root)
             .stdout(std::process::Stdio::piped())

--- a/src/utils/pdf_vision.rs
+++ b/src/utils/pdf_vision.rs
@@ -116,10 +116,34 @@ fn render_with_pdfium(
 ) -> Result<Vec<PathBuf>, String> {
     use pdfium_render::prelude::*;
 
-    let pdfium = Pdfium::new(
-        Pdfium::bind_to_system_library()
-            .map_err(|e| format!("Cannot bind pdfium library: {}", e))?,
-    );
+    // pdfium-render may only be initialized ONCE per process: `BINDINGS` is a
+    // process-global `OnceCell` and `Pdfium::new()` asserts it is still empty
+    // (pdfium.rs:180 `assertion failed: BINDINGS.get().is_none()`). The old
+    // code called `Pdfium::new(Pdfium::bind_to_system_library()?)` on EVERY
+    // render, so a second `pdf_to_images` call — or a race between two calls
+    // on parallel tokio workers — panicked the whole process instead of
+    // falling back to pdftoppm. Cache the bindings in a process-global
+    // `OnceLock` so every call reuses the same instance, and catch any init
+    // panic so a once-only violation degrades to the pdftoppm fallback
+    // instead of crashing the bot.
+    static PDFIUM: std::sync::OnceLock<Result<Pdfium, String>> = std::sync::OnceLock::new();
+
+    let pdfium: &Pdfium = match PDFIUM.get_or_init(|| {
+        // AssertUnwindSafe: the init closure runs exactly once; if it panics
+        // we must not take the whole process down — return an Err instead.
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Pdfium::bind_to_system_library()
+                .map_err(|e| format!("Cannot bind pdfium library: {e}"))
+                .map(Pdfium::new)
+        })) {
+            Ok(Ok(pdfium)) => Ok(pdfium),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err("pdfium library already initialized in this process".to_string()),
+        }
+    }) {
+        Ok(p) => p,
+        Err(e) => return Err(e.to_string()),
+    };
 
     let document = pdfium
         .load_pdf_from_file(pdf_path, None)


### PR DESCRIPTION
## Hotfix on top of tag v0.3.81 (matches running binary v0.3.81)

Two commits, based on tag `v0.3.81` (NOT main — main is ~113 commits ahead, so this may need a rebase before merge):

1. **`7df282ee` fix(prompt): hard-gate self_improve/feedback tools to autonomous RSI only** — patches `src/brain/prompt_builder.rs` RECURSIVE SELF-IMPROVEMENT section so agents NEVER call `feedback_analyze`/`feedback_record`/`self_improve` in user responses. Root cause of 5-hour response times + 700K-token rabbit holes on the materi-onno profile (78 tool calls in one retry loop).

2. **`321dab40` fix: bind pdfium once per process + build with pdfium feature** — cherry-picked upstream fix.

## Context
- materi-onno profile (374-PDF knowledge specialist) was triggering RSI tools on EVERY user message → 5h response times, tokens burned, Telegram flood from retry loops.
- Binary-level fix (system prompt overrides brain files), so AGENTS.md band-aid is insufficient — this patch is the real fix.
- Verified: branch pushed, commits present.