### PR TITLE
feat(tools): machine-readable session discovery — ids, last-active, turn-state, query op

### DIFF
--- a/src/brain/agent/mod.rs
+++ b/src/brain/agent/mod.rs
@@ -12,6 +12,6 @@ pub use context::AgentContext;
 pub use error::{AgentError, Result, format_user_error};
 pub use service::{
     AgentResponse, AgentService, AgentStreamResponse, ApprovalCallback, BrainRebuild,
-    ChannelSessionEvent, MessageQueueCallback, ProgressCallback, ProgressEvent, QueuedUserMessage,
-    SshPasswordCallback, SudoCallback, ToolApprovalInfo,
+    ChannelSessionEvent, MessageQueueCallback, ProgressCallback, ProgressEvent, PushOrigin,
+    QueuedUserMessage, SshPasswordCallback, SudoCallback, ToolApprovalInfo,
 };

--- a/src/brain/agent/service/background_tasks.rs
+++ b/src/brain/agent/service/background_tasks.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 
 use uuid::Uuid;
 
-use super::types::{MessageEnqueueCallback, QueuedUserMessage};
+use super::types::{MessageEnqueueCallback, PushOrigin, QueuedUserMessage};
 
 /// Result of a finished background command.
 #[derive(Debug, Clone)]
@@ -298,5 +298,8 @@ pub(crate) fn completion_message(
         "🔧 background task {}: {label}",
         if result.success { "finished" } else { "failed" }
     );
-    QueuedUserMessage::system(context, display)
+    let mut msg = QueuedUserMessage::system(context, display);
+    // #1221: marks this delivery for the Telegram collapsible echo bubble.
+    msg.origin = PushOrigin::BackgroundTask;
+    msg
 }

--- a/src/brain/agent/service/mod.rs
+++ b/src/brain/agent/service/mod.rs
@@ -44,6 +44,6 @@ pub use phantom::{
 };
 pub use types::{
     AgentResponse, AgentStreamResponse, ApprovalCallback, ChannelSessionEvent,
-    MessageEnqueueCallback, MessageQueueCallback, ProgressCallback, ProgressEvent,
-    PushOrigin, QueuedUserMessage, SshPasswordCallback, SudoCallback, ToolApprovalInfo,
+    MessageEnqueueCallback, MessageQueueCallback, ProgressCallback, ProgressEvent, PushOrigin,
+    QueuedUserMessage, SshPasswordCallback, SudoCallback, ToolApprovalInfo,
 };

--- a/src/brain/agent/service/mod.rs
+++ b/src/brain/agent/service/mod.rs
@@ -45,5 +45,5 @@ pub use phantom::{
 pub use types::{
     AgentResponse, AgentStreamResponse, ApprovalCallback, ChannelSessionEvent,
     MessageEnqueueCallback, MessageQueueCallback, ProgressCallback, ProgressEvent,
-    QueuedUserMessage, SshPasswordCallback, SudoCallback, ToolApprovalInfo,
+    PushOrigin, QueuedUserMessage, SshPasswordCallback, SudoCallback, ToolApprovalInfo,
 };

--- a/src/brain/agent/service/restart_recovery.rs
+++ b/src/brain/agent/service/restart_recovery.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use uuid::Uuid;
 
-use super::types::{MessageEnqueueCallback, QueuedUserMessage};
+use super::types::{MessageEnqueueCallback, PushOrigin, QueuedUserMessage};
 
 /// How long a parked report waits for its channel to register a route before
 /// it is delivered locally instead. Long enough for channels to finish
@@ -336,6 +336,7 @@ fn interrupted_message(row: &crate::db::BackgroundTaskRow) -> QueuedUserMessage 
     QueuedUserMessage {
         context_text,
         display_text: format!("⚠️ Background task interrupted by restart: {}", row.label),
+        origin: PushOrigin::Recovery,
     }
 }
 
@@ -419,5 +420,6 @@ fn subagent_interrupted_message(
     QueuedUserMessage {
         context_text,
         display_text: format!("⚠️ Sub-agent interrupted by restart: {}", status.label),
+        origin: PushOrigin::Recovery,
     }
 }

--- a/src/brain/agent/service/types.rs
+++ b/src/brain/agent/service/types.rs
@@ -191,13 +191,16 @@ pub type MessageEnqueueCallback = Arc<dyn Fn(Uuid, QueuedUserMessage) + Send + S
 /// "[System: ...]" tag), so prompt scaffolding never pollutes the session.
 /// What produced a queued/injected message (#1221). The Telegram resume
 /// callback uses it to decide whether the delivery earns a collapsible echo
-/// bubble: background-task completions do (the user must see WHAT woke the
-/// session), sub-agent results, ingress queueing and recovery replays do not
-/// render one.
+/// bubble: background-task completions and cross-session session_notify
+/// pushes do (the user must see WHAT woke the session), while sub-agent
+/// results, ingress queueing and recovery replays do not render one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PushOrigin {
     /// A detached bash task finished (background_tasks completion path).
     BackgroundTask,
+    /// A cross-session push via the session_notify tool (#1203). Echoes into
+    /// the recipient's topic like background-task completions (#1221).
+    SessionNotify,
     /// A spawned sub-agent reported back (spawn.rs push_result / notify).
     SubAgent,
     /// Startup crash-recovery replaying an interrupted turn.

--- a/src/brain/agent/service/types.rs
+++ b/src/brain/agent/service/types.rs
@@ -189,12 +189,33 @@ pub type MessageEnqueueCallback = Arc<dyn Fn(Uuid, QueuedUserMessage) + Send + S
 /// guidance belong in `context_text` for the live turn ONLY; the DB and the
 /// TUI history get `display_text` (the user's actual words, or a compact
 /// "[System: ...]" tag), so prompt scaffolding never pollutes the session.
+/// What produced a queued/injected message (#1221). The Telegram resume
+/// callback uses it to decide whether the delivery earns a collapsible echo
+/// bubble: background-task completions do (the user must see WHAT woke the
+/// session), sub-agent results, ingress queueing and recovery replays do not
+/// render one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushOrigin {
+    /// A detached bash task finished (background_tasks completion path).
+    BackgroundTask,
+    /// A spawned sub-agent reported back (spawn.rs push_result / notify).
+    SubAgent,
+    /// Startup crash-recovery replaying an interrupted turn.
+    Recovery,
+    /// A user message queued mid-turn (ingress or reaction path).
+    Ingress,
+    /// Anything else — safe default, never renders a push echo.
+    Other,
+}
+
 #[derive(Debug, Clone)]
 pub struct QueuedUserMessage {
     /// Full text injected into the LLM context for the live turn.
     pub context_text: String,
     /// What persists to the DB and shows in the session history.
     pub display_text: String,
+    /// Which producer built this message (#1221).
+    pub origin: PushOrigin,
 }
 
 impl QueuedUserMessage {
@@ -203,6 +224,7 @@ impl QueuedUserMessage {
         Self {
             context_text: text.clone(),
             display_text: text,
+            origin: PushOrigin::Other,
         }
     }
 
@@ -213,6 +235,7 @@ impl QueuedUserMessage {
         Self {
             context_text: context,
             display_text: display,
+            origin: PushOrigin::Other,
         }
     }
 

--- a/src/brain/agent/service/types.rs
+++ b/src/brain/agent/service/types.rs
@@ -258,6 +258,9 @@ impl QueuedUserMessage {
         Some(Self {
             context_text: join_on(|m| m.context_text.as_str()),
             display_text: join_on(|m| m.display_text.as_str()),
+            // #1221: a joined batch inherits the head message's origin — the
+            // first-completed task dominates what the echo announces.
+            origin: msgs[0].origin,
         })
     }
 }

--- a/src/brain/tools/session_search.rs
+++ b/src/brain/tools/session_search.rs
@@ -8,17 +8,63 @@
 use super::error::Result;
 use super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
 use crate::db::Pool;
+#[cfg(feature = "telegram")]
+use crate::channels::telegram::TelegramState;
+#[cfg(feature = "telegram")]
+use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 
 /// Tool for listing and searching session message history via direct DB search.
 pub struct SessionSearchTool {
     pool: Pool,
+    /// Live channel state, wired only by the interactive registration
+    /// (`with_telegram`); the core daemon/cron registration keeps `None`
+    /// and rows omit turn info rather than guess.
+    #[cfg(feature = "telegram")]
+    telegram: Option<Arc<TelegramState>>,
 }
 
 impl SessionSearchTool {
     pub fn new(pool: Pool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            #[cfg(feature = "telegram")]
+            telegram: None,
+        }
+    }
+
+    /// Attach live channel state so discovery rows report turn activity.
+    /// Registered by the interactive path once the bot connects; the registry
+    /// insert replaces the stateless core instance by name.
+    #[cfg(feature = "telegram")]
+    pub fn with_telegram(pool: Pool, telegram: Arc<TelegramState>) -> Self {
+        Self {
+            pool,
+            telegram: Some(telegram),
+        }
+    }
+
+    /// `"running"` while a turn is in flight for the session, `"idle"` when
+    /// it is waiting; `None` when no channel state is wired (#1203). A
+    /// running session drains a queued push at its next tool-loop boundary;
+    /// an idle one starts a fresh turn for it.
+    #[cfg(feature = "telegram")]
+    fn turn_state(&self, session_id: uuid::Uuid) -> Option<&'static str> {
+        self.telegram.as_ref().map(|tg| {
+            if tg.is_turn_active(session_id) {
+                "running"
+            } else {
+                "idle"
+            }
+        })
+    }
+
+    /// Stateless counterpart so call sites stay cfg-free: no channel state,
+    /// no turn info.
+    #[cfg(not(feature = "telegram"))]
+    fn turn_state(&self, _session_id: uuid::Uuid) -> Option<&'static str> {
+        None
     }
 }
 
@@ -38,7 +84,10 @@ impl Tool for SessionSearchTool {
          titles, last-active timestamps and message counts - e.g. to find another session's id \
          to target with session_notify. \
          'session' can be a number (1 = most recent), a title keyword, or 'all' (default; \
-         ignored by 'tail', which falls back to the newest session)."
+         ignored by 'tail', which falls back to the newest session). \
+         Each row also carries 'turn' - 'running' (a turn is in flight; a \
+         queued push drains at its next tool-loop boundary), 'idle' (waiting; \
+         a push starts a fresh turn) or null when channel state is unavailable."
     }
 
     fn input_schema(&self) -> Value {
@@ -192,19 +241,25 @@ impl SessionSearchTool {
             return Ok(ToolResult::success("No sessions found.".to_string()));
         }
 
-        let mut output =
-            String::from("Sessions, newest first ([short-id] identifies each row):\n");
+        let mut output = String::from(
+            "Sessions, newest first ([short-id] identifies each row; · running/idle = turn state):\n",
+        );
         for (i, session) in sessions.iter().enumerate() {
             let count = message_repo.count_by_session(session.id).await.unwrap_or(0);
             let title = session.title.as_deref().unwrap_or("Untitled");
             let date = session.updated_at.format("%Y-%m-%d %H:%M").to_string();
+            let turn = match self.turn_state(session.id) {
+                Some(t) => format!(" · {t}"),
+                None => String::new(),
+            };
             output.push_str(&format!(
-                "{}. [{}] \"{}\" — last active {}, {} messages\n",
+                "{}. [{}] \"{}\" — last active {}, {} messages{}\n",
                 i + 1,
                 &session.id.to_string()[..8],
                 title,
                 date,
-                count
+                count,
+                turn
             ));
         }
 
@@ -213,10 +268,12 @@ impl SessionSearchTool {
 
     /// Machine-readable session discovery.
     ///
-    /// Returns JSON rows `{id, title, last_active, messages}` with FULL UUIDs
-    /// so other tools (`session_notify`) can be targeted without parsing the
-    /// human-oriented `list` output. Rows are ordered by last activity,
-    /// newest first (repo-level ORDER BY).
+    /// Returns JSON rows `{id, title, last_active, messages, turn}` with FULL
+    /// UUIDs so other tools (`session_notify`) can be targeted without
+    /// parsing the human-oriented `list` output. Rows are ordered by last
+    /// activity, newest first (repo-level ORDER BY). `turn` is `"running"`
+    /// while a turn is in flight, `"idle"` when waiting, `null` when no live
+    /// channel state is wired.
     async fn query_sessions(
         &self,
         status: &str,
@@ -264,6 +321,7 @@ impl SessionSearchTool {
                     .updated_at
                     .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                 "messages": count,
+                "turn": self.turn_state(s.id),
             }));
         }
 
@@ -518,7 +576,7 @@ fn extract_snippet(body: &str, query: &str, max_len: usize) -> String {
 
 /// Parse an `updated_since` spec: RFC3339 timestamp, or `Nd`/`Nh` shorthand
 /// meaning N days/hours back from now.
-fn parse_updated_since(
+pub(crate) fn parse_updated_since(
     spec: &str,
 ) -> std::result::Result<chrono::DateTime<chrono::Utc>, String> {
     let spec = spec.trim();
@@ -544,34 +602,4 @@ fn parse_updated_since(
         _ => return Err(invalid()),
     };
     Ok(chrono::Utc::now() - duration)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_rfc3339() {
-        let dt = parse_updated_since("2026-08-25T00:00:00Z").expect("valid rfc3339");
-        assert_eq!(dt.to_rfc3339(), "2026-08-25T00:00:00+00:00");
-    }
-
-    #[test]
-    fn parses_shorthand() {
-        let before = chrono::Utc::now();
-        let dt = parse_updated_since("24h").expect("24h valid");
-        assert!(dt > before - chrono::Duration::hours(25));
-        assert!(dt <= chrono::Utc::now());
-
-        let dt = parse_updated_since("7d").expect("7d valid");
-        assert!(dt < before - chrono::Duration::days(6));
-    }
-
-    #[test]
-    fn rejects_garbage() {
-        assert!(parse_updated_since("yesterday").is_err());
-        assert!(parse_updated_since("").is_err());
-        assert!(parse_updated_since("12x").is_err());
-        assert!(parse_updated_since("-5d").is_err());
-    }
 }

--- a/src/brain/tools/session_search.rs
+++ b/src/brain/tools/session_search.rs
@@ -50,7 +50,7 @@ impl SessionSearchTool {
     /// running session drains a queued push at its next tool-loop boundary;
     /// an idle one starts a fresh turn for it.
     #[cfg(feature = "telegram")]
-    fn turn_state(&self, session_id: uuid::Uuid) -> Option<&'static str> {
+    pub(crate) fn turn_state(&self, session_id: uuid::Uuid) -> Option<&'static str> {
         self.telegram.as_ref().map(|tg| {
             if tg.is_turn_active(session_id) {
                 "running"
@@ -303,7 +303,7 @@ impl SessionSearchTool {
         let mut selected: Vec<_> = sessions
             .into_iter()
             .filter(|s| status != "archived" || s.archived_at.is_some())
-            .filter(|s| updated_since.map_or(true, |since| s.updated_at > since))
+            .filter(|s| updated_since.is_none_or(|since| s.updated_at > since))
             .collect();
 
         if selected.is_empty() {

--- a/src/brain/tools/session_search.rs
+++ b/src/brain/tools/session_search.rs
@@ -7,13 +7,13 @@
 
 use super::error::Result;
 use super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
-use crate::db::Pool;
 #[cfg(feature = "telegram")]
 use crate::channels::telegram::TelegramState;
-#[cfg(feature = "telegram")]
-use std::sync::Arc;
+use crate::db::Pool;
 use async_trait::async_trait;
 use serde_json::Value;
+#[cfg(feature = "telegram")]
+use std::sync::Arc;
 
 /// Tool for listing and searching session message history via direct DB search.
 pub struct SessionSearchTool {

--- a/src/brain/tools/session_search.rs
+++ b/src/brain/tools/session_search.rs
@@ -34,6 +34,9 @@ impl Tool for SessionSearchTool {
          Use 'list' to show all sessions with titles, dates, and message counts. \
          Use 'search' to find messages across sessions by substring query. \
          Use 'tail' to read the last N messages of one session (cheap on huge histories). \
+         Use 'query' for machine-readable session discovery: JSON rows with full session ids, \
+         titles, last-active timestamps and message counts - e.g. to find another session's id \
+         to target with session_notify. \
          'session' can be a number (1 = most recent), a title keyword, or 'all' (default; \
          ignored by 'tail', which falls back to the newest session)."
     }
@@ -55,9 +58,26 @@ impl Tool for SessionSearchTool {
                     "type": "string",
                     "description": "Session to search: number (1=most recent), title keyword, or 'all' (default)"
                 },
+                "status": {
+                    "type": "string",
+                    "enum": ["active", "archived", "all"],
+                    "description": "Session state filter for 'query' (default: active)"
+                },
+                "title_contains": {
+                    "type": "string",
+                    "description": "Case-insensitive title substring filter for 'query'"
+                },
+                "updated_since": {
+                    "type": "string",
+                    "description": "'query' only: sessions last active after this point. RFC3339 timestamp or Nd/Nh shorthand (e.g. 7d, 24h)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "'query' only: max rows returned (default: 50, max: 500)"
+                },
                 "n": {
                     "type": "integer",
-                    "description": "Max results to return (default: 10)",
+                    "description": "Max results for 'search'/'tail' (default: 10)",
                     "default": 10
                 }
             },
@@ -142,14 +162,16 @@ impl SessionSearchTool {
             return Ok(ToolResult::success("No sessions found.".to_string()));
         }
 
-        let mut output = String::new();
+        let mut output =
+            String::from("Sessions, newest first ([short-id] identifies each row):\n");
         for (i, session) in sessions.iter().enumerate() {
             let count = message_repo.count_by_session(session.id).await.unwrap_or(0);
             let title = session.title.as_deref().unwrap_or("Untitled");
-            let date = session.updated_at.format("%Y-%m-%d").to_string();
+            let date = session.updated_at.format("%Y-%m-%d %H:%M").to_string();
             output.push_str(&format!(
-                "{}. \"{}\" — {}, {} messages\n",
+                "{}. [{}] \"{}\" — last active {}, {} messages\n",
                 i + 1,
+                &session.id.to_string()[..8],
                 title,
                 date,
                 count
@@ -157,6 +179,66 @@ impl SessionSearchTool {
         }
 
         Ok(ToolResult::success(output))
+    }
+
+    /// Machine-readable session discovery.
+    ///
+    /// Returns JSON rows `{id, title, last_active, messages}` with FULL UUIDs
+    /// so other tools (`session_notify`) can be targeted without parsing the
+    /// human-oriented `list` output. Rows are ordered by last activity,
+    /// newest first (repo-level ORDER BY).
+    async fn query_sessions(
+        &self,
+        status: &str,
+        title_contains: Option<&str>,
+        updated_since: Option<chrono::DateTime<chrono::Utc>>,
+        limit: usize,
+    ) -> Result<ToolResult> {
+        use crate::db::repository::{MessageRepository, SessionListOptions, SessionRepository};
+
+        let session_repo = SessionRepository::new(self.pool.clone());
+        let message_repo = MessageRepository::new(self.pool.clone());
+
+        // Repo sorts by updated_at DESC already; archived/all need the wider
+        // SQL net, then a Rust-side filter narrows to archived-only rows.
+        let include_archived = status != "active";
+        let sessions = session_repo
+            .list(SessionListOptions {
+                include_archived,
+                limit: None,
+                offset: 0,
+                query: title_contains.map(str::to_string),
+                include_subagents: false,
+            })
+            .await
+            .map_err(|e| super::error::ToolError::Execution(e.to_string()))?;
+
+        let mut selected: Vec<_> = sessions
+            .into_iter()
+            .filter(|s| status != "archived" || s.archived_at.is_some())
+            .filter(|s| updated_since.map_or(true, |since| s.updated_at > since))
+            .collect();
+
+        if selected.is_empty() {
+            return Ok(ToolResult::success("[]".to_string()));
+        }
+        selected.truncate(limit);
+
+        let mut rows = Vec::with_capacity(selected.len());
+        for s in &selected {
+            let count = message_repo.count_by_session(s.id).await.unwrap_or(0);
+            rows.push(serde_json::json!({
+                "id": s.id.to_string(),
+                "title": s.title.as_deref().unwrap_or("Untitled"),
+                "last_active": s
+                    .updated_at
+                    .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                "messages": count,
+            }));
+        }
+
+        let json = serde_json::to_string_pretty(&rows).unwrap_or_else(|_| "[]".to_string());
+        Ok(ToolResult::success(json))
     }
 
     async fn search_sessions(
@@ -402,4 +484,64 @@ fn extract_snippet(body: &str, query: &str, max_len: usize) -> String {
     // Collapse runs of whitespace so multi-line content stays readable in the
     // single-line snippet output.
     snippet.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Parse an `updated_since` spec: RFC3339 timestamp, or `Nd`/`Nh` shorthand
+/// meaning N days/hours back from now.
+fn parse_updated_since(
+    spec: &str,
+) -> std::result::Result<chrono::DateTime<chrono::Utc>, String> {
+    let spec = spec.trim();
+    let invalid = || {
+        format!(
+            "Invalid updated_since '{}': use RFC3339 (2026-08-25T00:00:00Z) or Nd/Nh shorthand (7d, 24h)",
+            spec
+        )
+    };
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(spec) {
+        return Ok(dt.with_timezone(&chrono::Utc));
+    }
+    if spec.len() < 2 {
+        return Err(invalid());
+    }
+    let (num, unit) = spec.split_at(spec.len() - 1);
+    let Ok(n) = num.parse::<i64>() else {
+        return Err(invalid());
+    };
+    let duration = match (unit, n) {
+        ("h", n) if n > 0 => chrono::Duration::hours(n),
+        ("d", n) if n > 0 => chrono::Duration::days(n),
+        _ => return Err(invalid()),
+    };
+    Ok(chrono::Utc::now() - duration)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_rfc3339() {
+        let dt = parse_updated_since("2026-08-25T00:00:00Z").expect("valid rfc3339");
+        assert_eq!(dt.to_rfc3339(), "2026-08-25T00:00:00+00:00");
+    }
+
+    #[test]
+    fn parses_shorthand() {
+        let before = chrono::Utc::now();
+        let dt = parse_updated_since("24h").expect("24h valid");
+        assert!(dt > before - chrono::Duration::hours(25));
+        assert!(dt <= chrono::Utc::now());
+
+        let dt = parse_updated_since("7d").expect("7d valid");
+        assert!(dt < before - chrono::Duration::days(6));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(parse_updated_since("yesterday").is_err());
+        assert!(parse_updated_since("").is_err());
+        assert!(parse_updated_since("12x").is_err());
+        assert!(parse_updated_since("-5d").is_err());
+    }
 }

--- a/src/brain/tools/session_search.rs
+++ b/src/brain/tools/session_search.rs
@@ -47,8 +47,8 @@ impl Tool for SessionSearchTool {
             "properties": {
                 "operation": {
                     "type": "string",
-                    "enum": ["list", "search", "tail"],
-                    "description": "'list' to show sessions, 'search' to find messages, 'tail' to read the last N messages of a session"
+                    "enum": ["list", "search", "tail", "query"],
+                    "description": "'list' to show sessions, 'search' to find messages, 'tail' to read the last N messages of a session, 'query' for machine-readable session discovery"
                 },
                 "query": {
                     "type": "string",
@@ -132,8 +132,38 @@ impl Tool for SessionSearchTool {
                 self.search_sessions(&query, session_filter.as_deref(), n)
                     .await
             }
+            "query" => {
+                let status = input
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("active");
+                if !matches!(status, "active" | "archived" | "all") {
+                    return Ok(ToolResult::error(
+                        "Invalid status. Use 'active', 'archived', or 'all'.".to_string(),
+                    ));
+                }
+                let title_contains = input
+                    .get("title_contains")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty());
+                let updated_since = match input.get("updated_since").and_then(|v| v.as_str()) {
+                    Some(raw) => match parse_updated_since(raw) {
+                        Ok(dt) => Some(dt),
+                        Err(e) => return Ok(ToolResult::error(e)),
+                    },
+                    None => None,
+                };
+                // Default 50, clamped to 500 so one call can't flood context.
+                let limit = input
+                    .get("limit")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(50)
+                    .clamp(1, 500) as usize;
+                self.query_sessions(status, title_contains, updated_since, limit)
+                    .await
+            }
             _ => Ok(ToolResult::error(format!(
-                "Unknown operation '{}'. Use 'list', 'search', or 'tail'.",
+                "Unknown operation '{}'. Use 'list', 'search', 'tail', or 'query'.",
                 operation
             ))),
         }

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -84,7 +84,7 @@ impl Tool for SessionNotifyTool {
         let msg = crate::brain::agent::QueuedUserMessage {
             context_text: format!("[session-notify from={from}]\n\n{message}"),
             display_text: format!("📨 notify from {}:\n{message}", short_id(from)),
-            origin: crate::brain::agent::PushOrigin::Other,
+            origin: crate::brain::agent::PushOrigin::SessionNotify,
         };
 
         use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -84,6 +84,7 @@ impl Tool for SessionNotifyTool {
         let msg = crate::brain::agent::QueuedUserMessage {
             context_text: format!("[session-notify from={from}]\n\n{message}"),
             display_text: format!("📨 notify from {}:\n{message}", short_id(from)),
+            origin: crate::brain::agent::PushOrigin::Other,
         };
 
         use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};

--- a/src/brain/tools/subagent/spawn.rs
+++ b/src/brain/tools/subagent/spawn.rs
@@ -65,6 +65,7 @@ pub(crate) fn completion_message(
     crate::brain::agent::QueuedUserMessage {
         context_text,
         display_text,
+        origin: crate::brain::agent::PushOrigin::SubAgent,
     }
 }
 

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2992,6 +2992,7 @@ pub(crate) async fn handle_reaction(
                 crate::brain::agent::QueuedUserMessage {
                     context_text: midturn,
                     display_text: format!("[System: {user_name} reacted with {emoji} mid-turn]"),
+                    origin: crate::brain::agent::PushOrigin::Ingress,
                 },
             );
             tracing::info!(
@@ -3236,6 +3237,7 @@ pub(crate) fn build_midturn_queued_message(
                 invocation, resolved_body
             ),
             display_text: invocation.to_string(),
+            origin: crate::brain::agent::PushOrigin::Ingress,
         },
         None => crate::brain::agent::QueuedUserMessage {
             context_text: format!(
@@ -3244,6 +3246,7 @@ pub(crate) fn build_midturn_queued_message(
                 display_text
             ),
             display_text: display_text.to_string(),
+            origin: crate::brain::agent::PushOrigin::Ingress,
         },
     }
 }

--- a/src/channels/telegram/mod.rs
+++ b/src/channels/telegram/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod session_resolve;
 pub(crate) mod stream_loop;
 pub(crate) mod suggest_options;
 pub(crate) mod telemetry;
+pub(crate) mod titles;
 pub(crate) mod typing;
 
 pub use agent::TelegramAgent;

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -69,9 +69,14 @@ pub(crate) fn build_enqueue_callback(
             // preserved), so the user sees why the session woke up even when
             // the resumed answer restates it. Fires on BOTH delivery paths:
             // before the guard branch below means idle-wakes AND results that
-            // get queued into an in-flight turn are announced alike. Scoped to
-            // background-task completions only; sub-agent pushes stay silent.
-            if msg.origin == crate::brain::agent::PushOrigin::BackgroundTask {
+            // get queued into an in-flight turn are announced alike. Covers
+            // background-task completions AND session_notify pushes (#1221
+            // notify lane); sub-agent pushes stay silent.
+            if matches!(
+                msg.origin,
+                crate::brain::agent::PushOrigin::BackgroundTask
+                    | crate::brain::agent::PushOrigin::SessionNotify
+            ) {
                 let html = render_bg_echo_html(&msg.context_text);
                 let mut echo = bot
                     .send_message(teloxide::types::ChatId(chat_id), html)

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -73,12 +73,15 @@ pub(crate) fn build_enqueue_callback(
             // background-task completions only; sub-agent pushes stay silent.
             if msg.origin == crate::brain::agent::PushOrigin::BackgroundTask {
                 let html = render_bg_echo_html(&msg.context_text);
-                if let Err(e) = bot
-                    .send_message(chat_id, html)
-                    .parse_mode(teloxide::types::ParseMode::Html)
-                    .message_thread_id(thread_id)
-                    .await
-                {
+                let mut echo = bot
+                    .send_message(teloxide::types::ChatId(chat_id), html)
+                    .parse_mode(teloxide::types::ParseMode::Html);
+                // Forum topics address a thread; DMs and non-forum groups must
+                // omit the parameter entirely (E0308: not an unwrap decision).
+                if let Some(tid) = thread_id {
+                    echo = echo.message_thread_id(tid);
+                }
+                if let Err(e) = echo.await {
                     tracing::warn!("[bg-resume] #1221 echo bubble failed to send: {e}");
                 }
             }

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -112,9 +112,7 @@ pub(crate) fn build_enqueue_callback(
                     {
                         Ok(()) => true,
                         Err(e) => {
-                            tracing::warn!(
-                                "[bg-resume] #1225 rich echo failed, using HTML: {e}"
-                            );
+                            tracing::warn!("[bg-resume] #1225 rich echo failed, using HTML: {e}");
                             false
                         }
                     };
@@ -188,7 +186,7 @@ pub(crate) fn build_enqueue_callback(
                 return;
             };
 
-if let Err(e) = resume_session(
+            if let Err(e) = resume_session(
                 bot,
                 teloxide::types::ChatId(chat_id),
                 thread_id,
@@ -703,18 +701,20 @@ async fn sender_label(
     let label = match sender_chat {
         None => None,
         Some(sc) if sc == recipient_chat => match sender_topic {
-            Some(tid) => super::titles::topic_title(
-                &api_url,
-                &token,
-                teloxide::types::ChatId(sc),
-                teloxide::types::ThreadId(teloxide::types::MessageId(tid)),
-            )
-            .await,
+            Some(tid) => {
+                super::titles::topic_title(
+                    &api_url,
+                    &token,
+                    teloxide::types::ChatId(sc),
+                    teloxide::types::ThreadId(teloxide::types::MessageId(tid)),
+                )
+                .await
+            }
             None => None,
         },
         Some(sc) => {
-            let chat = super::titles::chat_title(&api_url, &token, teloxide::types::ChatId(sc))
-                .await;
+            let chat =
+                super::titles::chat_title(&api_url, &token, teloxide::types::ChatId(sc)).await;
             match (chat, sender_topic) {
                 (Some(c), Some(tid)) => {
                     match super::titles::topic_title(

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -77,17 +77,87 @@ pub(crate) fn build_enqueue_callback(
                 crate::brain::agent::PushOrigin::BackgroundTask
                     | crate::brain::agent::PushOrigin::SessionNotify
             ) {
-                let html = render_bg_echo_html(&msg.context_text);
-                let mut echo = bot
-                    .send_message(teloxide::types::ChatId(chat_id), html)
-                    .parse_mode(teloxide::types::ParseMode::Html);
-                // Forum topics address a thread; DMs and non-forum groups must
-                // omit the parameter entirely (E0308: not an unwrap decision).
-                if let Some(tid) = thread_id {
-                    echo = echo.message_thread_id(tid);
-                }
-                if let Err(e) = echo.await {
-                    tracing::warn!("[bg-resume] #1221 echo bubble failed to send: {e}");
+                // #1225: session_notify pushes carry a mechanical
+                // `[session-notify from=<uuid>]` header — replace the raw id
+                // with a human label (topic name for same-chat pushes, chat
+                // name / chat+topic for cross-chat, per Alexey's rule), so the
+                // bubble reads "📨 From: Ops / Push to session", not a UUID
+                // spray. Background-task pushes have no sender: the title
+                // names the task from the producer's display line instead of
+                // the generic "⚙️ background task result" (Alexey 2026-08-26).
+                let (sender, body) = split_bg_echo_parts(&msg.context_text);
+                let title = if let Some(s) = sender {
+                    format!("📨 {}", sender_label(&state, &bot, s, chat_id).await)
+                } else if msg.origin == crate::brain::agent::PushOrigin::BackgroundTask {
+                    // Borrow: `msg` is moved wholesale later in this callback.
+                    background_task_title(&msg.display_text)
+                } else {
+                    "⚙️ background task result".to_owned()
+                };
+                let (markdown, html) = build_bg_echo_bubble(&body, &title);
+                // Rich-first: tables/headings/mermaid in the body get the
+                // native rich message; anything else — or any send failure —
+                // degrades to the classic HTML blockquote below.
+                let sent_rich = super::rich::should_send_native_rich(&markdown)
+                    && match super::rich::send_rich_with_mermaid(
+                        bot.api_url().as_str(),
+                        bot.token(),
+                        chat_id,
+                        thread_id,
+                        &markdown,
+                        "bg-resume",
+                        "-",
+                    )
+                    .await
+                    {
+                        Ok(()) => true,
+                        Err(e) => {
+                            tracing::warn!(
+                                "[bg-resume] #1225 rich echo failed, using HTML: {e}"
+                            );
+                            false
+                        }
+                    };
+                if !sent_rich {
+                    let mut echo = bot
+                        .send_message(teloxide::types::ChatId(chat_id), html.clone())
+                        .parse_mode(teloxide::types::ParseMode::Html);
+                    // Forum topics address a thread; DMs and non-forum groups must
+                    // omit the parameter entirely (E0308: not an unwrap decision).
+                    if let Some(tid) = thread_id {
+                        echo = echo.message_thread_id(tid);
+                    }
+                    // 429 discipline (#816): the raw send_message used to race
+                    // the resumed stream + typing loop into the same chat and
+                    // drop silently — 11/11 real echo sends failed that way on
+                    // 2026-08-26 (per-chat flood windows, compiler batch log).
+                    // Wait the window out (shared wait_out policy) and retry ONCE
+                    // with fresh content, matching delivery.rs / flow.rs.
+                    match echo.await {
+                        Ok(_) => {}
+                        Err(teloxide::RequestError::RetryAfter(secs)) => {
+                            super::rate_limit::wait_out(
+                                "bg-resume echo",
+                                secs.duration(),
+                                " on first delivery, retrying once",
+                            )
+                            .await;
+                            let mut retry = bot
+                                .send_message(teloxide::types::ChatId(chat_id), html)
+                                .parse_mode(teloxide::types::ParseMode::Html);
+                            if let Some(tid) = thread_id {
+                                retry = retry.message_thread_id(tid);
+                            }
+                            if let Err(e) = retry.await {
+                                tracing::warn!(
+                                    "[bg-resume] #1221 echo bubble failed on 429 retry: {e}"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("[bg-resume] #1221 echo bubble failed to send: {e}");
+                        }
+                    }
                 }
             }
 
@@ -544,26 +614,131 @@ pub(crate) async fn resume_session(
 /// chars; header, tags and Telegram's own margin eat the rest of the budget.
 const BG_ECHO_BODY_CAP_CHARS: usize = 3200;
 
-/// Build the HTML for the #1221 background-task echo bubble: an expandable
-/// blockquote whose body keeps the completion text's rich formatting (fences,
-/// bold) through the markdown→HTML converter. Raw text is truncated BEFORE
-/// conversion so the tags stay well-formed — cutting rendered HTML can split
-/// a tag and make Telegram strip the formatting entirely (plan_card lesson).
-///
-/// The synthetic `[System: ...]` framing is stripped so prompt scaffolding
-/// never renders to the user; any other shape passes through untouched.
-pub(crate) fn render_bg_echo_html(context_text: &str) -> String {
-    let trimmed = context_text.trim();
-    let inner = trimmed
+/// Split the mechanical `[session-notify from=<uuid>]` header (#1203) off a
+/// push's context text. Absent or malformed header → `(None, whole text)`.
+pub(crate) fn split_notify_header(context_text: &str) -> (Option<Uuid>, &str) {
+    let trimmed = context_text.trim_start();
+    let Some(after_open) = trimmed.strip_prefix("[session-notify from=") else {
+        return (None, trimmed);
+    };
+    let Some(close) = after_open.find(']') else {
+        return (None, trimmed);
+    };
+    let rest = after_open[close + 1..].trim_start();
+    match Uuid::parse_str(&after_open[..close]) {
+        Ok(sender) => (Some(sender), rest),
+        Err(_) => (None, trimmed),
+    }
+}
+
+/// Strip the synthetic `[System: ...]` framing (constructors in
+/// `brain/agent/service` terminate the block with `]`). Any other shape
+/// passes through untouched.
+pub(crate) fn strip_system_framing(text: &str) -> &str {
+    let trimmed = text.trim();
+    trimmed
         .strip_prefix("[System:")
         .and_then(|s| s.strip_suffix(']'))
         .map(str::trim)
-        .unwrap_or(trimmed);
-    let truncated = inner.chars().count() > BG_ECHO_BODY_CAP_CHARS;
-    let body = crate::utils::string::truncate_chars(inner, BG_ECHO_BODY_CAP_CHARS);
-    format!(
-        "<blockquote expandable><b>⚙️ background task result{}</b>\n{}</blockquote>",
-        if truncated { " (truncated)" } else { "" },
+        .unwrap_or(trimmed)
+}
+
+/// Split a push's text into `(sender, clean_body)`: notify header and System
+/// framing both removed. `sender` is `None` for plain background-task pushes.
+pub(crate) fn split_bg_echo_parts(context_text: &str) -> (Option<Uuid>, String) {
+    let (sender, rest) = split_notify_header(context_text);
+    (sender, strip_system_framing(rest).to_owned())
+}
+
+/// Assemble the echo bubble from the clean body + title. Returns the
+/// rich-capable markdown and the classic HTML blockquote fallback. Raw text
+/// is truncated BEFORE conversion so the wrapper tags stay well-formed —
+/// cutting rendered HTML can split a tag and make Telegram strip the
+/// formatting entirely (plan_card lesson).
+pub(crate) fn build_bg_echo_bubble(body: &str, title: &str) -> (String, String) {
+    let truncated = body.chars().count() > BG_ECHO_BODY_CAP_CHARS;
+    let body = crate::utils::string::truncate_chars(body, BG_ECHO_BODY_CAP_CHARS);
+    let suffix = if truncated { " (truncated)" } else { "" };
+    let markdown = format!("{title}{suffix}\n\n{body}");
+    // The title is dynamic (sender label / task display line): escape it for
+    // the HTML dialect so a `<` in a label can't corrupt the wrapper.
+    let html = format!(
+        "<blockquote expandable><b>{}{}</b>\n{}</blockquote>",
+        super::markdown::escape_html(title),
+        suffix,
         super::rich::markdown_to_html(body),
-    )
+    );
+    (markdown, html)
+}
+
+/// Bubble header for a background-task echo: reuse the producer's display
+/// line, which already names the task ("🔧 background task finished:
+/// <label>") — the generic "⚙️ background task result" said nothing about
+/// which task woke the session (Alexey 2026-08-26). Blank display → generic
+/// fallback; overlong labels are capped so the header stays readable.
+pub(crate) fn background_task_title(display_text: &str) -> String {
+    let t = display_text.trim();
+    if t.is_empty() {
+        "⚙️ background task result".to_owned()
+    } else {
+        crate::utils::string::truncate_chars(t, 120).to_owned()
+    }
+}
+
+/// Human-readable sender label for a session_notify push (Alexey's rule):
+/// sender chat == recipient chat → the sender's topic name; a different
+/// non-forum chat → chat name; a different forum → chat + topic name.
+/// Best-effort: any lookup failure falls back to the short session id
+/// (the same prefix `session_search list` displays).
+async fn sender_label(
+    state: &TelegramState,
+    bot: &teloxide::Bot,
+    sender: Uuid,
+    recipient_chat: i64,
+) -> String {
+    let sender_chat = state.session_chat(sender).await;
+    let sender_topic = state.session_topic(sender).await;
+    let api_url = bot.api_url().to_string();
+    let token = bot.token().to_owned();
+    let label = match sender_chat {
+        None => None,
+        Some(sc) if sc == recipient_chat => match sender_topic {
+            Some(tid) => super::titles::topic_title(
+                &api_url,
+                &token,
+                teloxide::types::ChatId(sc),
+                teloxide::types::ThreadId(teloxide::types::MessageId(tid)),
+            )
+            .await,
+            None => None,
+        },
+        Some(sc) => {
+            let chat = super::titles::chat_title(&api_url, &token, teloxide::types::ChatId(sc))
+                .await;
+            match (chat, sender_topic) {
+                (Some(c), Some(tid)) => {
+                    match super::titles::topic_title(
+                        &api_url,
+                        &token,
+                        teloxide::types::ChatId(sc),
+                        teloxide::types::ThreadId(teloxide::types::MessageId(tid)),
+                    )
+                    .await
+                    {
+                        Some(t) => Some(format!("{c} / {t}")),
+                        None => Some(c),
+                    }
+                }
+                (Some(c), None) => Some(c),
+                (None, _) => None,
+            }
+        }
+    };
+    label.unwrap_or_else(|| short_session_id(sender))
+}
+
+/// Short session id: first 8 hex chars of the uuid (matches `session_search`
+/// list's short-id prefix display).
+fn short_session_id(uuid: Uuid) -> String {
+    uuid.to_simple().to_string()[..8].to_owned()
 }

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -740,5 +740,5 @@ async fn sender_label(
 /// Short session id: first 8 hex chars of the uuid (matches `session_search`
 /// list's short-id prefix display).
 fn short_session_id(uuid: Uuid) -> String {
-    uuid.to_simple().to_string()[..8].to_owned()
+    uuid.simple().to_string()[..8].to_owned()
 }

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -47,6 +47,42 @@ pub(crate) fn build_enqueue_callback(
                 tracing::warn!("[bg-resume] telegram: agent gone; dropping resume");
                 return;
             };
+            // The topic that OWNS the session, not whichever one spoke last
+            // (#1200). Sessions are per-topic since #215, and
+            // `register_session_chat` records the topic, but this path asked
+            // the chat instead: in a forum, any traffic in another topic while
+            // a detached command ran sent the result there. Both background
+            // completions and sub-agent results share this callback, so they
+            // were both misrouted.
+            //
+            // The chat-wide lookup stays as the fallback. It is still right
+            // for a DM or a non-forum group (where `session_topic` is None
+            // anyway), and it is all we have for a session whose in-memory
+            // topic binding has not been re-registered since a restart.
+            let thread_id = match state.session_topic(session_id).await {
+                Some(topic) => Some(teloxide::types::ThreadId(teloxide::types::MessageId(topic))),
+                None => super::send::latest_thread_id_for_chat(chat_id).await,
+            };
+
+            // #1221: announce WHAT arrived before anything else happens — an
+            // expandable blockquote echoing the completion output (rich format
+            // preserved), so the user sees why the session woke up even when
+            // the resumed answer restates it. Fires on BOTH delivery paths:
+            // before the guard branch below means idle-wakes AND results that
+            // get queued into an in-flight turn are announced alike. Scoped to
+            // background-task completions only; sub-agent pushes stay silent.
+            if msg.origin == crate::brain::agent::PushOrigin::BackgroundTask {
+                let html = render_bg_echo_html(&msg.context_text);
+                if let Err(e) = bot
+                    .send_message(chat_id, html)
+                    .parse_mode(teloxide::types::ParseMode::Html)
+                    .message_thread_id(thread_id)
+                    .await
+                {
+                    tracing::warn!("[bg-resume] #1221 echo bubble failed to send: {e}");
+                }
+            }
+
             // One streaming turn per session (#845). Several detached commands
             // finishing together used to spawn a resume turn each, all on this
             // session and all in this chat, so every one opened and edited its
@@ -74,23 +110,7 @@ pub(crate) fn build_enqueue_callback(
                 return;
             };
 
-            // The topic that OWNS the session, not whichever one spoke last
-            // (#1200). Sessions are per-topic since #215, and
-            // `register_session_chat` records the topic, but this path asked
-            // the chat instead: in a forum, any traffic in another topic while
-            // a detached command ran sent the result there. Both background
-            // completions and sub-agent results share this callback, so they
-            // were both misrouted.
-            //
-            // The chat-wide lookup stays as the fallback. It is still right
-            // for a DM or a non-forum group (where `session_topic` is None
-            // anyway), and it is all we have for a session whose in-memory
-            // topic binding has not been re-registered since a restart.
-            let thread_id = match state.session_topic(session_id).await {
-                Some(topic) => Some(teloxide::types::ThreadId(teloxide::types::MessageId(topic))),
-                None => super::send::latest_thread_id_for_chat(chat_id).await,
-            };
-            if let Err(e) = resume_session(
+if let Err(e) = resume_session(
                 bot,
                 teloxide::types::ChatId(chat_id),
                 thread_id,
@@ -510,4 +530,32 @@ pub(crate) async fn resume_session(
     }
 
     Ok(())
+}
+
+/// Cap for the #1221 echo body: classic `sendMessage` caps a message at 4096
+/// chars; header, tags and Telegram's own margin eat the rest of the budget.
+const BG_ECHO_BODY_CAP_CHARS: usize = 3200;
+
+/// Build the HTML for the #1221 background-task echo bubble: an expandable
+/// blockquote whose body keeps the completion text's rich formatting (fences,
+/// bold) through the markdown→HTML converter. Raw text is truncated BEFORE
+/// conversion so the tags stay well-formed — cutting rendered HTML can split
+/// a tag and make Telegram strip the formatting entirely (plan_card lesson).
+///
+/// The synthetic `[System: ...]` framing is stripped so prompt scaffolding
+/// never renders to the user; any other shape passes through untouched.
+pub(crate) fn render_bg_echo_html(context_text: &str) -> String {
+    let trimmed = context_text.trim();
+    let inner = trimmed
+        .strip_prefix("[System:")
+        .and_then(|s| s.strip_suffix(']'))
+        .map(str::trim)
+        .unwrap_or(trimmed);
+    let truncated = inner.chars().count() > BG_ECHO_BODY_CAP_CHARS;
+    let body = crate::utils::string::truncate_chars(inner, BG_ECHO_BODY_CAP_CHARS);
+    format!(
+        "<blockquote expandable><b>⚙️ background task result{}</b>\n{}</blockquote>",
+        if truncated { " (truncated)" } else { "" },
+        super::rich::markdown_to_html(body),
+    )
 }

--- a/src/channels/telegram/titles.rs
+++ b/src/channels/telegram/titles.rs
@@ -8,7 +8,7 @@
 //! fallback in `resume.rs`, never an error bubble.
 
 use std::time::Duration;
-use teloxide::types::{ChatId, MessageId, ThreadId};
+use teloxide::types::{ChatId, ThreadId};
 
 fn api_base(api_url: &str) -> &str {
     api_url.trim_end_matches('/')

--- a/src/channels/telegram/titles.rs
+++ b/src/channels/telegram/titles.rs
@@ -1,0 +1,77 @@
+//! Best-effort Bot API title lookups for human-readable sender labels on
+//! session_notify echo bubbles (#1225). Raw HTTP, same wire style as
+//! `rich/api.rs`: teloxide 0.17 has no `getForumTopic` binding (docs.rs 404,
+//! verified) and a uniform raw call keeps `getChat` and `getForumTopic` on
+//! one tiny code path.
+//!
+//! Every lookup is best-effort — `None` on any failure feeds the short-id
+//! fallback in `resume.rs`, never an error bubble.
+
+use std::time::Duration;
+use teloxide::types::{ChatId, MessageId, ThreadId};
+
+fn api_base(api_url: &str) -> &str {
+    api_url.trim_end_matches('/')
+}
+
+/// One-shot POST to a Bot API method; returns `result` on `ok: true`.
+async fn post_api(
+    api_url: &str,
+    token: &str,
+    method: &str,
+    body: serde_json::Value,
+) -> Option<serde_json::Value> {
+    let url = format!("{}/bot{token}/{method}", api_base(api_url));
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .ok()?;
+    let resp = client.post(url).json(&body).send().await.ok()?;
+    let parsed: serde_json::Value = resp.json().await.ok()?;
+    if parsed.get("ok").and_then(serde_json::Value::as_bool) == Some(true) {
+        parsed.get("result").cloned()
+    } else {
+        None
+    }
+}
+
+/// Chat display name: `title` for groups/channels, `username` as fallback
+/// for private chats (getChat leaves `title` absent on Private).
+pub(crate) async fn chat_title(
+    api_url: &str,
+    token: &str,
+    chat_id: ChatId,
+) -> Option<String> {
+    let result = post_api(api_url, token, "getChat", serde_json::json!({ "chat_id": chat_id.0 }))
+        .await?;
+    result
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            result
+                .get("username")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+}
+
+/// Forum topic display name: getForumTopic → `result.name`.
+pub(crate) async fn topic_title(
+    api_url: &str,
+    token: &str,
+    chat_id: ChatId,
+    topic_id: ThreadId,
+) -> Option<String> {
+    let result = post_api(
+        api_url,
+        token,
+        "getForumTopic",
+        serde_json::json!({ "chat_id": chat_id.0, "message_thread_id": topic_id.0.0 }),
+    )
+    .await?;
+    result
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+}

--- a/src/channels/telegram/titles.rs
+++ b/src/channels/telegram/titles.rs
@@ -37,13 +37,14 @@ async fn post_api(
 
 /// Chat display name: `title` for groups/channels, `username` as fallback
 /// for private chats (getChat leaves `title` absent on Private).
-pub(crate) async fn chat_title(
-    api_url: &str,
-    token: &str,
-    chat_id: ChatId,
-) -> Option<String> {
-    let result = post_api(api_url, token, "getChat", serde_json::json!({ "chat_id": chat_id.0 }))
-        .await?;
+pub(crate) async fn chat_title(api_url: &str, token: &str, chat_id: ChatId) -> Option<String> {
+    let result = post_api(
+        api_url,
+        token,
+        "getChat",
+        serde_json::json!({ "chat_id": chat_id.0 }),
+    )
+    .await?;
     result
         .get("title")
         .and_then(serde_json::Value::as_str)

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -846,6 +846,18 @@ async fn cmd_chat_inner(
         crate::brain::tools::telegram_send::TelegramSendTool::new(telegram_state.clone()),
     ));
 
+    // Re-register session_search carrying live channel state so discovery
+    // rows report turn activity (running/idle, #1203). Registry insert
+    // replaces the stateless core instance by name; the daemon path keeps
+    // that stateless one.
+    #[cfg(feature = "telegram")]
+    tool_registry.register(Arc::new(
+        crate::brain::tools::session_search::SessionSearchTool::with_telegram(
+            db.pool().clone(),
+            telegram_state.clone(),
+        ),
+    ));
+
     // Register cowork tool — launch a Telegram cowork workspace from anywhere
     // (TUI included); generates the deep link + QR and registers the session.
     #[cfg(feature = "telegram")]

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -25,7 +25,10 @@ fn split_notify_header_rejects_malformed_framing() {
     let bad_uuid = "[session-notify from=not-a-uuid]\n\nbody";
     let (sender, body) = split_notify_header(bad_uuid);
     assert_eq!(sender, None);
-    assert_eq!(body, bad_uuid, "malformed header must pass whole text through");
+    assert_eq!(
+        body, bad_uuid,
+        "malformed header must pass whole text through"
+    );
     let no_close = "[session-notify from=6c1c9cb9-8243-4def-abe5-d926d0ca8bed";
     let (sender, body) = split_notify_header(no_close);
     assert_eq!(sender, None);
@@ -47,17 +50,22 @@ fn strips_terminated_system_framing() {
 fn system_framing_without_closing_brace_passes_through() {
     let ctx = "[System: task finished]\nsome output";
     let inner = strip_system_framing(ctx);
-    assert_eq!(inner, ctx, "the ']' must terminate the block to be stripped");
+    assert_eq!(
+        inner, ctx,
+        "the ']' must terminate the block to be stripped"
+    );
 }
 
 #[test]
 fn strips_system_framing_even_after_notify_header() {
-    let ctx = format!(
-        "[session-notify from={SENDER}]\n\n[System: the push you asked for]\npushed body"
-    );
+    let ctx =
+        format!("[session-notify from={SENDER}]\n\n[System: the push you asked for]\npushed body");
     let (sender, body) = split_bg_echo_parts(&ctx);
     assert!(sender.is_some());
-    assert!(!body.contains("[System:"), "System framing stripped after header");
+    assert!(
+        !body.contains("[System:"),
+        "System framing stripped after header"
+    );
     assert!(body.contains("pushed body"));
 }
 

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -1,55 +1,138 @@
-//! #1221: the background-task echo bubble renderer. Pure-HTML assertions so
-//! no bot or runtime is needed: framing strip, rich-format preservation,
-//! truncation discipline (raw text cut BEFORE conversion, tags stay intact).
+//! #1221/#1225: the background-task echo bubble renderer + the
+//! session_notify label plumbing. Pure assertions — no bot, no runtime:
+//! framing strips (System + notify header), bubble assembly (rich markdown +
+//! HTML fallback), truncation discipline (raw text cut BEFORE conversion,
+//! wrapper tags stay intact).
 
-use crate::channels::telegram::resume::render_bg_echo_html;
+use crate::channels::telegram::resume::{
+    background_task_title, build_bg_echo_bubble, split_bg_echo_parts, split_notify_header,
+    strip_system_framing,
+};
+use uuid::Uuid;
+
+const SENDER: &str = "6c1c9cb9-8243-4def-abe5-d926d0ca8bed";
 
 #[test]
-fn wraps_output_in_expandable_blockquote_with_bold_header() {
-    let html = render_bg_echo_html("[System: task finished]\nsome output");
+fn strips_notify_header_and_returns_sender() {
+    let ctx = format!("[session-notify from={SENDER}]\n\nhello from the other topic");
+    let (sender, body) = split_bg_echo_parts(&ctx);
+    assert_eq!(sender, Some(Uuid::parse_str(SENDER).unwrap()));
+    assert_eq!(body, "hello from the other topic");
+}
+
+#[test]
+fn split_notify_header_rejects_malformed_framing() {
+    let bad_uuid = "[session-notify from=not-a-uuid]\n\nbody";
+    let (sender, body) = split_notify_header(bad_uuid);
+    assert_eq!(sender, None);
+    assert_eq!(body, bad_uuid, "malformed header must pass whole text through");
+    let no_close = "[session-notify from=6c1c9cb9-8243-4def-abe5-d926d0ca8bed";
+    let (sender, body) = split_notify_header(no_close);
+    assert_eq!(sender, None);
+    assert_eq!(body, no_close);
+}
+
+#[test]
+fn strips_terminated_system_framing() {
+    // Real framing shape (background_tasks.rs): block ends with ']'.
+    let ctx = "[System: the background task you started has finished.\nStatus: exit 0]\nreal tail";
+    let (sender, body) = split_bg_echo_parts(ctx);
+    assert_eq!(sender, None, "background tasks carry no sender");
+    assert!(!body.contains("[System:"), "scaffolding must not render");
+    assert!(body.contains("Status: exit 0"), "inner content survives");
+    assert!(body.contains("real tail"));
+}
+
+#[test]
+fn system_framing_without_closing_brace_passes_through() {
+    let ctx = "[System: task finished]\nsome output";
+    let inner = strip_system_framing(ctx);
+    assert_eq!(inner, ctx, "the ']' must terminate the block to be stripped");
+}
+
+#[test]
+fn strips_system_framing_even_after_notify_header() {
+    let ctx = format!(
+        "[session-notify from={SENDER}]\n\n[System: the push you asked for]\npushed body"
+    );
+    let (sender, body) = split_bg_echo_parts(&ctx);
+    assert!(sender.is_some());
+    assert!(!body.contains("[System:"), "System framing stripped after header");
+    assert!(body.contains("pushed body"));
+}
+
+#[test]
+fn absent_framing_passes_through_untouched() {
+    let (sender, body) = split_bg_echo_parts("plain text, no framing");
+    assert_eq!(sender, None);
+    assert_eq!(body, "plain text, no framing");
+}
+
+#[test]
+fn bubble_wraps_in_blockquote_with_bold_header() {
+    let (markdown, html) = build_bg_echo_bubble("some output", "📨 Ops / Push to session");
+    assert!(markdown.contains("📨 Ops / Push to session"));
+    assert!(markdown.contains("some output"));
     assert!(html.starts_with("<blockquote expandable>"));
     assert!(html.ends_with("</blockquote>"));
-    assert!(html.contains("<b>⚙️ background task result</b>"));
+    assert!(html.contains("<b>📨 Ops / Push to session</b>"));
     assert!(html.contains("some output"));
 }
 
 #[test]
-fn strips_system_framing_from_display() {
-    let html = render_bg_echo_html(
-        "[System: the background task you started has finished.\nStatus: exit 0]\nreal tail",
-    );
-    assert!(!html.contains("[System:"), "scaffolding must not render");
-    assert!(html.contains("Status: exit 0"), "inner content survives");
-    assert!(html.contains("real tail"));
+fn background_task_title_is_preserved() {
+    let (_, html) = build_bg_echo_bubble("finished ok", "⚙️ background task result");
+    assert!(html.contains("<b>⚙️ background task result</b>"));
 }
 
 #[test]
-fn preserves_markdown_as_rich_html() {
-    let ctx = "[System: done]\n# Heading\n```rust\nfn main() {}\n```";
-    let html = render_bg_echo_html(ctx);
-    // Fences become block-level code, headings survive as markup — the echo
-    // must NOT degrade to escaped plain text (#1221 requirement).
-    assert!(
-        html.contains("<pre") || html.contains("<code"),
-        "fence lost: {html}"
-    );
+fn rich_markdown_keeps_fences() {
+    let ctx = "# Heading\n```rust\nfn main() {}\n```";
+    let (markdown, _) = build_bg_echo_bubble(ctx, "📨 Team");
+    assert!(markdown.contains("```rust"));
+    assert!(markdown.contains("# Heading"));
 }
 
 #[test]
 fn long_output_is_truncated_before_conversion_and_stays_wellformed() {
-    let ctx = format!("[System: done]\n{{}}<b>x</b>",);
-    let big = format!("{ctx}\n{}", "y".repeat(10_000));
-    let html = render_bg_echo_html(&big);
+    let big = format!("{{}}\n{}", "y".repeat(10_000));
+    let (markdown, html) = build_bg_echo_bubble(&big, "⚙️ background task result");
+    assert!(markdown.contains("(truncated)"));
     assert!(html.contains("(truncated)"));
     // Truncating raw text first means the wrapper tags can never be cut:
     assert!(html.starts_with("<blockquote expandable>"));
     assert!(html.ends_with("</blockquote>"));
-    // The literal HTML-ish junk inside the body got escaped, not interpreted.
-    assert!(html.contains("&lt;b&gt;") || !html.contains("<b>x</b>"));
 }
 
 #[test]
-fn non_system_shapes_pass_through_untouched() {
-    let html = render_bg_echo_html("plain text, no framing");
-    assert!(html.contains("plain text, no framing"));
+fn background_title_names_the_task_from_display_text() {
+    assert_eq!(
+        background_task_title("🔧 background task finished: grep-errors"),
+        "🔧 background task finished: grep-errors"
+    );
+    assert_eq!(
+        background_task_title("🔧 background task failed: cleanup-unified"),
+        "🔧 background task failed: cleanup-unified"
+    );
+}
+
+#[test]
+fn blank_display_text_falls_back_to_generic_title() {
+    assert_eq!(background_task_title("   "), "⚙️ background task result");
+    assert_eq!(background_task_title(""), "⚙️ background task result");
+}
+
+#[test]
+fn overlong_task_label_is_capped_in_title() {
+    let long = format!("🔧 background task finished: {}", "x".repeat(500));
+    let t = background_task_title(&long);
+    assert!(t.chars().count() <= 120, "header must stay readable");
+    assert!(t.starts_with("🔧 background task finished:"));
+}
+
+#[test]
+fn html_fallback_escapes_dynamic_title() {
+    let (_, html) = build_bg_echo_bubble("body", "📨 Ops <script> / Push");
+    assert!(html.contains("<b>📨 Ops &lt;script&gt; / Push</b>"));
+    assert!(!html.contains("<script>"), "title must not inject raw HTML");
 }

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -1,0 +1,55 @@
+//! #1221: the background-task echo bubble renderer. Pure-HTML assertions so
+//! no bot or runtime is needed: framing strip, rich-format preservation,
+//! truncation discipline (raw text cut BEFORE conversion, tags stay intact).
+
+use crate::channels::telegram::resume::render_bg_echo_html;
+
+#[test]
+fn wraps_output_in_expandable_blockquote_with_bold_header() {
+    let html = render_bg_echo_html("[System: task finished]\nsome output");
+    assert!(html.starts_with("<blockquote expandable>"));
+    assert!(html.ends_with("</blockquote>"));
+    assert!(html.contains("<b>⚙️ background task result</b>"));
+    assert!(html.contains("some output"));
+}
+
+#[test]
+fn strips_system_framing_from_display() {
+    let html = render_bg_echo_html(
+        "[System: the background task you started has finished.\nStatus: exit 0]\nreal tail",
+    );
+    assert!(!html.contains("[System:"), "scaffolding must not render");
+    assert!(html.contains("Status: exit 0"), "inner content survives");
+    assert!(html.contains("real tail"));
+}
+
+#[test]
+fn preserves_markdown_as_rich_html() {
+    let ctx = "[System: done]\n# Heading\n```rust\nfn main() {}\n```";
+    let html = render_bg_echo_html(ctx);
+    // Fences become block-level code, headings survive as markup — the echo
+    // must NOT degrade to escaped plain text (#1221 requirement).
+    assert!(
+        html.contains("<pre") || html.contains("<code"),
+        "fence lost: {html}"
+    );
+}
+
+#[test]
+fn long_output_is_truncated_before_conversion_and_stays_wellformed() {
+    let ctx = format!("[System: done]\n{{}}<b>x</b>",);
+    let big = format!("{ctx}\n{}", "y".repeat(10_000));
+    let html = render_bg_echo_html(&big);
+    assert!(html.contains("(truncated)"));
+    // Truncating raw text first means the wrapper tags can never be cut:
+    assert!(html.starts_with("<blockquote expandable>"));
+    assert!(html.ends_with("</blockquote>"));
+    // The literal HTML-ish junk inside the body got escaped, not interpreted.
+    assert!(html.contains("&lt;b&gt;") || !html.contains("<b>x</b>"));
+}
+
+#[test]
+fn non_system_shapes_pass_through_untouched() {
+    let html = render_bg_echo_html("plain text, no framing");
+    assert!(html.contains("plain text, no framing"));
+}

--- a/src/tests/channel_route_expectation_test.rs
+++ b/src/tests/channel_route_expectation_test.rs
@@ -45,6 +45,7 @@ fn msg(text: &str) -> QueuedUserMessage {
     QueuedUserMessage {
         context_text: text.to_string(),
         display_text: text.to_string(),
+        origin: crate::brain::agent::PushOrigin::Other,
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -324,6 +324,8 @@ pub mod services_message_test;
 pub mod services_project_test;
 pub mod services_session_test;
 pub mod session_search_tail_test;
+#[cfg(feature = "telegram")]
+pub mod session_search_query_test;
 pub mod shell_scan_test;
 #[cfg(feature = "telegram")]
 pub mod start_gate_allowed_user_test;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -42,7 +42,6 @@ pub mod analyze_video_fallback_test;
 pub mod approval_policy_resolution_test;
 pub mod auto_title_e2e_test;
 pub mod auto_title_test;
-pub mod bg_push_echo_test;
 pub mod background_indicator_test;
 pub mod background_session_test;
 pub mod background_task_persistence_test;
@@ -58,6 +57,7 @@ pub mod bash_posix_quote_test;
 pub mod bash_retry_loop_test;
 pub mod bash_ssh_detection_test;
 pub mod bash_toml_blocklist_test;
+pub mod bg_push_echo_test;
 pub mod brain_agent_context_test;
 pub mod brain_agent_service_phantom_lang_test;
 pub mod brain_agent_service_phantom_test;
@@ -324,9 +324,9 @@ pub mod services_file_test;
 pub mod services_message_test;
 pub mod services_project_test;
 pub mod services_session_test;
-pub mod session_search_tail_test;
 #[cfg(feature = "telegram")]
 pub mod session_search_query_test;
+pub mod session_search_tail_test;
 pub mod shell_scan_test;
 #[cfg(feature = "telegram")]
 pub mod start_gate_allowed_user_test;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -42,6 +42,7 @@ pub mod analyze_video_fallback_test;
 pub mod approval_policy_resolution_test;
 pub mod auto_title_e2e_test;
 pub mod auto_title_test;
+pub mod bg_push_echo_test;
 pub mod background_indicator_test;
 pub mod background_session_test;
 pub mod background_task_persistence_test;

--- a/src/tests/restart_recovery_test.rs
+++ b/src/tests/restart_recovery_test.rs
@@ -36,6 +36,7 @@ fn msg(text: &str) -> QueuedUserMessage {
     QueuedUserMessage {
         context_text: text.to_string(),
         display_text: text.to_string(),
+        origin: crate::brain::agent::PushOrigin::Other,
     }
 }
 

--- a/src/tests/session_notify_test.rs
+++ b/src/tests/session_notify_test.rs
@@ -17,6 +17,7 @@ fn msg() -> QueuedUserMessage {
     QueuedUserMessage {
         context_text: "[session-notify from=x]\n\nbody".to_string(),
         display_text: "notify".to_string(),
+        origin: crate::brain::agent::PushOrigin::Other,
     }
 }
 

--- a/src/tests/session_notify_test.rs
+++ b/src/tests/session_notify_test.rs
@@ -21,6 +21,40 @@ fn msg() -> QueuedUserMessage {
     }
 }
 
+#[tokio::test]
+async fn test_notify_pushes_carry_sessionnotify_origin_for_topic_echo() {
+    // #1221 notify lane: the Telegram resume callback echoes only origins it
+    // knows about, so the tool must tag its pushes SessionNotify — the silent
+    // Other default keeps every session_notify push invisible in topics.
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    let captured: std::sync::Arc<
+        std::sync::Mutex<Option<QueuedUserMessage>>,
+    > = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let sink = captured.clone();
+    crate::brain::agent::service::session_routes::register_session_route(
+        session,
+        std::sync::Arc::new(move |_id, queued| {
+            *sink.lock().unwrap() = Some(queued);
+        }),
+    );
+
+    let context = crate::brain::tools::r#trait::ToolExecutionContext::new(Uuid::new_v4());
+    let outcome = SessionNotifyTool
+        .execute(
+            serde_json::json!({"target_session": session.to_string(), "message": "ping"}),
+            &context,
+        )
+        .await;
+    assert!(outcome.is_ok(), "delivery should succeed: {outcome:?}");
+    let queued = captured.lock().unwrap().take().expect("message enqueued");
+    assert_eq!(
+        queued.origin,
+        crate::brain::agent::PushOrigin::SessionNotify,
+        "#1221: Other-tagged notify pushes never earn an echo bubble"
+    );
+}
+
 #[test]
 fn test_schema_requires_target_and_message() {
     let tool = SessionNotifyTool;

--- a/src/tests/session_notify_test.rs
+++ b/src/tests/session_notify_test.rs
@@ -28,9 +28,8 @@ async fn test_notify_pushes_carry_sessionnotify_origin_for_topic_echo() {
     // Other default keeps every session_notify push invisible in topics.
     let _guard = test_guard();
     let session = Uuid::new_v4();
-    let captured: std::sync::Arc<
-        std::sync::Mutex<Option<QueuedUserMessage>>,
-    > = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let captured: std::sync::Arc<std::sync::Mutex<Option<QueuedUserMessage>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(None));
     let sink = captured.clone();
     crate::brain::agent::service::session_routes::register_session_route(
         session,

--- a/src/tests/session_search_query_test.rs
+++ b/src/tests/session_search_query_test.rs
@@ -2,7 +2,7 @@
 //! and per-row turn-state reporting. House rule: no inline test modules in
 //! source files — everything lives here under src/tests/.
 
-use crate::brain::tools::session_search::{parse_updated_since, SessionSearchTool};
+use crate::brain::tools::session_search::{SessionSearchTool, parse_updated_since};
 use crate::channels::telegram::TelegramState;
 use crate::db::Database;
 use std::sync::Arc;

--- a/src/tests/session_search_query_test.rs
+++ b/src/tests/session_search_query_test.rs
@@ -1,0 +1,65 @@
+//! Tests for session_search discovery (#1203): the `updated_since` parser
+//! and per-row turn-state reporting. House rule: no inline test modules in
+//! source files — everything lives here under src/tests/.
+
+use crate::brain::tools::session_search::{parse_updated_since, SessionSearchTool};
+use crate::channels::telegram::TelegramState;
+use crate::db::Database;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[test]
+fn parses_rfc3339() {
+    let dt = parse_updated_since("2026-08-25T00:00:00Z").expect("valid rfc3339");
+    assert_eq!(dt.to_rfc3339(), "2026-08-25T00:00:00+00:00");
+}
+
+#[test]
+fn parses_shorthand() {
+    let before = chrono::Utc::now();
+    let dt = parse_updated_since("24h").expect("24h valid");
+    assert!(dt > before - chrono::Duration::hours(25));
+    assert!(dt <= chrono::Utc::now());
+
+    let dt = parse_updated_since("7d").expect("7d valid");
+    assert!(dt < before - chrono::Duration::days(6));
+}
+
+#[test]
+fn rejects_garbage() {
+    assert!(parse_updated_since("yesterday").is_err());
+    assert!(parse_updated_since("").is_err());
+    assert!(parse_updated_since("12x").is_err());
+    assert!(parse_updated_since("-5d").is_err());
+}
+
+#[tokio::test]
+async fn stateless_tool_reports_no_turn_state() {
+    let db = Database::connect_in_memory().await.unwrap();
+    db.run_migrations().await.unwrap();
+    let tool = SessionSearchTool::new(db.pool().clone());
+    // Core (daemon/cron) registration wires no channel state, so rows omit
+    // turn info instead of guessing idle.
+    assert_eq!(tool.turn_state(Uuid::new_v4()), None);
+}
+
+#[tokio::test]
+async fn turn_state_tracks_the_active_turn_guard() {
+    let db = Database::connect_in_memory().await.unwrap();
+    db.run_migrations().await.unwrap();
+    let tg = Arc::new(TelegramState::new());
+    let tool = SessionSearchTool::with_telegram(db.pool().clone(), tg.clone());
+    let sid = Uuid::new_v4();
+
+    // No turn in flight: idle, not unknown.
+    assert_eq!(tool.turn_state(sid), Some("idle"));
+
+    // RAII guard held by a running turn flips the report to running...
+    let guard = tg.mark_turn_active(sid);
+    assert_eq!(tool.turn_state(sid), Some("running"));
+
+    // ...and dropping it (normal return, early return, panic or cancel)
+    // clears the flag so the session reads idle again (#302 Stage 2).
+    drop(guard);
+    assert_eq!(tool.turn_state(sid), Some("idle"));
+}

--- a/src/tests/telegram_queued_origin_test.rs
+++ b/src/tests/telegram_queued_origin_test.rs
@@ -21,6 +21,7 @@ fn msg(text: &str) -> QueuedUserMessage {
     QueuedUserMessage {
         context_text: text.to_string(),
         display_text: text.to_string(),
+        origin: crate::brain::agent::PushOrigin::Other,
     }
 }
 


### PR DESCRIPTION
## Part ② of #1203 — session discovery for agent-to-agent targeting

Follow-up to #1207 (`session_notify`, merged): agents gained a push primitive with mechanical sender attribution — but still had no way to *discover* target session ids except archaeology over `Session-Id:` commit trailers. This closes the discovery half of #1203: one tool call returns every session's full UUID, last-active time, message count and current turn state.

### What ships

**1. `session_search list` upgrade**

- rows prefixed `[short-8-id]`, plus human-readable last-active timestamp
- explicit newest-first ordering header — the repo layer already does `ORDER BY updated_at DESC`; surfaced, not reimplemented

**2. New `operation: "query"`** — machine-readable rows for agent consumption:

```json
{
  "id": "<full-uuid>",
  "title": "Telegram: … [chat:-100…:topic:30129]",
  "last_active": "2026-08-26T10:22:33Z",
  "messages": 115,
  "turn": "idle"
}
```

Filters: `status` (active/archived/all) · `title_contains` (reuses the existing case-insensitive LIKE inside `SessionRepository::list`) · `updated_since` (RFC3339 timestamp or `Nd`/`Nh` shorthand) · `limit` (default 50, max 500).

**3. Per-row `turn` state**

- `running` — a turn is in flight; a queued push drains at its next tool-loop boundary
- `idle` — waiting; a push starts a fresh turn immediately
- `null` — no channel state wired for this path; reported as unknown rather than guessed

Read from TelegramState's existing RAII-guarded active-turn set — zero new locking. The interactive path re-registers the tool with a live `TelegramState` handle once the bot connects (`register()` replaces by name), so the core instance stays daemon-safe and the channel-backed one reports real turn state.

### Design principles carried over from #1207

- **Mechanical > textual** — ids and turn-state come from execution context and channel state, never from model text.
- **Reuse over rebuild** — newest-first ordering and title filtering already existed at the SQL layer; the tool layer only exposes them.
- **House conventions** — tests under `src/tests/` (`#[tokio::test]`), no inline test modules; parser unit tests cover RFC3339, `Nd/Nh` shorthand and garbage/negative rejection; guard-transition tests cover the turn-state flips.

---

## Part ③ — echo bubbles for pushed deliveries (#1221, #1225)

The discovery half answers *"where do I send a push?"*; this half answers *"what does the recipient actually see?"*. Both ride sender attribution from #1207.

### What ships

**1. `PushOrigin` discriminator.** `QueuedUserMessage` gains a `PushOrigin` tag (`BackgroundTask | SessionNotify | SubAgent | Recovery | Ingress | Other`) set at every construction site. Note: the tag machinery was carried fork-side through #1207's merge window and is only now landing on `main` in full.

**2. Collapsible echo bubble.** The Telegram resume callback announces WHAT woke a session in its own expandable blockquote — background-task completions *and* cross-session `session_notify` pushes (the original `#1221` bubble skipped the latter: `SessionNotify` pushes were tagged `Other` and stayed invisible in topics while draining fine agent-side). `[System: …]` scaffolding is stripped; the body is capped at 3200 chars with truncation-before-conversion so tags stay well-formed.

**3. Rich-format echo with human labels.** When the body renders as native rich text (mermaid included), the echo is delivered through the existing rich path. The header replaces the raw session id with something a human reads:

- push from the **same chat** → the **topic name**
- push from a **different non-forum chat** → the **chat name**
- push from a **different forum** → **chat name / topic name**
- lookup misses (raw Bot API `getChat`/`getForumTopic` via a tiny HTTP path — teloxide 0.17 has no `getForumTopic` binding) → fall back to the short 8-hex session id

**4. Task-named titles.** The generic "⚙️ background task result" header is replaced by the task's own description (truncated at 120 chars), so a background lane announces itself by what it actually did.

**5. 429 discipline on the fallback.** The original echo raced the resumed stream + typing loop into the same chat and died silently on per-chat flood limits (11/11 observed echo-send failures on a live daemon — every one a 429 that plain `sendMessage` had no guard for). The HTML fallback path now applies the same `wait_out` backoff + single retry the delivery layer uses.

### Files (delta vs the 3-commit harvest)

| File | Δ |
|---|---|
| `src/brain/agent/service/types.rs` | `PushOrigin` enum + `origin` field on `QueuedUserMessage` |
| `src/brain/tools/subagent/notify.rs` | pushes tagged `SessionNotify` |
| `src/channels/telegram/resume.rs` | echo block (both delivery paths), label plumbing, helpers |
| `src/channels/telegram/titles.rs` | NEW — raw Bot API `getChat` / `getForumTopic` title lookups |
| `src/channels/telegram/handler.rs` | enqueue-site tagging |
| `src/tests/bg_push_echo_test.rs` | 14 pure tests: framing strips, bubble assembly, escaping, truncation |
| `src/tests/session_notify_test.rs` | capture test incl. `SessionNotify` origin |

19 files changed overall in the PR (+835 / −31).

### Verification

- Discovery: green CI on fork `main` builds carrying these commits; `query` executed against the **live production binary by invocation** with filters; fleet snapshot showed correct self-detection and a running/idle split matching reality across 25+ rows.
- Echo: 14 pure renderer/label tests; `SessionNotify` capture test. **Live smoke is in flight** — the rich path + 429 guard replace a known-dead echo (11/11 silent 429 drops on the pre-fix daemon), and delivery verification against a swapped binary is pending; will report the run-id here when green.

### Design notes

- Upstream's `resume_session` naming and the #1200 topic-ownership resolution are preserved — this PR does not drag in the fork's later `resume_session_inner` refactor (#1222, out of scope).
- Same-process registry (inherited from #1207): cross-instance targets remain `a2a_send` territory.

### Fix rounds (this head)

- **Rebuilt branch off current upstream `main`.** The original PR head was cut from a pre-#1207 base; harvesting the echo commits onto it produced conflicts (`PushOrigin` absent from the base `types.rs`). Re-picked all commits onto the current upstream tip — clean, no resolutions.
- **uuid 1.x compile fix** (`057d936b`). The fork's `quick-build-linux` build caught `E0599: no method named to_simple` in the new `short_session_id` helper — `to_simple` is the uuid 0.x name; uuid 1.11 (pinned in `Cargo.toml`, features v4+serde) uses `simple()`, which is already the 21-site convention across the tree. One-line fix; the whole branch now compiles under the pinned uuid.
