### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4495,7 +4495,7 @@ cargo test
 
 ## Star History Chart
 
-[![Star History Chart](https://api.star-history.com/svg?repos=adolfousier/opencrabs&type=date&legend=top-left)](https://www.star-history.com/#adolfousier/opencrabs)
+[![Star History Chart](https://star-history.dera.page/svg?repos=adolfousier/opencrabs&type=date&legend=top-left)](https://star-history.dera.page/#adolfousier/opencrabs&type=date)
 
 ## ✨ Stay Tuned
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the upstream GitHub stargazer API is restricted, so the image no longer renders.

This change points the chart at a working data source so it displays correctly again.