### PR TITLE
fix(ci): restore clippy-clean main baseline

### DIFF
--- a/src/brain/tools/browser/events.rs
+++ b/src/brain/tools/browser/events.rs
@@ -81,11 +81,6 @@ impl EventLog {
     pub fn len(&self) -> usize {
         self.inner.lock().unwrap().len()
     }
-
-    #[cfg(test)]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
 }
 
 /// Reduce a raw CDP event to a display summary, keeping only the

--- a/src/tests/nesting_gate_test.rs
+++ b/src/tests/nesting_gate_test.rs
@@ -7,7 +7,6 @@
 use crate::brain::tools::subagent::SubAgent;
 use crate::brain::tools::subagent::SubAgentManager;
 use tokio::sync::mpsc;
-use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 fn make_agent(session_id: Uuid, allow_nested: bool) -> SubAgent {

--- a/src/tests/question_common_test.rs
+++ b/src/tests/question_common_test.rs
@@ -88,10 +88,12 @@ fn channel_budgets_stay_sane_and_fold_aware() {
     use crate::channels::question_common::{
         DISCORD_LABEL_BUDGET, FOLD_THRESHOLD, SLACK_LABEL_BUDGET, TELEGRAM_LABEL_BUDGET,
     };
-    assert!(FOLD_THRESHOLD > 0);
-    assert!(
-        TELEGRAM_LABEL_BUDGET > FOLD_THRESHOLD,
-        "fold must fire before any single label gets truncated"
-    );
-    assert!(DISCORD_LABEL_BUDGET > 0 && SLACK_LABEL_BUDGET > 0);
+    const {
+        assert!(FOLD_THRESHOLD > 0);
+        assert!(
+            TELEGRAM_LABEL_BUDGET > FOLD_THRESHOLD,
+            "fold must fire before any single label gets truncated"
+        );
+        assert!(DISCORD_LABEL_BUDGET > 0 && SLACK_LABEL_BUDGET > 0);
+    }
 }

--- a/src/tests/subagent_compaction_preamble_test.rs
+++ b/src/tests/subagent_compaction_preamble_test.rs
@@ -10,7 +10,6 @@
 //! pin what belongs in it — and, just as importantly, what must not.
 
 use crate::brain::tools::subagent::manager::{SubAgent, SubAgentManager, SubAgentState};
-use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 fn agent(id: &str, label: &str, state: SubAgentState) -> SubAgent {

--- a/src/tests/subagent_push_result_test.rs
+++ b/src/tests/subagent_push_result_test.rs
@@ -6,9 +6,8 @@
 //! parent already blocked on `wait_agent` receives the output as that tool's
 //! result, so pushing as well would deliver it twice.
 
-use crate::brain::tools::subagent::manager::{SubAgent, SubAgentManager, SubAgentState};
+use crate::brain::tools::subagent::manager::{SubAgent, SubAgentManager};
 use crate::brain::tools::subagent::spawn::completion_message;
-use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 fn manager_with_agent(id: &str) -> SubAgentManager {

--- a/src/tests/subagent_test.rs
+++ b/src/tests/subagent_test.rs
@@ -381,13 +381,12 @@ mod manager {
 
 mod send_input_tool {
     use crate::brain::tools::subagent::SendInputTool;
-    use crate::brain::tools::subagent::{SubAgent, SubAgentManager, SubAgentState};
+    use crate::brain::tools::subagent::{SubAgent, SubAgentManager};
     use crate::brain::tools::{Tool, ToolExecutionContext};
     use serde_json::json;
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::mpsc;
-    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
     fn test_context() -> ToolExecutionContext {
@@ -548,7 +547,6 @@ mod close_agent_tool {
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::mpsc;
-    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
     fn test_context() -> ToolExecutionContext {
@@ -670,13 +668,12 @@ mod close_agent_tool {
 
 mod wait_agent_tool {
     use crate::brain::tools::subagent::WaitAgentTool;
-    use crate::brain::tools::subagent::{SubAgent, SubAgentManager, SubAgentState};
+    use crate::brain::tools::subagent::{SubAgent, SubAgentManager};
     use crate::brain::tools::{Tool, ToolExecutionContext};
     use serde_json::json;
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::mpsc;
-    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
     fn test_context() -> ToolExecutionContext {
@@ -996,7 +993,6 @@ mod lifecycle {
 // ─── Child Registry & Grant Tests (#1173) ─────────────────────────────────
 
 mod agent_type {
-    use crate::brain::tools::subagent::SubAgentState;
     use crate::brain::tools::subagent::map_deprecated_agent_type;
 
     /// Build a mock parent registry with common tools for filtering tests.
@@ -1137,7 +1133,6 @@ mod agent_type {
     #[test]
     fn read_only_grant_frozen_in_manager() {
         use crate::brain::tools::subagent::{SubAgent, SubAgentManager};
-        use tokio_util::sync::CancellationToken;
         use uuid::Uuid;
         let mgr = SubAgentManager::new();
         mgr.insert(SubAgent {
@@ -1276,15 +1271,12 @@ mod team_manager {
 // ─── TeamDeleteTool Tests ───────────────────────────────────────────────────
 
 mod team_delete_tool {
-    use crate::brain::tools::subagent::{
-        SubAgent, SubAgentManager, SubAgentState, TeamDeleteTool, TeamManager,
-    };
+    use crate::brain::tools::subagent::{SubAgent, SubAgentManager, TeamDeleteTool, TeamManager};
     use crate::brain::tools::{Tool, ToolExecutionContext};
     use serde_json::json;
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::mpsc;
-    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
     fn test_context() -> ToolExecutionContext {
@@ -1405,14 +1397,13 @@ mod team_delete_tool {
 
 mod team_broadcast_tool {
     use crate::brain::tools::subagent::{
-        SubAgent, SubAgentManager, SubAgentState, TeamBroadcastTool, TeamManager,
+        SubAgent, SubAgentManager, TeamBroadcastTool, TeamManager,
     };
     use crate::brain::tools::{Tool, ToolExecutionContext};
     use serde_json::json;
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::mpsc;
-    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
     fn test_context() -> ToolExecutionContext {

--- a/src/tests/wait_agent_resolver_test.rs
+++ b/src/tests/wait_agent_resolver_test.rs
@@ -7,10 +7,9 @@
 //! logs where the model passed truncated UUIDs, role labels like
 //! "clippy", and stale ids.
 
-use crate::brain::tools::subagent::{SubAgent, SubAgentManager, SubAgentState, WaitAgentTool};
+use crate::brain::tools::subagent::{SubAgent, SubAgentManager, WaitAgentTool};
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 fn mk_agent(id: &str, label: &str) -> SubAgent {


### PR DESCRIPTION
## Summary

Restore the exact clippy baseline on current `main` after the subagent builder refactor.

This is a prerequisite-only change for the receive-only Telegram userbot PR. It contains no userbot code.

## Changes

- remove 17 imports proven unused by Rust 1.98 clippy
- remove the unused test-only `EventLog::is_empty` helper
- move three constant budget assertions into a const block

## Verification

- `cargo +1.98.0 fmt --all -- --check`
- `cargo +1.98.0 clippy --locked --lib --bins --tests --all-features -- -D warnings`

Both pass on the exact toolchain used by CI.

Fixes #1212
