### PR TITLE
feat(tools): session_notify — cross-session push with mechanical sender attribution (#1203)

### DIFF
--- a/src/brain/tools/catalog.rs
+++ b/src/brain/tools/catalog.rs
@@ -135,6 +135,7 @@ pub const EXTENDED_TOOL_INVENTORY: &[(&str, &[&str])] = &[
             "send_input",
             "close_agent",
             "resume_agent",
+            "session_notify",
             "team_create",
             "team_delete",
             "team_broadcast",
@@ -277,6 +278,7 @@ pub fn tool_category(name: &str) -> &'static str {
             || n.starts_with("send_input")
             || n.starts_with("close_agent")
             || n.starts_with("resume_agent")
+            || n.starts_with("session_notify")
             || n.starts_with("team_") =>
         {
             "agents"

--- a/src/brain/tools/subagent/mod.rs
+++ b/src/brain/tools/subagent/mod.rs
@@ -10,6 +10,7 @@
 pub mod agent_type;
 mod close;
 pub mod manager;
+mod notify;
 pub mod reconcile;
 mod resume;
 mod send_input;
@@ -22,6 +23,7 @@ pub(crate) mod worktree;
 pub use agent_type::{build_child_registry, map_deprecated_agent_type};
 pub use close::CloseAgentTool;
 pub use manager::{SubAgent, SubAgentManager, SubAgentState};
+pub use notify::SessionNotifyTool;
 pub use resume::ResumeAgentTool;
 pub use send_input::SendInputTool;
 pub use spawn::SpawnAgentTool;

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -74,7 +74,7 @@ impl Tool for SessionNotifyTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidInput("'message' is required".into()))?;
         if message.trim().is_empty() {
-            return Ok(ToolResult::error("Refusing to send an empty message"));
+            return Ok(ToolResult::error("Refusing to send an empty message".to_string()));
         }
 
         // Mechanical sender signature — from execution context, not model text.

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -1,0 +1,121 @@
+//! session_notify tool — push a message into another live session's queue.
+//!
+//! Thin agent-facing wrapper over `session_routes::deliver_to_session`, so an
+//! orchestrator (e.g. a compiling agent) can hand work back to the sessions
+//! whose commits broke the build (issue adolfousier/opencrabs#1203).
+//!
+//! Sender identity is injected MECHANICALLY from `ToolExecutionContext`
+//! — the calling model can neither forge nor omit the `[session-notify
+//! from=<uuid>]` header prepended to every delivery.
+
+use crate::brain::tools::error::{Result, ToolError};
+use crate::brain::tools::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Tool that pushes a queued user message into another session.
+pub struct SessionNotifyTool;
+
+/// Short display form of a session UUID (first 8 hex chars).
+fn short_id(id: uuid::Uuid) -> String {
+    id.simple().to_string()[..8].to_string()
+}
+
+#[async_trait]
+impl Tool for SessionNotifyTool {
+    fn name(&self) -> &str {
+        "session_notify"
+    }
+
+    fn description(&self) -> &str {
+        "Push a message to another session's queue in this process. The target \
+         drains it at its next tool-loop boundary, or wakes immediately if idle. \
+         Every delivery carries a mechanical header [session-notify from=<sender \
+         session id>]; to reply, call session_notify with target_session set to \
+         that id. Discover target ids via session_search list/query."
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "target_session": {
+                    "type": "string",
+                    "description": "UUID of the target session (from session_search list/query, or the from=<id> header of a session_notify you received)"
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Text to deliver to the target session"
+                }
+            },
+            "required": ["target_session", "message"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![]
+    }
+
+    fn requires_approval(&self) -> bool {
+        false
+    }
+
+    async fn execute(&self, input: Value, context: &ToolExecutionContext) -> Result<ToolResult> {
+        let target = input
+            .get("target_session")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidInput("'target_session' is required".into()))?;
+        let target: uuid::Uuid = target.parse().map_err(|_| {
+            ToolError::InvalidInput(format!("'target_session' is not a valid UUID: {target}"))
+        })?;
+
+        let message = input
+            .get("message")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidInput("'message' is required".into()))?;
+        if message.trim().is_empty() {
+            return Ok(ToolResult::error("Refusing to send an empty message"));
+        }
+
+        // Mechanical sender signature — from execution context, not model text.
+        let from = context.session_id;
+        let msg = crate::brain::agent::QueuedUserMessage {
+            context_text: format!("[session-notify from={from}]\n\n{message}"),
+            display_text: format!("📨 notify from {}:\n{message}", short_id(from)),
+        };
+
+        if crate::brain::agent::service::session_routes::deliver_to_session(target, msg) {
+            Ok(ToolResult::success(format!(
+                "Delivered to session {target}. It will process the message on its next turn."
+            )))
+        } else {
+            Ok(ToolResult::error(format!(
+                "No live route for session {target} in this process — it has not messaged \
+                 since boot, or belongs to another instance/profile. Use a2a_send for \
+                 cross-instance targets."
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_id_truncates_to_8_chars() {
+        let id = uuid::Uuid::parse_str("3f2a1b4c5d6e7f8090a1b2c3d4e5f607").unwrap();
+        assert_eq!(short_id(id), "3f2a1b4c");
+    }
+
+    #[test]
+    fn name_and_schema_are_consistent() {
+        let tool = SessionNotifyTool;
+        assert_eq!(tool.name(), "session_notify");
+        assert!(!tool.requires_approval());
+        let schema = tool.input_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert_eq!(required.len(), 2);
+        assert!(!tool.description().is_empty());
+    }
+}

--- a/src/cli/tool_setup.rs
+++ b/src/cli/tool_setup.rs
@@ -143,6 +143,11 @@ pub(crate) fn register_core_agent_tools(
             tool_registry.clone(),
         ),
     ));
+    // Cross-session push (issue #1203): needs no manager — deliver_to_session
+    // is a free function on the in-process session-route registry.
+    tool_registry.register(Arc::new(
+        crate::brain::tools::subagent::SessionNotifyTool,
+    ));
 
     // Phase 6: Team orchestration
     let team_manager = Arc::new(crate::brain::tools::subagent::TeamManager::new());
@@ -165,7 +170,7 @@ pub(crate) fn register_core_agent_tools(
             team_manager.clone(),
         ),
     ));
-    tracing::info!("Registered 8 sub-agent + team orchestration tools");
+    tracing::info!("Registered 9 sub-agent + team orchestration tools");
 
     // Recursive Self-Improvement tools
     tool_registry.register(Arc::new(


### PR DESCRIPTION
## Summary

Adds **`session_notify`**, a new agent-facing tool for cross-session message push **within a single OpenCrabs process**. Any session can deliver a queued system message to any other live session by UUID; the receiving session drains it at its next tool-loop boundary, or immediately (fresh turn) if idle.

**Motivation.** Multi-agent workflows need an orchestrator/compiler session to hand results back to worker/editor sessions — the canonical loop being "compile the whole binary → push compile errors to each editing agent's session → editor fixes its own code". Today the only push path is sub-agent completion (`push_result()` in `spawn.rs`), which is tied to a parent-child relationship and only fires once, when the child finishes. `session_notify` generalizes delivery to arbitrary session pairs, in both directions.

Refs #1203 (part 1 of 2 — the session-discovery part lands separately) · Related: #1200 (forum-topic routing of background pushes — see caveats).

## Design

- Thin wrapper over the existing internal primitive `deliver_to_session(session_id, QueuedUserMessage)` (`src/brain/agent/service/session_routes.rs`) — the exact path sub-agent results already ride. No new transport, registry, or queue.
- Parameters: `{ target_session: Uuid, message: String }`.
- **Mechanical sender attribution.** The calling session's UUID is taken from `ToolExecutionContext.session_id` (execution context), never from model-generated text. On enqueue the tool prepends a `[session-notify from=<uuid>]` header to the payload. A receiving agent can always reply later by calling `session_notify` back with that UUID — reply routing comes free. The calling model cannot forge or omit the sender identity.
- Payload is built as a system `QueuedUserMessage`, so transcripts show a compact tagged entry instead of raw scaffolding.
- Delivery failure (target not registered: unknown id, different instance/profile, or not seen since boot) returns an error hinting at `a2a_send` for cross-instance targets.

Ontology kept deliberately tiny for LLM efficiency — three tokens total: `session_notify`, `from=<uuid>`, `Session-Id:` trailer.

## Changes

| File | Change |
|---|---|
| `src/brain/tools/subagent/notify.rs` | new tool (~130 lines), mirrors sibling `send_input.rs` structure |
| `src/brain/tools/subagent/mod.rs` | module wiring |
| `src/brain/tools/tool_setup.rs` | registration (agent tools 8→9) |
| `src/brain/tools/catalog.rs` | discovery-catalog entry + category arm |

No exhaustive-list test changes needed; assertions on these surfaces are additive.

## Verification

- **Compiles green:** built in CI (fork quick-build run 32877632142 @ merge sha `10c73644`; content of these 4 files on this branch proven byte-identical via empty `git diff <merge> <branch> -- <files>`).
- **Live end-to-end smoke test passed** in production: registry lookup → enqueue → mechanical header injection → drain at next tool boundary; received payload carried the intact `[session-notify from=…]` header.
- **Caller self-id already solved:** `session_context {operation:"summary"}` prints the session's own UUID (first line) — agents can sign commits with `Session-Id:` trailers without any new plumbing.
- **Lint gate:** baseline-diffed against upstream main — delta = 3 strict advisories on new lines only, all matching existing sibling-file house patterns (import style ≡ `send_input.rs:11`, qualified path style ≡ `spawn.rs:90`). Zero errors.

## Known limitations / future work

- **Same-process only.** `SESSION_ROUTES` is an in-process registry; pushing across instances/profiles stays on `a2a_send`.
- **Restart edge.** Routes are re-claimed by a session's first message after daemon boot; a push to a not-yet-seen session falls back to the booting surface instead of that session's forum topic.
- **Follow-up (tracked in #1203):** structured session discovery in `session_search` — print ids (short form) + last-active timestamps, sort descending, add a machine-readable `query` op — so agents can find target UUIDs without parsing commit trailers.

