### PR TITLE
fix(tg): normalize General-topic sessions (#1220); recovery replay claims the turn slot (#1222)

### DIFF
--- a/src/channels/telegram/agent.rs
+++ b/src/channels/telegram/agent.rs
@@ -482,7 +482,7 @@ impl TelegramAgent {
                                                 }
                                             };
                                         if let Err(e) =
-                                            crate::channels::telegram::resume::resume_session(
+                                            crate::channels::telegram::resume::resume_session_inner(
                                                 bot_clone,
                                                 chat_id,
                                                 thread_id,
@@ -1528,7 +1528,7 @@ impl TelegramAgent {
                                             // runner; a button tap triggers it exactly like a
                                             // resumed turn (no inbound message to react to).
                                             if let Err(e) =
-                                                crate::channels::telegram::resume::resume_session(
+                                                crate::channels::telegram::resume::resume_session_inner(
                                                     bot2,
                                                     chat_id,
                                                     thread_id,
@@ -1645,7 +1645,7 @@ impl TelegramAgent {
                                                     }
                                                 };
                                             if let Err(e) =
-                                                crate::channels::telegram::resume::resume_session(
+                                                crate::channels::telegram::resume::resume_session_inner(
                                                     bot_cb,
                                                     cb_chat,
                                                     cb_thread,

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -432,7 +432,9 @@ pub(crate) async fn handle_message(
     // is a forum group. Recorded for EVERY message before early returns, so
     // chatter not addressed to the bot still feeds the cache.
     let raw_thread = thread_id.map(|t| t.0.0);
-    telegram_state.note_thread_evidence(msg.chat.id.0, raw_thread).await;
+    telegram_state
+        .note_thread_evidence(msg.chat.id.0, raw_thread)
+        .await;
 
     // Forum-topic session isolation (#215). #130 fixed the reply ADDRESS
     // (replies land in the right topic); this scopes the CONVERSATION so each

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2787,40 +2787,50 @@ pub(crate) async fn handle_message(
 
     let leftover_reactions: Vec<_> = leftover_reactions.into_iter().map(|i| i.msg).collect();
     if !leftover_reactions.is_empty() {
+        // #1213: leftovers can be background-task or subagent completions that
+        // raced the final-bubble delivery — the resume callback found the turn
+        // guard still held and queued them here, but no tool loop remained to
+        // drain them between rounds. A toolless single-shot reply leaves the
+        // model announcing follow-up work it has no tools to execute, then the
+        // session stalls until the next inbound message. Run them through the
+        // FULL streaming pipeline instead (tools intact), under the turn gate
+        // so a completion resuming concurrently cannot fork a second
+        // overlapping block (#845). If another turn won the race, re-queue:
+        // that turn drains them between rounds as designed.
         let combined = leftover_reactions
             .iter()
             .map(|m| m.context_text.as_str())
             .collect::<Vec<_>>()
             .join("\n\n");
-        let combined_display = leftover_reactions
-            .iter()
-            .map(|m| m.display_text.as_str())
-            .collect::<Vec<_>>()
-            .join("\n\n");
-        match agent
-            .send_message_with_display(session_id, combined, Some(combined_display), None)
-            .await
-        {
-            Ok(resp) => {
-                let (txt, _imgs) = crate::utils::extract_img_markers(&resp.content);
-                let txt = crate::utils::sanitize::strip_llm_artifacts(&txt);
-                let txt = redact_secrets(&txt);
-                let (txt, react_emoji) = crate::utils::extract_react_marker(&txt);
-                if let Some(em) = react_emoji {
-                    fire_reaction(&bot, msg.chat.id, msg.id, &em).await;
-                }
-                if !txt.trim().is_empty() {
-                    let html = markdown_to_telegram_html(&txt);
-                    if let Err(e) =
-                        send_html_or_plain(&bot, msg.chat.id, thread_id, &html, "turn").await
-                    {
-                        tracing::warn!("Telegram: failed to deliver flushed reaction reply: {e}");
-                    }
+        match telegram_state.try_begin_turn(session_id) {
+            Some(_flush_turn_guard) => {
+                tracing::info!(
+                    "Telegram: flushing {} stranded reaction(s) for session {session_id} via full pipeline (#1213)",
+                    leftover_reactions.len()
+                );
+                // Guard held across the await: the resumed pipeline owns the
+                // session exclusively, same as any other turn.
+                if let Err(e) = super::resume::resume_session_inner(
+                    bot.clone(),
+                    msg.chat.id,
+                    thread_id,
+                    session_id,
+                    combined,
+                    agent.clone(),
+                    telegram_state.clone(),
+                )
+                .await
+                {
+                    tracing::warn!(
+                        "Telegram: flushed-reaction full pipeline failed for session {session_id}: {e}"
+                    );
                 }
             }
-            Err(e) => tracing::warn!(
-                "Telegram: flushed reaction turn failed for session {session_id}: {e}"
-            ),
+            None => {
+                for r in leftover_reactions {
+                    telegram_state.enqueue_reaction(session_id, r);
+                }
+            }
         }
     }
 

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -428,14 +428,23 @@ pub(crate) async fn handle_message(
     // return, since the burying messages are usually not addressed to the bot.
     telegram_state.note_incoming_msg(msg.chat.id.0, msg.id.0);
 
+    // Forum-ness evidence (#1220): any thread-scoped message proves this chat
+    // is a forum group. Recorded for EVERY message before early returns, so
+    // chatter not addressed to the bot still feeds the cache.
+    let raw_thread = thread_id.map(|t| t.0.0);
+    telegram_state.note_thread_evidence(msg.chat.id.0, raw_thread).await;
+
     // Forum-topic session isolation (#215). #130 fixed the reply ADDRESS
     // (replies land in the right topic); this scopes the CONVERSATION so each
     // topic gets its own session instead of every topic sharing one. Gated on
     // is_topic_message so only real forum topics isolate: DMs, non-forum
-    // groups, the General topic, and plain reply-threads resolve to None and
-    // keep sharing the base [chat:<id>] session.
-    let topic_id =
-        session_resolve::topic_session_id(msg.is_topic_message, thread_id.map(|t| t.0.0));
+    // groups, plain reply-threads — and, since #1220, NOT the General topic
+    // of a known forum: there it normalizes to Some(GENERAL_TOPIC_ID), giving
+    // General its own session bucket so bg-task/subagent pushes route home.
+    let topic_id = session_resolve::normalize_topic(
+        session_resolve::topic_session_id(msg.is_topic_message, raw_thread),
+        telegram_state.is_known_forum(msg.chat.id.0).await,
+    );
 
     // Topic NAME for the session label, so a forum topic reads as "Devops"
     // rather than the numeric "topic:2". Prefer the name carried on THIS

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -90,7 +90,7 @@ pub(crate) fn build_enqueue_callback(
                 Some(topic) => Some(teloxide::types::ThreadId(teloxide::types::MessageId(topic))),
                 None => super::send::latest_thread_id_for_chat(chat_id).await,
             };
-            if let Err(e) = resume_session(
+            if let Err(e) = resume_session_inner(
                 bot,
                 teloxide::types::ChatId(chat_id),
                 thread_id,
@@ -107,9 +107,59 @@ pub(crate) fn build_enqueue_callback(
     })
 }
 
-/// Resume an interrupted session with full streaming (typing, tool messages, edit loop).
+/// Public entry for resuming a session with the full streaming pipeline:
+/// claims the session's turn slot (#1222), then drives `resume_session_inner`.
+///
+/// Callers that ALREADY hold the turn guard — the bg-resume enqueue callback
+/// (resume.rs #845/#1213), the end-of-turn stranded flush (handler.rs #1213)
+/// and the agent approval flows (agent.rs) — must call `resume_session_inner`
+/// directly so the slot is not double-claimed.
+///
 /// Called from ui.rs on startup when pending Telegram requests are detected.
 pub(crate) async fn resume_session(
+    bot: Bot,
+    chat_id: ChatId,
+    thread_id: Option<teloxide::types::ThreadId>,
+    session_id: Uuid,
+    prompt: String,
+    agent: Arc<AgentService>,
+    telegram_state: Arc<TelegramState>,
+) -> anyhow::Result<()> {
+    // Claim the session's turn slot for the whole replay (#1222). A recovery
+    // replay drives the SAME edit loop as an ingress turn but used to run
+    // without holding TelegramState's active_turns flag, so any inbound
+    // message arriving mid-replay read the session as idle and forked a
+    // second concurrent tool loop on top of it — two interleaved streaming
+    // blocks progressing in one topic. Holding the RAII guard for the whole
+    // resumed turn makes ingress queue follow-ups (#501/#845) exactly as it
+    // does for normal turns; resume-born loops already drain those queues.
+    // If the slot is somehow taken, skipping is safe: the pending item was
+    // already cleared from the repo and something else owns the turn.
+    let _turn_guard = match telegram_state.try_begin_turn(session_id) {
+        Some(guard) => guard,
+        None => {
+            tracing::warn!(
+                "Telegram: resume_session {session_id} skipped — a turn is already active for this session"
+            );
+            return Ok(());
+        }
+    };
+    resume_session_inner(
+        bot,
+        chat_id,
+        thread_id,
+        session_id,
+        prompt,
+        agent,
+        telegram_state,
+    )
+    .await
+}
+
+/// Unguarded core of `resume_session`. The turn-slot contract lives in the
+/// caller: either hold an `ActiveTurnGuard` across the await, or go through
+/// the public wrapper.
+pub(crate) async fn resume_session_inner(
     bot: Bot,
     chat_id: ChatId,
     thread_id: Option<teloxide::types::ThreadId>,

--- a/src/channels/telegram/session_resolve.rs
+++ b/src/channels/telegram/session_resolve.rs
@@ -74,6 +74,31 @@ pub fn topic_session_id(is_topic_message: bool, thread_id: Option<i32>) -> Optio
     if is_topic_message { thread_id } else { None }
 }
 
+/// Canonical Telegram thread id of a forum group's built-in General topic.
+/// General messages carry NO explicit `message_thread_id` and are not flagged
+/// `is_topic_message`, which historically made them indistinguishable from
+/// DMs / non-forum groups (#1220).
+pub const GENERAL_TOPIC_ID: i32 = 1;
+
+/// #1220: normalize a raw topic resolution for KNOWN forum chats.
+///
+/// `raw` is the output of [`topic_session_id`]; `known_forum` is the
+/// evidence-based verdict that this chat has hosted at least one
+/// thread-scoped message (see `TelegramState::note_thread_evidence`).
+///
+/// In a known forum, a message with no explicit topic IS the General topic,
+/// not "no topic" — so it gets its own session bucket keyed on
+/// `Some(GENERAL_TOPIC_ID)` instead of collapsing into the base
+/// `[chat:<id>]` session. This makes bg-task / subagent pushes (#1200)
+/// route back to General instead of falling to the chat-wide-latest
+/// lookup and landing in whatever topic spoke last.
+///
+/// Cold start: until the chat's first thread-scoped message is observed
+/// (in-memory cache), `known_forum` is false and behaviour is unchanged.
+pub fn normalize_topic(raw: Option<i32>, known_forum: bool) -> Option<i32> {
+    raw.or_else(|| if known_forum { Some(GENERAL_TOPIC_ID) } else { None })
+}
+
 /// True when a session exceeded the configured idle window (same rule as handler suffix path).
 pub fn session_idle_expired(
     updated_at: chrono::DateTime<chrono::Utc>,

--- a/src/channels/telegram/session_resolve.rs
+++ b/src/channels/telegram/session_resolve.rs
@@ -96,7 +96,7 @@ pub const GENERAL_TOPIC_ID: i32 = 1;
 /// Cold start: until the chat's first thread-scoped message is observed
 /// (in-memory cache), `known_forum` is false and behaviour is unchanged.
 pub fn normalize_topic(raw: Option<i32>, known_forum: bool) -> Option<i32> {
-    raw.or_else(|| if known_forum { Some(GENERAL_TOPIC_ID) } else { None })
+    raw.or(if known_forum { Some(GENERAL_TOPIC_ID) } else { None })
 }
 
 /// True when a session exceeded the configured idle window (same rule as handler suffix path).

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -114,6 +114,13 @@ pub struct TelegramState {
     /// pre-topic behaviour. Each forum topic therefore binds its own session.
     chat_sessions: Mutex<HashMap<(i64, Option<i32>), Uuid>>,
     session_topic: Mutex<HashMap<Uuid, Option<i32>>>,
+    /// Evidence-based forum detection (#1220): chat_id → true once ANY
+    /// thread-scoped message was seen from that chat. A bare thread id can
+    /// only exist on forum topics (governor.rs reached the same rule), so
+    /// one observation proves forum-ness permanently for the process
+    /// lifetime. Consumed by `normalize_topic` at ingress to give the
+    /// General topic its own session bucket instead of None.
+    chat_forums: Mutex<HashMap<i64, bool>>,
     /// Pending approval channels: approval_id → oneshot sender of (approved, always).
     pending_approvals: Mutex<HashMap<String, oneshot::Sender<(bool, bool)>>>,
     /// Pending follow-up questions: question_id → (oneshot sender of
@@ -283,6 +290,7 @@ impl TelegramState {
             session_chats: Mutex::new(HashMap::new()),
             chat_sessions: Mutex::new(HashMap::new()),
             session_topic: Mutex::new(HashMap::new()),
+            chat_forums: Mutex::new(HashMap::new()),
             pending_approvals: Mutex::new(HashMap::new()),
             pending_followups: Mutex::new(HashMap::new()),
             solo_evaluated: Mutex::new(HashMap::new()),
@@ -490,13 +498,37 @@ impl TelegramState {
         self.bot.lock().await.is_some()
     }
 
+    /// Record forum-ness evidence for a chat (#1220). Any message carrying a
+    /// bare `thread_id` proves the chat is a forum group — ordinary
+    /// reply-threads never set it (same rule governor.rs uses). One-way:
+    /// forum-ness never un-proves itself for the process lifetime.
+    pub async fn note_thread_evidence(&self, chat_id: i64, thread_id: Option<i32>) {
+        if thread_id.is_some() {
+            self.chat_forums.lock().await.insert(chat_id, true);
+        }
+    }
+
+    /// Whether this chat has ever hosted a thread-scoped message (#1220).
+    /// False until the first observation — the cold-start window during which
+    /// General-topic messages keep the legacy shared-session behaviour.
+    pub async fn is_known_forum(&self, chat_id: i64) -> bool {
+        self.chat_forums
+            .lock()
+            .await
+            .get(&chat_id)
+            .copied()
+            .unwrap_or(false)
+    }
+
     /// Record which chat_id corresponds to a given session (for approval routing).
     /// Also maintains a reverse map so callbacks can resolve session from chat.
     ///
     /// The reverse map keys on `(chat_id, topic_id)` so distinct forum topics in
-    /// one supergroup bind distinct sessions (#215); pass `None` for DMs,
-    /// non-forum groups, and the General topic. The forward `session_chats` map
-    /// stays topic-agnostic (approval routing only needs the chat_id).
+    /// one supergroup bind distinct sessions (#215); since #1220 the General
+    /// topic of a KNOWN forum passes `Some(GENERAL_TOPIC_ID)` (normalized at
+    /// ingress), while plain `None` remains for DMs / non-forum groups. The
+    /// forward `session_chats` map stays topic-agnostic (approval routing only
+    /// needs the chat_id).
     pub async fn register_session_chat(
         &self,
         session_id: Uuid,
@@ -517,8 +549,9 @@ impl TelegramState {
     }
 
     /// Look up the forum topic_id for a given session_id. Returns `Some(tid)`
-    /// for forum-topic sessions, `None` for DMs / non-forum groups / General.
-    /// Used by `make_approval_callback` to route
+    /// for forum-topic sessions — including General-topic sessions of known
+    /// forums (`Some(GENERAL_TOPIC_ID)`, #1220) — and `None` for DMs /
+    /// non-forum groups. Used by `make_approval_callback` to route
     /// messages to the correct forum topic (#247, #249).
     pub async fn session_topic(&self, session_id: Uuid) -> Option<i32> {
         self.session_topic

--- a/src/tests/telegram_session_resolve_test.rs
+++ b/src/tests/telegram_session_resolve_test.rs
@@ -229,7 +229,7 @@ fn topic_session_id_gates_on_is_topic_message() {
 /// #1220: General-topic normalization for known forums.
 #[test]
 fn normalize_topic_gives_general_its_own_bucket_in_known_forums() {
-    use super::super::telegram::session_resolve::{GENERAL_TOPIC_ID, normalize_topic};
+    use crate::channels::telegram::session_resolve::{GENERAL_TOPIC_ID, normalize_topic};
 
     // Raw topic resolution always wins — normalization only fills the gap.
     assert_eq!(normalize_topic(Some(5), true), Some(5));

--- a/src/tests/telegram_session_resolve_test.rs
+++ b/src/tests/telegram_session_resolve_test.rs
@@ -226,6 +226,43 @@ fn topic_session_id_gates_on_is_topic_message() {
     assert_eq!(topic_session_id(true, None), None);
 }
 
+/// #1220: General-topic normalization for known forums.
+#[test]
+fn normalize_topic_gives_general_its_own_bucket_in_known_forums() {
+    use super::super::telegram::session_resolve::{GENERAL_TOPIC_ID, normalize_topic};
+
+    // Raw topic resolution always wins — normalization only fills the gap.
+    assert_eq!(normalize_topic(Some(5), true), Some(5));
+    assert_eq!(normalize_topic(Some(5), false), Some(5));
+
+    // Known forum + no explicit topic = the General topic: own bucket.
+    assert_eq!(normalize_topic(None, true), Some(GENERAL_TOPIC_ID));
+
+    // Unknown chat (cold start) or genuinely topicless chat: legacy None.
+    assert_eq!(normalize_topic(None, false), None);
+}
+
+/// #1220: evidence-based forum detection on TelegramState.
+#[tokio::test]
+async fn thread_evidence_marks_forum_once_and_only_from_threaded_msgs() {
+    let state = TelegramState::new();
+    let chat = 777_i64;
+
+    // No evidence yet — cold start keeps legacy behaviour.
+    assert!(!state.is_known_forum(chat).await);
+
+    // A thread-scoped message proves forum-ness...
+    state.note_thread_evidence(chat, Some(42)).await;
+    assert!(state.is_known_forum(chat).await);
+
+    // ...and later topicless traffic never un-proves it.
+    state.note_thread_evidence(chat, None).await;
+    assert!(state.is_known_forum(chat).await);
+
+    // A different chat stays unknown.
+    assert!(!state.is_known_forum(888).await);
+}
+
 #[tokio::test]
 async fn chat_map_isolates_topic_from_base_session() {
     // The reverse map keys on (chat_id, topic_id): the same supergroup chat


### PR DESCRIPTION
Two Telegram routing/concurrency fixes from the ops fleet, shipped together as a draft until CI validates the pair.

## 1. General-topic session normalization (#1220)

Telegram forum **General** posts carry no `message_thread_id` and no `is_topic_message`, so sessions started there recorded topic `None` — indistinguishable from DMs/non-forum chats. In a busy forum, any push fallback (`latest_thread_id_for_chat`) then routed their results into whichever topic spoke last.

Fix: evidence-based forum detection (a chat is a forum once any message with a thread id is seen — same rule the flood governors use), cached per chat in `TelegramState`. At ingress, forum + missing thread id ⇒ topic `1`. Resume-side routing heals automatically since `session_topic` now returns `Some(1)`.

## 2. Recovery replay claims the turn slot (#1222)

Boot-recovery replays drove the full streaming pipeline **without** holding `TelegramState::try_begin_turn`. Any inbound message arriving mid-replay read the session as idle and forked a **second concurrent tool loop** — two interleaved streaming bubbles progressing in one topic (production log evidence in the issue: iteration counters regressing 6→4 across interleaved loops).

Fix: `resume_session` becomes a thin guarded entry that claims the slot for the whole resumed turn (skip + warn when taken); all callers that already hold the guard — bg-resume callback, stranded-reaction flush, agent approval flows — call `resume_session_inner` directly so the slot is never double-claimed. The handler spawn that deliberately drops its guard before resuming keeps using the public entry and now re-acquires for real.

## Notes

- Both fixes run in production on our fork (fleet of ops daemons); smoke-tested against live traffic.
- Marked draft pending CI on this base — will mark ready once green.
- Refs: #1220, #1222