### PR TITLE
fix(tg): telegram_send reply/edit route rich-first - tables render as real grids not pre blocks (#1230)

### DIFF
--- a/src/brain/tools/telegram_send.rs
+++ b/src/brain/tools/telegram_send.rs
@@ -509,6 +509,7 @@ impl TelegramSendTool {
             &text,
             "tool",
             "send",
+            None,
         )
         .await
         {
@@ -534,64 +535,31 @@ impl TelegramSendTool {
         let NewTarget { chat_id, thread_id } =
             pget!(resolve_new_target(input, context.session_id, &self.telegram_state).await);
         let message_id = pget!(get_id(input, "message_id"));
-        // Convert markdown to Telegram HTML, same as the "send"
-        // action, so formatting (bold, code, tables) renders instead
-        // of arriving as raw literal tags (#834).
-        let html = crate::channels::telegram::handler::markdown_to_telegram_html(&text);
-        let reply_text = text.clone();
-        match send_retrying_rate_limit("telegram_send reply", || {
-            crate::channels::telegram::send::message_in_thread(
-                bot,
-                ChatId(chat_id),
-                thread_id,
-                html.clone(),
-            )
-            .parse_mode(teloxide::types::ParseMode::Html)
-            .reply_parameters(ReplyParameters::new(MessageId(message_id as i32)))
-        })
+        // Reply rich-first through the shared outbox ladder (#1230): a table
+        // in a reply renders as a native rich message (real grid), exactly
+        // like the `send` action — instead of the old direct
+        // markdown_to_telegram_html+ParseMode::Html path which degraded
+        // tables to a monospace `<pre>` grid. The outbox owns the reply
+        // target via `reply_to`, retry, chunking and plain-text fallback.
+        let sent = match crate::channels::telegram::send::send_markdown_outbox(
+            bot,
+            ChatId(chat_id),
+            thread_id,
+            &text,
+            "tool",
+            "reply",
+            Some(message_id),
+        )
         .await
         {
-            Ok(m) => {
-                log_send_success(
-                    "tool",
-                    "reply",
-                    "reply",
-                    &context.session_id.to_string(),
-                    "html",
-                    chat_id,
-                    thread_id.map(|t| t.0.0),
-                    m.id.0,
-                    html.len(),
-                    &content_hash8(&html),
-                );
-                // Persist for reply-recovery (a user can reply to this bot reply).
-                crate::channels::telegram::send::record_outgoing(
-                    None,
-                    chat_id,
-                    thread_id,
-                    &[(m.id.0, reply_text.clone())],
-                )
-                .await;
-                Ok(ToolResult::success(format!(
-                    "Reply sent to message {message_id}."
-                )))
-            }
-            Err(e) => {
-                log_send_failure(
-                    "tool",
-                    "reply",
-                    "reply",
-                    &context.session_id.to_string(),
-                    "html",
-                    chat_id,
-                    thread_id.map(|t| t.0.0),
-                    html.len(),
-                    &content_hash8(&html),
-                    &e.to_string(),
-                );
-                Ok(ToolResult::error(format!("Failed to reply: {e}")))
-            }
-        }
+            Ok(sent) => sent,
+            Err(e) => return Ok(ToolResult::error(format!("Failed to reply: {e}"))),
+        };
+        // Persist for reply-recovery (a user can reply to this bot reply).
+        crate::channels::telegram::send::record_outgoing(None, chat_id, thread_id, &sent).await;
+        Ok(ToolResult::success(format!(
+            "Reply sent to message {message_id}."
+        )))
     }
 
     /// `edit` — rewrite the text of an existing message.
@@ -606,6 +574,48 @@ impl TelegramSendTool {
             chat_id,
             message_id,
         } = pget!(resolve_existing_target(input, context.session_id, &self.telegram_state).await);
+        // Rich-first edit (#1230): a structured edit (table / heading /
+        // list) rewrites the message as a native rich message, so a table
+        // stays a real grid rather than degrading to a monospace `<pre>`
+        // block under the old HTML edit. Plain prose skips rich so Telegram
+        // never reinterprets incidental characters; on any rich failure we
+        // fall through to the classic HTML edit below so the edit always
+        // lands exactly like the `send` outbox fallback design.
+        if crate::channels::telegram::rich::should_send_native_rich(&text) {
+            match crate::channels::telegram::rich::api::edit_rich_markdown(
+                bot.api_url().as_str(),
+                bot.token(),
+                chat_id,
+                message_id as i32,
+                &text,
+                None,
+                "tool",
+                "edit",
+            )
+            .await
+            {
+                Ok(()) => {
+                    log_send_success(
+                        "tool",
+                        "edit",
+                        "edit",
+                        &context.session_id.to_string(),
+                        "rich",
+                        chat_id,
+                        None,
+                        message_id as i32,
+                        text.len(),
+                        &content_hash8(&text),
+                    );
+                    return Ok(ToolResult::success(format!("Message {message_id} edited.")));
+                }
+                Err(e) => {
+                    // Fall through to the HTML edit on any rich failure so
+                    // the edit is never dropped.
+                    tracing::warn!("telegram_send edit: native rich edit failed ({e}) — falling back to HTML");
+                }
+            }
+        }
         // Convert markdown to Telegram HTML, same as the "send"
         // action, so formatting renders correctly (#834).
         let html = crate::channels::telegram::handler::markdown_to_telegram_html(&text);

--- a/src/brain/tools/telegram_send.rs
+++ b/src/brain/tools/telegram_send.rs
@@ -548,7 +548,7 @@ impl TelegramSendTool {
             &text,
             "tool",
             "reply",
-            Some(message_id),
+            Some(message_id as i32),
         )
         .await
         {

--- a/src/channels/telegram/commands_tg.rs
+++ b/src/channels/telegram/commands_tg.rs
@@ -120,7 +120,7 @@ pub(crate) async fn handle_channel_command(
             }
             if let Err(e) = req.await {
                 tracing::warn!("Telegram: model-switch reply failed: {e}");
-                send_html_or_plain(bot, msg.chat.id, thread_id, reply, "turn").await?;
+                send_html_or_plain(bot, msg.chat.id, thread_id, reply, "turn", None).await?;
             }
             return Ok(CommandOutcome::Handled);
         }
@@ -158,7 +158,7 @@ pub(crate) async fn handle_channel_command(
                     // A short delivery finishes publicly: dropping the tail
                     // would truncate the reply with nothing to show for it.
                     for chunk in chunks.iter().skip(delivered) {
-                        send_html_or_plain(bot, msg.chat.id, thread_id, chunk, "turn").await?;
+                        send_html_or_plain(bot, msg.chat.id, thread_id, chunk, "turn", None).await?;
                     }
                     return Ok(CommandOutcome::Handled);
                 }
@@ -189,7 +189,7 @@ pub(crate) async fn handle_channel_command(
             if !sent_rich {
                 let html = command_md_to_html(&reply);
                 for chunk in split_message(&html, 4096) {
-                    send_html_or_plain(bot, msg.chat.id, thread_id, chunk, "turn").await?;
+                    send_html_or_plain(bot, msg.chat.id, thread_id, chunk, "turn", None).await?;
                 }
             }
             return Ok(CommandOutcome::Handled);

--- a/src/channels/telegram/delivery.rs
+++ b/src/channels/telegram/delivery.rs
@@ -855,7 +855,7 @@ pub(crate) async fn deliver_final_response(
                                         // resend fails too the message is gone entirely,
                                         // so the recovery path must not be the quiet one.
                                         if let Ok(sent) = send_html_or_plain(
-                                            bot, chat_id, thread_id, &chunks[0], "turn",
+                                            bot, chat_id, thread_id, &chunks[0], "turn", None,
                                         )
                                         .await
                                         {
@@ -881,7 +881,7 @@ pub(crate) async fn deliver_final_response(
                                 );
                                 best_effort_delete(bot, chat_id, mid, "edit-final fallback").await;
                                 if let Ok(sent) =
-                                    send_html_or_plain(bot, chat_id, thread_id, &chunks[0], "turn")
+                                    send_html_or_plain(bot, chat_id, thread_id, &chunks[0], "turn", None)
                                         .await
                                 {
                                     sent_reply_id = Some(sent.0);
@@ -900,7 +900,7 @@ pub(crate) async fn deliver_final_response(
                         for chunk in &chunks {
                             // Last chunk wins — that's the bubble a user replies to.
                             if let Ok(sent) =
-                                send_html_or_plain(bot, chat_id, thread_id, chunk, "turn").await
+                                send_html_or_plain(bot, chat_id, thread_id, chunk, "turn", None).await
                             {
                                 sent_reply_id = Some(sent.0);
                                 final_bubble = Some(super::state::MergeBubble {

--- a/src/channels/telegram/delivery.rs
+++ b/src/channels/telegram/delivery.rs
@@ -454,6 +454,7 @@ pub(crate) async fn deliver_final_response(
                     chat_id.0,
                     thread_id,
                     &rich_md,
+                    None,
                     "turn",
                     "-",
                 )
@@ -689,6 +690,7 @@ pub(crate) async fn deliver_final_response(
                                 chat_id.0,
                                 thread_id,
                                 &rich_md,
+                                None,
                                 "turn",
                                 "-",
                             )
@@ -705,6 +707,7 @@ pub(crate) async fn deliver_final_response(
                                     chat_id.0,
                                     thread_id,
                                     &rich_md,
+                                    None,
                                     "turn",
                                     "-",
                                 )

--- a/src/channels/telegram/ephemeral.rs
+++ b/src/channels/telegram/ephemeral.rs
@@ -81,7 +81,7 @@ pub(crate) fn build_rich_body(
     receiver_user_id: i64,
     markdown: &str,
 ) -> serde_json::Value {
-    let mut body = super::rich::api::build_body(chat_id, thread_id, markdown);
+    let mut body = super::rich::api::build_body(chat_id, thread_id, markdown, None);
     body["receiver_user_id"] = serde_json::json!(receiver_user_id);
     body
 }

--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -1368,7 +1368,7 @@ pub(crate) async fn open_flow(
     if html.is_empty() {
         return;
     }
-    if let Ok(mid) = send_html_or_plain(bot, chat, thread_id, &html, "turn").await {
+    if let Ok(mid) = send_html_or_plain(bot, chat, thread_id, &html, "turn", None).await {
         let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
         s.open_group_msg_id = Some(mid);
         s.flow_rich = false;
@@ -1575,7 +1575,7 @@ pub(crate) async fn restick_flow_if_buried(
         if html.is_empty() {
             return false;
         }
-        match send_html_or_plain(bot, chat, thread_id, &html, "turn").await {
+        match send_html_or_plain(bot, chat, thread_id, &html, "turn", None).await {
             Ok(mid) => Some(mid),
             Err(e) => {
                 tracing::warn!(

--- a/src/channels/telegram/intermediates.rs
+++ b/src/channels/telegram/intermediates.rs
@@ -81,6 +81,7 @@ pub(crate) async fn try_send_intermediate_rich(
         chat_id.0,
         thread_id,
         text,
+        None,
         "turn",
         "-",
     )

--- a/src/channels/telegram/intermediates.rs
+++ b/src/channels/telegram/intermediates.rs
@@ -11,7 +11,7 @@ use super::markdown::{markdown_to_telegram_html, split_message, strip_html_tags}
 use super::send::message_in_thread;
 use std::sync::Arc;
 use teloxide::prelude::*;
-use teloxide::types::{MessageId, ParseMode};
+use teloxide::types::{MessageId, ParseMode, ReplyParameters};
 
 /// Send an HTML message, falling back to plain text if Telegram rejects the HTML.
 /// Returns the resulting `MessageId` so callers that need to track or later delete
@@ -160,7 +160,7 @@ pub(crate) async fn deliver_intermediate_message(
     }
     let mut sent_ids: Vec<MessageId> = Vec::new();
     for chunk in split_message(&html, 4096) {
-        match send_html_or_plain(bot, chat, thread_id, chunk, "turn").await {
+        match send_html_or_plain(bot, chat, thread_id, chunk, "turn", None).await {
             Ok(id) => {
                 tg.note_bot_bubble(chat.0, id.0);
                 sent_ids.push(id);
@@ -256,6 +256,7 @@ pub(crate) async fn send_html_or_plain(
     thread_id: Option<teloxide::types::ThreadId>,
     html: &str,
     origin: &str,
+    reply_to: Option<i32>,
 ) -> std::result::Result<MessageId, teloxide::RequestError> {
     // G3 send pacing (#1211): the universal outbox ladder funnels cron
     // deliveries, tool sends and chunked replies through here, so the
@@ -289,8 +290,14 @@ pub(crate) async fn send_html_or_plain(
     // matching every other send path — previously this hand-rolled a single
     // retry. Only a final failure falls back to plain text, and the
     // fallback rides the same ladder so a 429 cannot drop it either.
+    // `reply_to` (optional) attaches Telegram reply_parameters so the same
+    // seam carries tool-reply targeting without a separate writer (#1230).
     match send_retrying_rate_limit("HTML send", || {
-        message_in_thread(bot, chat_id, thread_id, html).parse_mode(ParseMode::Html)
+        let mut req = message_in_thread(bot, chat_id, thread_id, html);
+        if let Some(mid) = reply_to {
+            req = req.reply_parameters(ReplyParameters::new(MessageId(mid)));
+        }
+        req.parse_mode(ParseMode::Html)
     })
     .await
     {
@@ -307,7 +314,11 @@ pub(crate) async fn send_html_or_plain(
             let plain_hash8 = super::telemetry::content_hash8(&plain);
             let plain_len = plain.len();
             match send_retrying_rate_limit("plain fallback", || {
-                message_in_thread(bot, chat_id, thread_id, plain.as_str())
+                let mut req = message_in_thread(bot, chat_id, thread_id, plain.as_str());
+                if let Some(mid) = reply_to {
+                    req = req.reply_parameters(ReplyParameters::new(MessageId(mid)));
+                }
+                req
             })
             .await
             {

--- a/src/channels/telegram/rich/api.rs
+++ b/src/channels/telegram/rich/api.rs
@@ -37,6 +37,34 @@ pub(crate) async fn send_rich_html_id(
         .ok_or_else(|| anyhow::anyhow!("sendRichMessage ok but response carried no message_id"))
 }
 
+/// Edit an existing rich message with markdown input (#1230). Telegram's
+/// `editMessageText` accepts `rich_message.markdown`; editing from the raw
+/// source (rather than pre-converted HTML) keeps pipe tables native through
+/// the edit, exactly like the markdown rich send path. `reply_markup` is
+/// optional — pass `None` to leave the keyboard unchanged.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn edit_rich_markdown(
+    api_url: &str,
+    token: &str,
+    chat_id: i64,
+    message_id: i32,
+    markdown: &str,
+    reply_markup: Option<&serde_json::Value>,
+    origin: &str,
+    origin_detail: &str,
+) -> anyhow::Result<()> {
+    let url = format!("{}/bot{token}/editMessageText", api_base(api_url));
+    let mut body = serde_json::json!({
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "rich_message": { "markdown": markdown },
+    });
+    if let Some(kb) = reply_markup {
+        body["reply_markup"] = kb.clone();
+    }
+    post_and_check(&url, &body, origin, origin_detail).await
+}
+
 /// Edit an existing rich message with HTML input (#420 path A).
 /// `reply_markup` is optional — pass `None` to leave the keyboard unchanged.
 #[allow(clippy::too_many_arguments)]
@@ -74,10 +102,37 @@ pub(crate) async fn send_rich_markdown_id(
     origin: &str,
     origin_detail: &str,
 ) -> anyhow::Result<i32> {
+    send_rich_markdown_target_id(
+        api_url,
+        token,
+        chat_id,
+        thread_id,
+        None,
+        markdown,
+        origin,
+        origin_detail,
+    )
+    .await
+}
+
+/// [`send_rich_markdown_id`] with an optional Telegram reply target.
+/// `reply_to` is a message id in the same chat; when set the rich body
+/// carries `reply_parameters` so the reply lands threaded to that message
+/// (#1230).
+pub(crate) async fn send_rich_markdown_target_id(
+    api_url: &str,
+    token: &str,
+    chat_id: i64,
+    thread_id: Option<ThreadId>,
+    reply_to: Option<i32>,
+    markdown: &str,
+    origin: &str,
+    origin_detail: &str,
+) -> anyhow::Result<i32> {
     let url = format!("{}/bot{token}/sendRichMessage", api_base(api_url));
     let result = post_rich(
         &url,
-        &build_body(chat_id, thread_id, markdown),
+        &build_body_target(chat_id, thread_id, reply_to, markdown),
         origin,
         origin_detail,
     )
@@ -263,6 +318,19 @@ pub(crate) fn build_body(
     chat_id: i64,
     thread_id: Option<ThreadId>,
     markdown: &str,
+    reply_to: Option<i32>,
+) -> serde_json::Value {
+    build_body_target(chat_id, thread_id, reply_to, markdown)
+}
+
+/// [`build_body`] with an optional Telegram reply target (#1230). When
+/// `reply_to` is set, the body carries `reply_parameters: {message_id}`
+/// so a rich reply lands threaded to that message.
+pub(crate) fn build_body_target(
+    chat_id: i64,
+    thread_id: Option<ThreadId>,
+    reply_to: Option<i32>,
+    markdown: &str,
 ) -> serde_json::Value {
     let mut body = serde_json::json!({
         "chat_id": chat_id,
@@ -271,6 +339,9 @@ pub(crate) fn build_body(
     if let Some(t) = thread_id {
         // ThreadId wraps a MessageId(i32).
         body["message_thread_id"] = serde_json::json!(t.0.0);
+    }
+    if let Some(mid) = reply_to {
+        body["reply_parameters"] = serde_json::json!({ "message_id": mid });
     }
     body
 }
@@ -309,10 +380,38 @@ pub(crate) async fn send_rich_markdown_media_id(
     origin: &str,
     origin_detail: &str,
 ) -> anyhow::Result<i32> {
+    send_rich_markdown_media_target_id(
+        api_url,
+        token,
+        chat_id,
+        thread_id,
+        None,
+        markdown,
+        media,
+        origin,
+        origin_detail,
+    )
+    .await
+}
+
+/// [`send_rich_markdown_media_id`] with an optional Telegram reply target
+/// (#1230); carries `reply_parameters` when `reply_to` is set.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn send_rich_markdown_media_target_id(
+    api_url: &str,
+    token: &str,
+    chat_id: i64,
+    thread_id: Option<ThreadId>,
+    reply_to: Option<i32>,
+    markdown: &str,
+    media: &[super::mermaid::MediaEntry],
+    origin: &str,
+    origin_detail: &str,
+) -> anyhow::Result<i32> {
     let url = format!("{}/bot{token}/sendRichMessage", api_base(api_url));
     let result = post_rich(
         &url,
-        &build_body_markdown_media(chat_id, thread_id, markdown, media),
+        &build_body_markdown_media_target(chat_id, thread_id, reply_to, markdown, media),
         origin,
         origin_detail,
     )
@@ -333,6 +432,19 @@ pub(crate) fn build_body_markdown_media(
     thread_id: Option<ThreadId>,
     markdown: &str,
     media: &[super::mermaid::MediaEntry],
+    reply_to: Option<i32>,
+) -> serde_json::Value {
+    build_body_markdown_media_target(chat_id, thread_id, reply_to, markdown, media)
+}
+
+/// [`build_body_markdown_media`] with an optional Telegram reply target
+/// (#1230); carries `reply_parameters` when `reply_to` is set.
+pub(crate) fn build_body_markdown_media_target(
+    chat_id: i64,
+    thread_id: Option<ThreadId>,
+    reply_to: Option<i32>,
+    markdown: &str,
+    media: &[super::mermaid::MediaEntry],
 ) -> serde_json::Value {
     let media_arr: Vec<serde_json::Value> = media
         .iter()
@@ -349,6 +461,9 @@ pub(crate) fn build_body_markdown_media(
     });
     if let Some(t) = thread_id {
         body["message_thread_id"] = serde_json::json!(t.0.0);
+    }
+    if let Some(mid) = reply_to {
+        body["reply_parameters"] = serde_json::json!({ "message_id": mid });
     }
     body
 }

--- a/src/channels/telegram/rich/api.rs
+++ b/src/channels/telegram/rich/api.rs
@@ -93,12 +93,14 @@ pub(crate) async fn edit_rich_html(
 /// Send `markdown` as a native rich message and return the new message id.
 /// Used for intermediate streamed segments, which must be tracked for later
 /// footer-append / dedup. Returns `Err` so the caller can fall back to HTML.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn send_rich_markdown_id(
     api_url: &str,
     token: &str,
     chat_id: i64,
     thread_id: Option<ThreadId>,
     markdown: &str,
+    reply_to: Option<i32>,
     origin: &str,
     origin_detail: &str,
 ) -> anyhow::Result<i32> {
@@ -107,7 +109,7 @@ pub(crate) async fn send_rich_markdown_id(
         token,
         chat_id,
         thread_id,
-        None,
+        reply_to,
         markdown,
         origin,
         origin_detail,
@@ -119,6 +121,7 @@ pub(crate) async fn send_rich_markdown_id(
 /// `reply_to` is a message id in the same chat; when set the rich body
 /// carries `reply_parameters` so the reply lands threaded to that message
 /// (#1230).
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn send_rich_markdown_target_id(
     api_url: &str,
     token: &str,
@@ -377,6 +380,7 @@ pub(crate) async fn send_rich_markdown_media_id(
     thread_id: Option<ThreadId>,
     markdown: &str,
     media: &[super::mermaid::MediaEntry],
+    reply_to: Option<i32>,
     origin: &str,
     origin_detail: &str,
 ) -> anyhow::Result<i32> {
@@ -385,7 +389,7 @@ pub(crate) async fn send_rich_markdown_media_id(
         token,
         chat_id,
         thread_id,
-        None,
+        reply_to,
         markdown,
         media,
         origin,

--- a/src/channels/telegram/rich/mod.rs
+++ b/src/channels/telegram/rich/mod.rs
@@ -183,6 +183,7 @@ pub(crate) async fn send_rich_with_mermaid(
         chat_id,
         thread_id,
         markdown,
+        None,
         origin,
         origin_detail,
     )
@@ -197,6 +198,7 @@ pub(crate) async fn send_rich_with_mermaid_id(
     chat_id: i64,
     thread_id: Option<teloxide::types::ThreadId>,
     markdown: &str,
+    reply_to: Option<i32>,
     origin: &str,
     origin_detail: &str,
 ) -> anyhow::Result<i32> {
@@ -205,7 +207,7 @@ pub(crate) async fn send_rich_with_mermaid_id(
         token,
         chat_id,
         thread_id,
-        None,
+        reply_to,
         markdown,
         origin,
         origin_detail,

--- a/src/channels/telegram/rich/mod.rs
+++ b/src/channels/telegram/rich/mod.rs
@@ -200,12 +200,39 @@ pub(crate) async fn send_rich_with_mermaid_id(
     origin: &str,
     origin_detail: &str,
 ) -> anyhow::Result<i32> {
+    send_rich_with_mermaid_target_id(
+        api_url,
+        token,
+        chat_id,
+        thread_id,
+        None,
+        markdown,
+        origin,
+        origin_detail,
+    )
+    .await
+}
+
+/// Like [`send_rich_with_mermaid_id`] but carries an optional Telegram reply
+/// target (`reply_parameters`) on the rich send, so a rich reply lands
+/// threaded to an existing message (#1230).
+pub(crate) async fn send_rich_with_mermaid_target_id(
+    api_url: &str,
+    token: &str,
+    chat_id: i64,
+    thread_id: Option<teloxide::types::ThreadId>,
+    reply_to: Option<i32>,
+    markdown: &str,
+    origin: &str,
+    origin_detail: &str,
+) -> anyhow::Result<i32> {
     if !mermaid::should_render_mermaid(markdown) {
-        return api::send_rich_markdown_id(
+        return api::send_rich_markdown_target_id(
             api_url,
             token,
             chat_id,
             thread_id,
+            reply_to,
             markdown,
             origin,
             origin_detail,
@@ -221,11 +248,12 @@ pub(crate) async fn send_rich_with_mermaid_id(
     // All fences failed → `resolved` carries only failure blocks, no media to
     // embed; send it as plain rich markdown (no `media` field).
     if media.is_empty() {
-        return api::send_rich_markdown_id(
+        return api::send_rich_markdown_target_id(
             api_url,
             token,
             chat_id,
             thread_id,
+            reply_to,
             &resolved,
             origin,
             origin_detail,
@@ -234,11 +262,12 @@ pub(crate) async fn send_rich_with_mermaid_id(
     }
 
     // Primary: markdown dialect + media array keeps pipe tables native.
-    match api::send_rich_markdown_media_id(
+    match api::send_rich_markdown_media_target_id(
         api_url,
         token,
         chat_id,
         thread_id,
+        reply_to,
         &resolved,
         &media,
         origin,

--- a/src/channels/telegram/send.rs
+++ b/src/channels/telegram/send.rs
@@ -315,6 +315,7 @@ pub(crate) async fn send_markdown_outbox(
     markdown: &str,
     origin: &str,
     origin_detail: &str,
+    reply_to: Option<i32>,
 ) -> std::result::Result<Vec<(i32, String)>, String> {
     let thread = thread_id.map(|t| t.0.0);
 
@@ -322,11 +323,12 @@ pub(crate) async fn send_markdown_outbox(
     // line for this send (with origin + detail threaded through), so the
     // outbox does not double-log the rich success (review F3/F8).
     if super::rich::should_send_native_rich(markdown) {
-        match super::rich::send_rich_with_mermaid_id(
+        match super::rich::send_rich_with_mermaid_target_id(
             bot.api_url().as_str(),
             bot.token(),
             chat_id.0,
             thread_id,
+            reply_to,
             markdown,
             origin,
             origin_detail,
@@ -348,7 +350,15 @@ pub(crate) async fn send_markdown_outbox(
     let total = chunks.len();
     let mut sent: Vec<(i32, String)> = Vec::new();
     for (i, chunk) in chunks.into_iter().enumerate() {
-        match super::intermediates::send_html_or_plain(bot, chat_id, thread_id, chunk, origin).await
+        match super::intermediates::send_html_or_plain(
+                bot,
+                chat_id,
+                thread_id,
+                chunk,
+                origin,
+                reply_to,
+            )
+            .await
         {
             Ok(mid) => {
                 super::telemetry::log_send_success(

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -1146,6 +1146,7 @@ async fn deliver_telegram(
             &message,
             "cron",
             &job_name,
+            None,
         )
         .await
         {

--- a/src/tests/telegram_ephemeral_test.rs
+++ b/src/tests/telegram_ephemeral_test.rs
@@ -44,7 +44,7 @@ fn html_body_sets_parse_mode() {
 fn rich_body_is_the_public_body_plus_the_receiver() {
     // The scoped rich attempt must be byte-for-byte the public rich request
     // apart from the scoping field, or the two paths render differently.
-    let public = crate::channels::telegram::rich::api::build_body(-100200, None, "# hi");
+    let public = crate::channels::telegram::rich::api::build_body(-100200, None, "# hi", None);
     let scoped = build_rich_body(-100200, None, 12345, "# hi");
     assert_eq!(scoped["rich_message"], public["rich_message"]);
     assert_eq!(scoped["chat_id"], public["chat_id"]);

--- a/src/tests/telegram_mermaid_test.rs
+++ b/src/tests/telegram_mermaid_test.rs
@@ -305,7 +305,7 @@ fn build_body_markdown_media_matches_prototype_shape() {
         id: "diag0".into(),
         url: "https://mermaid.ink/img/abc".into(),
     }];
-    let body = build_body_markdown_media(-100, None, "text", &media);
+    let body = build_body_markdown_media(-100, None, "text", &media, None);
     assert_eq!(body["chat_id"], -100);
     assert_eq!(body["rich_message"]["markdown"], "text");
     let arr = body["rich_message"]["media"]
@@ -321,7 +321,7 @@ fn build_body_markdown_media_matches_prototype_shape() {
 #[test]
 fn build_body_markdown_media_includes_thread_id_when_present() {
     use teloxide::types::{MessageId, ThreadId};
-    let body = build_body_markdown_media(-100, Some(ThreadId(MessageId(249))), "m", &[]);
+    let body = build_body_markdown_media(-100, Some(ThreadId(MessageId(249))), "m", &[], None);
     assert_eq!(body["message_thread_id"], 249);
 }
 

--- a/src/tests/telegram_rich_api_test.rs
+++ b/src/tests/telegram_rich_api_test.rs
@@ -24,6 +24,7 @@ async fn send_rich_markdown_id_uses_custom_api_url() {
         12345,
         None,
         "hello **world**",
+        None,
         "test",
         "-",
     )
@@ -110,6 +111,7 @@ async fn send_rich_markdown_media_id_uses_custom_api_url() {
             id: "1".to_string(),
             url: "https://example.com/img.png".to_string(),
         }],
+        None,
         "test",
         "-",
     )

--- a/src/tests/telegram_rich_parse_test.rs
+++ b/src/tests/telegram_rich_parse_test.rs
@@ -316,6 +316,7 @@ fn rich_request_body_passes_markdown_through() {
         12345,
         None,
         "# Title\n\n| a | b |\n| - | - |\n| 1 | 2 |",
+        None,
     );
     assert_eq!(body["chat_id"], 12345);
     assert_eq!(

--- a/src/tests/telegram_rich_test.rs
+++ b/src/tests/telegram_rich_test.rs
@@ -54,7 +54,7 @@ fn rich_structure_whitespace_only_false() {
 
 #[test]
 fn rich_request_body_with_thread_id() {
-    let body = build_body(99, Some(ThreadId(MessageId(42))), "| A |\n| - |\n| 1 |");
+    let body = build_body(99, Some(ThreadId(MessageId(42))), "| A |\n| - |\n| 1 |", None);
     assert_eq!(body["chat_id"], 99);
     assert_eq!(body["message_thread_id"], 42);
     assert_eq!(body["rich_message"]["markdown"], "| A |\n| - |\n| 1 |");
@@ -62,7 +62,7 @@ fn rich_request_body_with_thread_id() {
 
 #[test]
 fn rich_request_body_without_thread_id() {
-    let body = build_body(100, None, "hello");
+    let body = build_body(100, None, "hello", None);
     assert_eq!(body["chat_id"], 100);
     assert!(body.get("message_thread_id").is_none());
     assert_eq!(body["rich_message"]["markdown"], "hello");


### PR DESCRIPTION
## Problem

`telegram_send`'s **`reply`** and **`edit`** actions were the last two send lanes still routed through the direct `markdown_to_telegram_html` converter, bypassing the native rich pipeline (#1044). Consequence: any pipe table arriving in a reply or an edited message rendered flat — `<pre>` blocks / literal pipes instead of real rich grids. `send`, cron delivery, intermediates and resume already gated through `should_send_native_rich`; these two did not.

Fixes #1230

## Change (3 atomic commits)

1. **Rich-first routing** (`6d966a46`) — `action_reply` routes via `send_markdown_outbox(..., "tool", "reply", Some(message_id))`; `action_edit` rich-gates via `should_send_native_rich` → `edit_rich_markdown`, falling back to the existing HTML path.
2. **`reply_to` threading through the rich ladder** (`75357679`) — new target-id variants `send_rich_markdown_target_id`, `send_rich_markdown_media_target_id`, `edit_rich_markdown`, `send_rich_with_mermaid_target_id`; `build_body*` builders carry `reply_parameters` when `Some`. `send_markdown_outbox` / `send_html_or_plain` gain `reply_to: Option<i32>` and thread it to both rich and HTML paths. Existing call sites pass `None` (no behavior change).
3. **i32 cast** (`6affcb5a`) — narrow outbox `reply_to` message id from i64 → i32 (fixes E0304 surfaced post-merge).

## Verification

- Local stat gate (`modum`): pass, 0 errors in changed lines.
- Carrier pre-flight build (`features=telegram`, source pinned to tip `1be9df4e`): **green** — https://github.com/leshchenko1979/opencrabs/actions/runs/33020528065
- Live smoke against the deployed binary built from this chain (wire-level receipts):
  - reply → `kind=rich_api path=sendRichMessage … thread=Some(31847)` ; ingest stored `rich:true`, table rendered as grid
  - edit → `kind=rich_edit path=editMessageText …` ; re-parse verdict `rich: true … table=true` — still a grid after edit
- Owner confirmed smoke PASS on the live unit.

## Notes

- Scope deliberately excludes `action_send_buttons` (carries an inline keyboard; separate wire concern).
- Related discovery filed separately: #1234 (bg-echo bubble bodies pre-flatten tables via the fallback converter — different lane).


## Consent (CONSENT REGISTER)

Owner approval for shipping this lane upstream, registered in `workers-ledger.json` `consents[]`:

> Owner message **32602**, Crabs Kanban Board topic **31847** (chat `-1003936827469`), **2026-08-26T22:09:48Z**, verbatim: **"Smoke test passed"** — certification for the #1230 lane under the SKILL.md CONSENT REGISTER rule.
