### PR TITLE
telegram: render untagged Mermaid fences; surface diagram-bearing intermediates

### DIFF
--- a/src/channels/telegram/intermediates.rs
+++ b/src/channels/telegram/intermediates.rs
@@ -59,7 +59,9 @@ pub(crate) fn build_last_intermediate_with_footer(
 }
 
 /// Send a structured intermediate segment as a native rich message, returning
-/// its id for tracking. Returns `None` when the text carries no rich structure
+/// its id for tracking. Mermaid-aware (#1044/#1202): fences resolve to a media
+/// array; with no fence this is byte-identical to `send_rich_markdown_id`.
+/// Returns `None` when the text carries no rich structure
 /// or the rich API rejects it — the caller then falls back to the HTML path.
 pub(crate) async fn try_send_intermediate_rich(
     bot: &Bot,
@@ -70,7 +72,10 @@ pub(crate) async fn try_send_intermediate_rich(
     if !super::rich::should_send_native_rich(text) {
         return None;
     }
-    match super::rich::api::send_rich_markdown_id(
+    // Mermaid-aware sender (#1044/#1202): resolves fences into the rich
+    // markdown media array; byte-identical to send_rich_markdown_id when no
+    // fence is present, so non-diagram reports are unaffected.
+    match super::rich::send_rich_with_mermaid_id(
         bot.api_url().as_str(),
         bot.token(),
         chat_id.0,
@@ -102,6 +107,14 @@ pub(crate) fn is_deliverable_rich_report(text: &str) -> bool {
     // folded log as raw pipes. Reflow first — the same recovery the final-
     // response and HTML-render paths already apply. Idempotent.
     let reflowed = super::rich::reflow_collapsed_tables(text);
+    // A mermaid fence (tagged or content-classified, #1202) is report-shaped
+    // on its own: folding buries the diagram behind a tap-to-expand tap AND
+    // leaves raw fence text in the log, because neither the fold renderer nor
+    // the pre-fix rich path resolved fences. Surfaced intermediates go
+    // through deliver_intermediate_message, which now resolves them.
+    if super::rich::mermaid::has_mermaid_fence(&reflowed) {
+        return true;
+    }
     super::rich::contains_table(&reflowed) && text.trim().chars().count() >= 200
 }
 
@@ -137,7 +150,11 @@ pub(crate) async fn deliver_intermediate_message(
         s.intermediate_msg_ids.push(id);
         return true;
     }
-    let html = markdown_to_telegram_html(text);
+    // Resolve fences here too (#1142 parity): when the rich path rejected the
+    // message, the HTML fallback must still render the diagram instead of
+    // shipping raw fence text. Identical to markdown_to_telegram_html when
+    // the feature is off or no fence is present.
+    let html = super::rich::markdown_to_html_mermaid(text).await;
     if html.is_empty() {
         return false;
     }

--- a/src/channels/telegram/rich/mermaid.rs
+++ b/src/channels/telegram/rich/mermaid.rs
@@ -55,30 +55,75 @@ pub(crate) fn base64url(input: &str) -> String {
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(input.as_bytes())
 }
 
-/// Whether `text` contains an opening ``` fence tagged `mermaid`.
-/// A fast line-scan used to gate the richer (async) render path.
-pub(crate) fn has_mermaid_fence(text: &str) -> bool {
-    let mut in_fence = false;
-    for line in text.lines() {
-        let t = line.trim();
-        if let Some(rest) = t.strip_prefix("```") {
-            if in_fence {
-                in_fence = false; // a closing fence
-            } else {
-                if rest.trim().eq_ignore_ascii_case("mermaid") {
-                    return true;
-                }
-                in_fence = true;
-            }
+/// Whether a fence body (the text between opening and closing ``` lines)
+/// starts like a mermaid diagram. Used to classify *untagged* fences, whose
+/// info string is empty: models frequently emit diagrams as ```graph TD ...
+/// without the `mermaid` tag. The first non-blank, non-comment (`%%`) line
+/// must start with a known diagram opener; `graph` additionally requires a
+/// direction word (`TD`/`TB`/`BT`/`LR`/`RL`) so DOT-style `graph G {` and
+/// similar foreign notations are not misclassified.
+pub(crate) fn looks_like_mermaid_source(source: &str) -> bool {
+    for raw in source.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with("%%") {
+            continue;
         }
+        let mut words = line.split_whitespace();
+        let head = words.next().unwrap_or("").to_ascii_lowercase();
+        return match head.as_str() {
+            "graph" => words.next().is_some_and(|d| {
+                matches!(
+                    d.to_ascii_lowercase().as_str(),
+                    "td" | "tb" | "bt" | "lr" | "rl"
+                )
+            }),
+            "flowchart" | "sequencediagram" | "classdiagram" | "classdiagram-v2"
+            | "statediagram" | "statediagram-v2" | "erdiagram" | "journey" | "gantt"
+            | "pie" | "quadrantchart" | "requirementdiagram" | "gitgraph" | "mindmap"
+            | "timeline" | "zenuml" | "sankey-beta" | "xychart-beta" | "block-beta"
+            | "packet-beta" | "architecture-beta" => true,
+            _ => false,
+        };
     }
     false
 }
 
-/// Locate every ```mermaid fence in `text`, returning byte ranges and the
+/// Whether `text` contains a fence that should render as a mermaid diagram:
+/// either tagged ```mermaid, or untagged with mermaid-shaped content
+/// ([`looks_like_mermaid_source`]). A fast line-scan used to gate the richer
+/// (async) render path.
+pub(crate) fn has_mermaid_fence(text: &str) -> bool {
+    let mut in_fence = false;
+    let mut tagged_mermaid = false;
+    let mut body_start = 0usize;
+    let mut pos = 0usize;
+    for line in text.split_inclusive('\n') {
+        let line_end = pos + line.len();
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("```") {
+            if in_fence {
+                let body = text[body_start..pos].trim_end_matches('\n');
+                if tagged_mermaid || (rest.is_empty() && looks_like_mermaid_source(body)) {
+                    return true;
+                }
+                in_fence = false;
+            } else {
+                in_fence = true;
+                tagged_mermaid = rest.trim().eq_ignore_ascii_case("mermaid");
+                body_start = line_end;
+            }
+        }
+        pos = line_end;
+    }
+    false
+}
+
+/// Locate every mermaid fence in `text`, returning byte ranges and the
 /// diagram source between the fences. Consistent with [`has_mermaid_fence`]:
-/// a fence is an opening ``` whose info string trims to `mermaid`
-/// (case-insensitive), closed by the next bare ``` line.
+/// a fence qualifies when its info string trims to `mermaid`
+/// (case-insensitive), or is empty and the body starts like a diagram
+/// ([`looks_like_mermaid_source`]); either way it is closed by the next
+/// bare ``` line.
 pub(crate) fn find_mermaid_fences(text: &str) -> Vec<MermaidFence> {
     let mut fences = Vec::new();
     let mut in_fence = false;
@@ -92,11 +137,12 @@ pub(crate) fn find_mermaid_fences(text: &str) -> Vec<MermaidFence> {
         let trimmed = line.trim();
         if let Some(rest) = trimmed.strip_prefix("```") {
             if in_fence {
-                if is_mermaid {
+                let source = &text[source_start..pos];
+                if is_mermaid || (rest.is_empty() && looks_like_mermaid_source(source)) {
                     fences.push(MermaidFence {
                         start: block_start,
                         end: line_end,
-                        source: text[source_start..pos].to_string(),
+                        source: source.to_string(),
                     });
                 }
                 in_fence = false;
@@ -256,10 +302,10 @@ pub(crate) fn resolve_blocks(blocks: Vec<Block>) -> BoxFuture<'static, Vec<Block
 fn resolve_block(block: Block) -> BoxFuture<'static, Block> {
     async move {
         match block {
-            Block::Code {
-                lang: Some(lang),
-                text,
-            } if is_mermaid_lang(&lang) => {
+            Block::Code { lang, text }
+                if lang.as_deref().is_some_and(is_mermaid_lang)
+                    || (lang.is_none() && looks_like_mermaid_source(&text)) =>
+            {
                 let result = prevalidate(&text).await;
                 Block::Mermaid {
                     source: text,

--- a/src/tests/telegram_flow_chrome_test.rs
+++ b/src/tests/telegram_flow_chrome_test.rs
@@ -1208,3 +1208,29 @@ fn deliverable_rich_report_detects_collapsed_tables() {
         "Checking the a|b split now, will report once the run finishes and the numbers settle."
     ));
 }
+
+#[test]
+fn deliverable_rich_report_surfaces_mermaid_diagrams() {
+    // #1202 follow-up: a diagram emitted before a tool call is report-shaped
+    // content too. Folding buries it behind a tap-to-expand tap AND leaves
+    // raw fence text there — no fold-side renderer resolves mermaid. Any
+    // closed mermaid fence therefore surfaces, regardless of total length.
+    use crate::channels::telegram::intermediates::is_deliverable_rich_report;
+
+    let tagged = "Dependency graph of today's fix:\n\n\
+        ```mermaid\ngraph TD\n    A[Push] --> B[Issue]\n```\n";
+    assert!(is_deliverable_rich_report(tagged));
+
+    // Untagged fence whose body classifies as mermaid (#1202) counts too.
+    let untagged =
+        "Same graph without the qualifier:\n\n```\ngraph TD\n    A[Push] --> B[Issue]\n```\n";
+    assert!(is_deliverable_rich_report(untagged));
+
+    // An untagged NON-mermaid code block keeps folding.
+    let sql = "Migration used:\n\n```\nSELECT id FROM users WHERE active = 1;\n```\n";
+    assert!(!is_deliverable_rich_report(sql));
+
+    // Unclosed fence stays folded (matches final-delivery semantics).
+    let unclosed = "Draft diagram:\n\n```mermaid\ngraph TD\n    A --> B\n";
+    assert!(!is_deliverable_rich_report(unclosed));
+}

--- a/src/tests/telegram_mermaid_test.rs
+++ b/src/tests/telegram_mermaid_test.rs
@@ -13,8 +13,8 @@ use crate::channels::telegram::rich::ast::{Block, Inline, MermaidResult};
 use crate::channels::telegram::rich::markdown_to_html_mermaid;
 use crate::channels::telegram::rich::mermaid::{
     MediaEntry, base64url, error_note, failure_html, find_mermaid_fences, has_mermaid_fence,
-    image_html, is_image_response, markdown_failure_block, replacement_for, resolve_blocks,
-    resolve_markdown_media,
+    image_html, is_image_response, looks_like_mermaid_source, markdown_failure_block,
+    replacement_for, resolve_blocks, resolve_markdown_media,
 };
 
 // ---------------------------------------------------------------------------
@@ -335,4 +335,66 @@ async fn resolve_markdown_media_passes_through_without_fences() {
     let (resolved, media) = resolve_markdown_media(text).await;
     assert_eq!(resolved, text, "no-fence text must be byte-identical");
     assert!(media.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// untagged fences (bare ```) classified by content
+// ---------------------------------------------------------------------------
+
+#[test]
+fn has_mermaid_fence_detects_untagged_mermaid_bodies() {
+    assert!(has_mermaid_fence("```\ngraph TD\nA-->B\n```"));
+    assert!(has_mermaid_fence("```\nflowchart LR\nA-->B\n```"));
+    assert!(has_mermaid_fence("```\nsequenceDiagram\nA->>B: hi\n```"));
+    // Blank and %%-comment lines are skipped before classification.
+    assert!(has_mermaid_fence("```\n\n%%{init: {}}%%\ngitGraph\n```"));
+}
+
+#[test]
+fn has_mermaid_fence_rejects_untagged_non_mermaid_bodies() {
+    // Plain code.
+    assert!(!has_mermaid_fence("```\nSELECT * FROM t;\n```"));
+    // DOT notation: digraph, or graph without a mermaid direction word.
+    assert!(!has_mermaid_fence("```\ndigraph G { a -> b }\n```"));
+    assert!(!has_mermaid_fence("```\ngraph G {\n  a -- b\n}\n```"));
+    assert!(!has_mermaid_fence("```\ngraph\n```"));
+}
+
+#[test]
+fn find_mermaid_fences_locates_untagged_fences_with_ranges() {
+    let text = "before\n```\ngraph TD\nA-->B\n```\nafter";
+    let fences = find_mermaid_fences(text);
+    assert_eq!(fences.len(), 1);
+    let f = &fences[0];
+    // start points at the opening fence line, end just past the closing one.
+    assert_eq!(&text[f.start..f.end], "```\ngraph TD\nA-->B\n```\n");
+    assert_eq!(f.source, "graph TD\nA-->B\n");
+}
+
+#[test]
+fn find_mermaid_fences_mixes_tagged_and_untagged_in_order() {
+    let text = "```mermaid\nA\n```\nmid\n```\nflowchart TD\nB\n```";
+    let fences = find_mermaid_fences(text);
+    assert_eq!(fences.len(), 2);
+    assert_eq!(fences[0].source, "A\n");
+    assert_eq!(fences[1].source, "flowchart TD\nB\n");
+    assert!(fences[0].start < fences[1].start);
+}
+
+#[test]
+fn find_mermaid_fences_ignores_untagged_non_mermaid_and_unclosed() {
+    assert!(find_mermaid_fences("```\nprint('hi')\n```").is_empty());
+    // Unclosed untagged fence: nothing captured, same as tagged.
+    assert!(find_mermaid_fences("```\ngraph TD\n").is_empty());
+}
+
+#[test]
+fn looks_like_mermaid_source_matches_known_openers() {
+    assert!(looks_like_mermaid_source("graph BT\na-->b"));
+    assert!(looks_like_mermaid_source("flowchart LR\na-->b"));
+    assert!(looks_like_mermaid_source("stateDiagram-v2\n[*] --> s1"));
+    assert!(looks_like_mermaid_source("erDiagram\nUSER ||--o{ POST : has"));
+    assert!(looks_like_mermaid_source("%% comment\nclassDiagram\nclass A"));
+    assert!(!looks_like_mermaid_source("let x = 1;"));
+    assert!(!looks_like_mermaid_source(""));
 }


### PR DESCRIPTION
Refs #1202 (problem statement + patch links there).

## Problem

LLM-generated messages frequently wrap Mermaid in a bare ``` fence without the `mermaid` info string. The rich renderer only treated fences tagged `mermaid` as diagrams (#1044), so these rendered as gray code boxes. Separately, assistant narration emitted *before* a tool call ("intermediates") is folded into the expandable flow blockquote as escaped plain text — so even correctly tagged diagrams vanished behind tap-to-expand as raw source.

## Changes

**Commit 1 — content-based untagged classification**
- new `looks_like_mermaid_source()`: first non-blank, non-`%%` line must start a known opener (`flowchart`, `graph`, `sequenceDiagram`, `classDiagram`, `stateDiagram`, `erDiagram`, `gantt`, `pie`, `mindmap`, `timeline`, `gitGraph`, …)
- a bare `graph` additionally requires a direction token (`TD/TB/BT/LR/RL`), so Graphviz DOT sources stay plain code
- wired into all three render paths: fence-detection gate, markdown+media path, and the HTML fallback (`Code{lang: None}`)

**Commit 2 — intermediate surfacing**
- the deliverable-rich gate for pre-tool-call narration now also accepts any closed mermaid fence (tagged or content-classified), so diagram-bearing intermediates surface as their own rendered bubble instead of folding into the collapsed flow log
- surfaced sends route through the mermaid-resolving sender; the HTML fallback resolves fences too
- non-fence rich reports keep byte-identical behavior

## Tests

New cases in `telegram_mermaid_test.rs` / `telegram_flow_chrome_test.rs`: detection positives per opener, rejections (SQL, DOT `graph G {`, bare unclassifiable fence), byte-range extraction on an untagged fence, mixed tagged+untagged ordering, unclosed-fence pass-through, surfacing-gate coverage.

## Verification

Deployed on our fork build and verified live in production against Telegram's renderer: untagged fences render as diagrams, and diagram-bearing intermediates surface as standalone rendered bubbles.
