### PR TITLE
fix(tg): render bg-push echo bubbles as native <details> rich cards (#1221 follow-up)

### DIFF
--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -94,7 +94,15 @@ pub(crate) fn build_enqueue_callback(
                 } else {
                     "⚙️ background task result".to_owned()
                 };
-                let (_, html) = build_bg_echo_bubble(&body, &title);
+                let (_, classic_html) = build_bg_echo_bubble(&body, &title);
+                // Rich dialect needs the RICH envelope: `<details><summary>`
+                // collapsibles (RichBlockDetails, Bot API 10.1) — the same card
+                // component plan_card renders. The classic
+                // `<blockquote expandable>` markup is the sendMessage dialect;
+                // under sendRichMessage it renders as a flat quote, not a rich
+                // card (user-verified 2026-08-26).
+                let rich_html = build_bg_echo_bubble_rich(&body, &title);
+                
                 // Rich-first: route the echo bubble through the same canonical
                 // rich send plan_card uses. Any send failure degrades to the
                 // classic HTML blockquote below.
@@ -103,7 +111,7 @@ pub(crate) fn build_enqueue_callback(
                     bot.token(),
                     chat_id,
                     thread_id,
-                    &html,
+                    &rich_html,
                     None,
                     "bg-resume",
                     "-",
@@ -120,7 +128,7 @@ pub(crate) fn build_enqueue_callback(
                 };
                 if !sent_rich {
                     let mut echo = bot
-                        .send_message(teloxide::types::ChatId(chat_id), html.clone())
+                        .send_message(teloxide::types::ChatId(chat_id), classic_html.clone())
                         .parse_mode(teloxide::types::ParseMode::Html);
                     // Forum topics address a thread; DMs and non-forum groups must
                     // omit the parameter entirely (E0308: not an unwrap decision).
@@ -143,7 +151,7 @@ pub(crate) fn build_enqueue_callback(
                             )
                             .await;
                             let mut retry = bot
-                                .send_message(teloxide::types::ChatId(chat_id), html)
+                                .send_message(teloxide::types::ChatId(chat_id), classic_html)
                                 .parse_mode(teloxide::types::ParseMode::Html);
                             if let Some(tid) = thread_id {
                                 retry = retry.message_thread_id(tid);
@@ -767,6 +775,25 @@ pub(crate) fn build_bg_echo_bubble(body: &str, title: &str) -> (String, String) 
         super::rich::markdown_to_html(body),
     );
     (markdown, html)
+}
+
+/// RICH dialect envelope for the echo bubble: `<details><summary>` collapsible
+/// — the exact card component plan_card renders via `send_rich_html_id`
+/// (Bot API 10.1 RichBlockDetails). The classic
+/// `<blockquote expandable>` markup from [`build_bg_echo_bubble`] belongs to
+/// the sendMessage dialect and renders flat under `sendRichMessage`.
+/// Mirrors plan_card.rs `CollapsibleStyle::DetailsSummary`:
+/// `<details><summary><b>{title}</b></summary>{body}</details>`.
+pub(crate) fn build_bg_echo_bubble_rich(body: &str, title: &str) -> String {
+    let truncated = body.chars().count() > BG_ECHO_BODY_CAP_CHARS;
+    let body = crate::utils::string::truncate_chars(body, BG_ECHO_BODY_CAP_CHARS);
+    let suffix = if truncated { " (truncated)" } else { "" };
+    format!(
+        "<details><summary><b>{}{}</b></summary>{}</details>",
+        super::markdown::escape_html(title),
+        suffix,
+        super::rich::markdown_to_html(body),
+    )
 }
 
 /// Bubble header for a background-task echo: reuse the producer's display

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -102,7 +102,7 @@ pub(crate) fn build_enqueue_callback(
                 // under sendRichMessage it renders as a flat quote, not a rich
                 // card (user-verified 2026-08-26).
                 let rich_html = build_bg_echo_bubble_rich(&body, &title);
-                
+
                 // Rich-first: route the echo bubble through the same canonical
                 // rich send plan_card uses. Any send failure degrades to the
                 // classic HTML blockquote below.
@@ -120,9 +120,7 @@ pub(crate) fn build_enqueue_callback(
                 {
                     Ok(_) => true,
                     Err(e) => {
-                        tracing::warn!(
-                            "[bg-resume] #1225 rich echo failed, using HTML: {e}"
-                        );
+                        tracing::warn!("[bg-resume] #1225 rich echo failed, using HTML: {e}");
                         false
                     }
                 };

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -94,28 +94,30 @@ pub(crate) fn build_enqueue_callback(
                 } else {
                     "⚙️ background task result".to_owned()
                 };
-                let (markdown, html) = build_bg_echo_bubble(&body, &title);
-                // Rich-first: tables/headings/mermaid in the body get the
-                // native rich message; anything else — or any send failure —
-                // degrades to the classic HTML blockquote below.
-                let sent_rich = super::rich::should_send_native_rich(&markdown)
-                    && match super::rich::send_rich_with_mermaid(
-                        bot.api_url().as_str(),
-                        bot.token(),
-                        chat_id,
-                        thread_id,
-                        &markdown,
-                        "bg-resume",
-                        "-",
-                    )
-                    .await
-                    {
-                        Ok(()) => true,
-                        Err(e) => {
-                            tracing::warn!("[bg-resume] #1225 rich echo failed, using HTML: {e}");
-                            false
-                        }
-                    };
+                let (_, html) = build_bg_echo_bubble(&body, &title);
+                // Rich-first: route the echo bubble through the same canonical
+                // rich send plan_card uses. Any send failure degrades to the
+                // classic HTML blockquote below.
+                let sent_rich = match super::rich::api::send_rich_html_id(
+                    bot.api_url().as_str(),
+                    bot.token(),
+                    chat_id,
+                    thread_id,
+                    &html,
+                    None,
+                    "bg-resume",
+                    "-",
+                )
+                .await
+                {
+                    Ok(_) => true,
+                    Err(e) => {
+                        tracing::warn!(
+                            "[bg-resume] #1225 rich echo failed, using HTML: {e}"
+                        );
+                        false
+                    }
+                };
                 if !sent_rich {
                     let mut echo = bot
                         .send_message(teloxide::types::ChatId(chat_id), html.clone())

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -5,8 +5,8 @@
 //! wrapper tags stay intact).
 
 use crate::channels::telegram::resume::{
-    background_task_title, build_bg_echo_bubble, split_bg_echo_parts, split_notify_header,
-    strip_system_framing,
+    background_task_title, build_bg_echo_bubble, build_bg_echo_bubble_rich, split_bg_echo_parts,
+    split_notify_header, strip_system_framing,
 };
 use uuid::Uuid;
 
@@ -143,4 +143,29 @@ fn html_fallback_escapes_dynamic_title() {
     let (_, html) = build_bg_echo_bubble("body", "📨 Ops <script> / Push");
     assert!(html.contains("<b>📨 Ops &lt;script&gt; / Push</b>"));
     assert!(!html.contains("<script>"), "title must not inject raw HTML");
+}
+#[test]
+fn rich_bubble_uses_details_summary_envelope() {
+    let rich = build_bg_echo_bubble_rich("some output", "📨 Ops / Push to session");
+    assert!(rich.starts_with("<details><summary><b>"), "rich envelope must open details+summary");
+    assert!(rich.contains("</summary>"), "summary must close before body");
+    assert!(rich.ends_with("</details>"), "rich envelope must close details");
+    assert!(!rich.contains("blockquote"), "classic dialect must not leak into rich bubble");
+    assert!(rich.contains("<b>📨 Ops / Push to session</b>"));
+    assert!(rich.contains("some output"));
+}
+
+#[test]
+fn rich_bubble_escapes_dynamic_title() {
+    let rich = build_bg_echo_bubble_rich("body", "📨 Ops <script> / Push");
+    assert!(rich.contains("<b>📨 Ops &lt;script&gt; / Push</b>"));
+    assert!(!rich.contains("<script>"), "title must not inject raw HTML");
+}
+
+#[test]
+fn classic_and_rich_builders_stay_separate() {
+    let (_, classic) = build_bg_echo_bubble("body", "T");
+    let rich = build_bg_echo_bubble_rich("body", "T");
+    assert!(classic.contains("blockquote expandable"), "fallback stays classic-dialect");
+    assert!(rich.contains("details"), "primary stays rich-dialect");
 }

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -147,10 +147,22 @@ fn html_fallback_escapes_dynamic_title() {
 #[test]
 fn rich_bubble_uses_details_summary_envelope() {
     let rich = build_bg_echo_bubble_rich("some output", "📨 Ops / Push to session");
-    assert!(rich.starts_with("<details><summary><b>"), "rich envelope must open details+summary");
-    assert!(rich.contains("</summary>"), "summary must close before body");
-    assert!(rich.ends_with("</details>"), "rich envelope must close details");
-    assert!(!rich.contains("blockquote"), "classic dialect must not leak into rich bubble");
+    assert!(
+        rich.starts_with("<details><summary><b>"),
+        "rich envelope must open details+summary"
+    );
+    assert!(
+        rich.contains("</summary>"),
+        "summary must close before body"
+    );
+    assert!(
+        rich.ends_with("</details>"),
+        "rich envelope must close details"
+    );
+    assert!(
+        !rich.contains("blockquote"),
+        "classic dialect must not leak into rich bubble"
+    );
     assert!(rich.contains("<b>📨 Ops / Push to session</b>"));
     assert!(rich.contains("some output"));
 }
@@ -166,6 +178,9 @@ fn rich_bubble_escapes_dynamic_title() {
 fn classic_and_rich_builders_stay_separate() {
     let (_, classic) = build_bg_echo_bubble("body", "T");
     let rich = build_bg_echo_bubble_rich("body", "T");
-    assert!(classic.contains("blockquote expandable"), "fallback stays classic-dialect");
+    assert!(
+        classic.contains("blockquote expandable"),
+        "fallback stays classic-dialect"
+    );
     assert!(rich.contains("details"), "primary stays rich-dialect");
 }


### PR DESCRIPTION
## Rich echo bubble needs the RICH message dialect (#1221 follow-up)

Follow-up to #1225: the squash landed the echo-bubble machinery, but the bubble rendered **flat** because it sent a classic-dialect payload through the rich-dialect transport. This PR completes the dialect switch that #1221 tracked (user-verified end-to-end on the fork's production deploy).

### Root cause

`sendRichMessage` accepts two payload dialects and they are not interchangeable:

| Surface | Envelope | Renders as |
|---|---|---|
| Classic `sendMessage` | `<blockquote expandable>` | flat collapsible quote |
| Rich `sendRichMessage` | `<details><summary>` (`RichBlockDetails`, Bot API 10.1) | native collapsible card |

#1225's resume path fed `<blockquote expandable>` HTML into `rich_message.html` → Telegram rendered the same flat gray quote as before, just via the other API call.

### Changes

1. **Un-gate the rich route** (`resume.rs`): the echo previously had to pass `should_send_native_rich` (the *answer-stream* heuristic — requires tables/headings/lists in the body). A notification bubble is short prose by nature, so it could never qualify and always degraded to classic HTML. Now the echo routes through the same canonical `rich::api::send_rich_html_id` sender `plan_card.rs` uses, unconditionally, degrading to classic blockquote only on send failure (with the existing 429 `wait_out` + single-retry discipline preserved).
2. **Rich envelope builder** (`resume.rs`): new `build_bg_echo_bubble_rich()` renders `<details><summary><b>📨 <label></b></summary><body></details>` — mirroring plan_card's card component byte-for-byte in style. `build_bg_echo_bubble()` (classic blockquote) stays exclusively for the fallback path. Title text is HTML-escaped in both dialects; truncation cap unchanged.
3. **Tests** (`bg_push_echo_test.rs`, +3): envelope shape (`details→summary→body→details`), dynamic-title escaping inside the rich envelope, and a dialect-separation assertion (classic builder must contain blockquote, rich builder must not).

### Testing

- CI build of this exact head is GREEN ([quick-build run 33019693577](https://github.com/leshchenko1979/opencrabs/actions/runs/33019693577), job name embeds full sha).
- `modum check` scoped to both touched files: 0 errors; all remaining findings are pre-existing policy classes on untouched lines.
- Production verification on a CI-built artifact of this change set:
  - binary presence differential: `<details>/<summary>` occurrences ×6 vs ×5 before (+1 = the new echo envelope);
  - runtime telemetry pair: `origin=bg-resume kind=rich_api path=sendRichMessage`, with the source-line fingerprint shifted by exactly the new builder's insertion;
  - primary acceptance: operator visually confirmed a native collapsible card rendering in Telegram (tap-to-expand summary "📨 Push to session").

### Commits

- Ungate the rich route for background-echo bubbles
- Render the echo payload in the rich `<details><summary>` dialect

Both carry `Session-Id` and `Issue-Ref: #1221` trailers per atomicity convention. Scope: 2 files, +80/−26.

Refs #1221.

Issue #1221 is already closed (machinery shipped squashed in #1225); this PR completes the visual polish that issue tracked against the code #1225 landed.
