### PR TITLE
fix(subagents): re-bind tool_search to each child registry so runtime-activated tools work in children

### DIFF
--- a/src/brain/tools/subagent/agent_type.rs
+++ b/src/brain/tools/subagent/agent_type.rs
@@ -13,7 +13,10 @@
 //! bash, so it was write-capable). Unknown values fail closed rather than
 //! silently escalating to full write access.
 
-use crate::brain::tools::ToolRegistry;
+use crate::brain::tools::catalog;
+use crate::brain::tools::registry::ToolRegistry;
+use crate::brain::tools::tool_search::ToolSearchTool;
+use std::sync::Arc;
 
 /// Tools that sub-agents must NEVER have access to (prevents recursion / dangerous ops).
 const ALWAYS_EXCLUDED: &[&str] = &[
@@ -34,11 +37,31 @@ const ALWAYS_EXCLUDED: &[&str] = &[
 /// This is the FULL-access child baseline. When the parent granted only read
 /// access, the caller additionally applies plan_gate's
 /// `restrict_registry_to_read_only` on the returned registry.
-pub fn build_child_registry(parent: &ToolRegistry) -> ToolRegistry {
-    let child = ToolRegistry::new();
+///
+/// Returns an [`Arc`] because callers hand the registry to `AgentService`
+/// wrapped anyway — and because [`ToolSearchTool`] must be RE-BOUND to this
+/// child Arc (#1210): the parent's search-tool instance captured the parent's
+/// registry at construction. Copying that instance here made a child's
+/// `tool_search` activate schemas in the PARENT's registry under the child's
+/// session id, while the child's request builder read active tools from its
+/// OWN registry — so a discovered tool's schema never rode on the child's
+/// next request, and well-behaved models looped re-searching forever instead
+/// of emitting calls for undeclared tools (observed live on two models across
+/// two providers; see upstream #1210). Re-binding per level also keeps the
+/// fix correct for nested spawns: each generation's search tool points at
+/// its own registry.
+pub fn build_child_registry(parent: &ToolRegistry) -> Arc<ToolRegistry> {
+    let child = Arc::new(ToolRegistry::new());
 
     for name in parent.list_tools() {
         if ALWAYS_EXCLUDED.contains(&name.as_str()) {
+            continue;
+        }
+
+        if name == catalog::TOOL_SEARCH_NAME {
+            // Fresh instance bound to THIS registry, so the child's searches
+            // land where the child's requests read (#1210).
+            child.register(Arc::new(ToolSearchTool::new(child.clone())));
             continue;
         }
 

--- a/src/brain/tools/subagent/resume.rs
+++ b/src/brain/tools/subagent/resume.rs
@@ -216,7 +216,7 @@ impl Tool for ResumeAgentTool {
             Arc::new(
                 crate::brain::agent::AgentService::new(provider, service_context, &config)
                     .await
-                    .with_tool_registry(Arc::new(child_registry))
+                    .with_tool_registry(child_registry)
                     .with_auto_approve_tools(true)
                     .with_working_directory(context.working_dir()),
             )

--- a/src/brain/tools/subagent/spawn.rs
+++ b/src/brain/tools/subagent/spawn.rs
@@ -419,7 +419,7 @@ impl Tool for SpawnAgentTool {
             let agent =
                 crate::brain::agent::AgentService::new(provider, service_context.clone(), &config)
                     .await
-                    .with_tool_registry(Arc::new(child_registry))
+                    .with_tool_registry(child_registry)
                     .with_auto_approve_tools(true) // children auto-approve (parent already approved spawn)
                     .with_working_directory(child_dir)
                     .with_plan_session_override(plan_session_override);

--- a/src/brain/tools/subagent/team/create.rs
+++ b/src/brain/tools/subagent/team/create.rs
@@ -285,7 +285,7 @@ impl Tool for TeamCreateTool {
             let child_service = Arc::new(
                 crate::brain::agent::AgentService::new(provider, service_context.clone(), &config)
                     .await
-                    .with_tool_registry(Arc::new(child_registry))
+                    .with_tool_registry(child_registry)
                     .with_auto_approve_tools(true)
                     .with_working_directory(context.working_dir()),
             );

--- a/src/tests/tool_search_activation_test.rs
+++ b/src/tests/tool_search_activation_test.rs
@@ -12,7 +12,14 @@
 //! announcement-loop detector. Removing the spawn from the task made it
 //! complete immediately.
 
+use crate::brain::tools::catalog;
 use crate::brain::tools::registry::ToolRegistry;
+use crate::brain::tools::subagent;
+use crate::brain::tools::tool_search::ToolSearchTool;
+use crate::brain::tools::{self, Tool, ToolExecutionContext};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::sync::Arc;
 use uuid::Uuid;
 
 /// A tool the session has not searched for is not active.
@@ -62,5 +69,83 @@ fn tool_search_activates_what_it_returns() {
         src.contains("activate_tools"),
         "tool_search must activate its matches; returning schemas as text only \
          leaves the model unable to call what it just found"
+    );
+}
+
+/// Minimal EXTENDED tool for discovery tests — deliberately outside
+/// CORE_TOOLS so `search_tools` matches it (it filters out core tools) and
+/// activation is what puts it on the request.
+struct ProbeTool;
+
+#[async_trait]
+impl Tool for ProbeTool {
+    fn name(&self) -> &str {
+        "probe_channel_send"
+    }
+    fn description(&self) -> &str {
+        "Send a probe message on a channel; #1210 discovery regression fixture."
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object", "properties": {}})
+    }
+    fn capabilities(&self) -> Vec<tools::ToolCapability> {
+        vec![]
+    }
+    async fn execute(&self, _input: Value, _ctx: &ToolExecutionContext) -> tools::error::Result<tools::ToolResult> {
+        Ok(tools::ToolResult::success("sent".to_string()))
+    }
+}
+
+/// Regression for #1210: a child's tool_search must activate into the CHILD's
+/// registry, not the parent's.
+///
+/// Production wiring binds the discovery tool to the PARENT registry at
+/// startup (tool_setup), then `build_child_registry` copies those instances
+/// into a fresh child registry. Pre-fix, the child inherited the parent-bound
+/// instance, so a search executed under the child's session id wrote the
+/// parent's active-set while the child's request builder read its OWN
+/// (empty) one — the discovered schema never rode on a child request, and
+/// well-behaved models looped re-searching instead of emitting calls for
+/// undeclared tools. Observed live on two models across two providers.
+#[tokio::test]
+async fn child_tool_search_activates_into_the_child_registry() {
+    // Parent registry with the discovery tool bound to ITSELF, exactly as
+    // startup wiring does.
+    let parent = Arc::new(ToolRegistry::new());
+    parent.register(Arc::new(ProbeTool));
+    parent.register(Arc::new(ToolSearchTool::new(parent.clone())));
+
+    // Child registry built the way spawn/resume/team_create build theirs.
+    let child = subagent::build_child_registry(&parent);
+
+    // The child must carry its OWN discovery instance...
+    let child_search = child
+        .get(catalog::TOOL_SEARCH_NAME)
+        .expect("child must inherit tool_search");
+
+    let session = Uuid::new_v4();
+    let ctx = ToolExecutionContext::new(session);
+    let result = child_search
+        .execute(
+            json!({"query": "send probe message on channel"}),
+            &ctx,
+        )
+        .await
+        .expect("child tool_search executes");
+    assert!(result.success, "search failed: {:?}", result.error);
+
+    // THE assertion (#1210): the discovered tool's schema now rides on the
+    // CHILD's next request.
+    assert!(
+        child.active_tools(session).contains("probe_channel_send"),
+        "#1210: child's tool_search must activate into the CHILD registry; \
+         pre-fix the write landed in the parent's registry while the child \
+         read its own empty active set, so the schema never rode"
+    );
+
+    // ...and a child's search must never mutate the PARENT's active set.
+    assert!(
+        !parent.active_tools(session).contains("probe_channel_send"),
+        "a child's tool_search writes its own registry, never the parent's"
     );
 }


### PR DESCRIPTION
## Problem

Tools activated at runtime via `tool_search` are never callable inside **subagent sessions**. A child that searches for a tool receives the schema back as text, then re-runs `tool_search` forever because the tool never appears in its request's tool set. Observed live (#1210): two independent models on two providers (deepseek-v4-flash/openrouter, kimi-k2.7-code/opencode) converged byte-identically on this loop — four identical `tool_search` calls each, zero calls to the searched tool — until the harness loop-breaker killed the turn.

## Root cause

The activation write and the request-build read hit **different registry instances**:

- `ToolSearchTool::new(tool_registry.clone())` binds the discovery tool to the **parent** registry Arc once at setup (`cli/tool_setup.rs:116`)
- `build_child_registry` copies the *same* `Arc<dyn Tool>` instances into a fresh child registry (`src/brain/tools/subagent/agent_type.rs`) — children stabilize at 61 tools vs parent 71
- a child's search activates matches into the captured (**parent**) registry under the *child's* session id (`src/brain/tools/tool_search.rs:115`)
- the child's request builder reads `self.tool_registry.active_tools(session_id)` = the **child** registry (`src/brain/service/helpers.rs:239`) → active set empty → schema never rides the request

#1025 added the activation plumbing plus tests, but its tests exercise a single registry in isolation — none mounts a child service whose copied search tool still points at the parent registry. #1025 was closed with an explicit "not verified live" caveat; running that live check is what surfaced this (#1210).

## Fix

`build_child_registry` now returns `Arc<ToolRegistry>` and re-binds a **fresh `ToolSearchTool`** onto the child's own registry whenever it copies one in, so every nesting level points discovery at its own registry. The three callers (`spawn.rs`, `resume.rs`, `team/create.rs`) pass the Arc straight through.

## Regression test

Extends `tool_search_activation_test.rs`: mounts a parent registry with the discovery tool bound to the parent exactly as production wires it, builds a child, executes the child's search instance, then asserts the activation landed in the **child's** active set and never touched the parent's. Signature-agnostic by design — it compiles against pre-fix code and fails there by assertion, not compile error.

## Evidence

- Live failure (#1210): 4 spawns / 2 models / 2 providers; child registry pinned at "61 tools" across every `tool_search`; loop-breaker fired twice (20:29:33Z and 20:31:54Z on 2026-08-25)
- Green build containing this fix: [leshchenko1979/opencrabs run 32903857601](https://github.com/leshchenko1979/opencrabs/actions/runs/32903857601) (merge commit `21099265`)
- Deployed: our production ops instance runs a sha256-verified binary built from this fix
- Honest caveat: the new regression test has compiled everywhere but has not yet executed in fork CI — cancel-in-progress churn on a busy fork main kept killing full runs before the test job started; verification here was modum-gated

Refs #1210
Refs #1025
