### PR TITLE
fix(tg): re-stick completed plan card to thread bottom after flood-delayed finalize (#1231)

### DIFF
--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2704,17 +2704,19 @@ pub(crate) async fn handle_message(
         // flood control and produced duplicate cards. Skipping the re-stick
         // still refreshes in place below, so the card stays correct; it just
         // stays where it is until the next re-stick is due.
-        if crate::utils::plan_files::recent_archived_plan(
-            session_id,
-            std::time::Duration::from_secs(120),
-        )
-        .await
-        {
-            // Plan completed THIS settle (#1158): finalize the tracked card
-            // in place (✅ header, keyboard stripped, one-shot untrack)
-            // instead of re-sticking or refreshing a now-archived plan.
-            super::plan_card::finalize_plan_card(&bot, msg.chat.id, &telegram_state, session_id)
-                .await;
+        if crate::utils::plan_files::take_plan_just_archived(session_id).await {
+            // Plan completed THIS settle (#1158, #1231): finalize the tracked
+            // card (✅ header, keyboard stripped, one-shot untrack) and re-stick
+            // the completed card to the bottom of the thread instead of
+            // re-sticking or refreshing a now-archived plan.
+            super::plan_card::finalize_plan_card(
+                &bot,
+                msg.chat.id,
+                thread_id,
+                &telegram_state,
+                session_id,
+            )
+            .await;
         } else {
             const RESTICK_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(90);
             if telegram_state

--- a/src/channels/telegram/plan_card.rs
+++ b/src/channels/telegram/plan_card.rs
@@ -471,7 +471,17 @@ pub(crate) async fn refresh_plan_card(
     )
     .await
     else {
-        remove_plan_card_locked(bot, chat, state, session_id).await;
+        // No live plan. If THIS settle just archived the plan, the completion
+        // arrived on a path that didn't run the handler settle gate (a
+        // flood-delayed settle via resume.rs/stream_loop drives refresh_plan_card
+        // directly). Finalize the completed card and re-stick it to the bottom
+        // instead of silently deleting it (#1231). Otherwise it's a genuine
+        // plan-gone/discard removal.
+        if crate::utils::plan_files::take_plan_just_archived(session_id).await {
+            finalize_plan_card_locked(bot, chat, thread_id, state, session_id).await;
+        } else {
+            remove_plan_card_locked(bot, chat, state, session_id).await;
+        }
         return;
     };
     let kb = plan_kb.keyboard();
@@ -553,27 +563,53 @@ pub(crate) async fn refresh_plan_card(
 /// removal (discard / plan gone) and — followed by a later [`refresh_plan_card`]
 /// — as a re-stick so the next card posts fresh at the bottom of the
 /// conversation, keeping exactly one card visible as it follows the turns down.
-/// Completed-plan finalization (#1158): when a turn settles right after the
-/// session's plan was archived, edit the tracked card IN PLACE into its
-/// completed form instead of deleting+reposting or leaving it live: ✅ header,
-/// final checklist, keyboard stripped (explicit EMPTY `inline_keyboard`;
-/// omitting `reply_markup` leaves stale buttons attached per Bot API
-/// semantics), footer noting the archive.
+/// Completed-plan finalization (#1158, #1231): when a turn settles right after
+/// the session's plan was archived, turn the card into its completed form and
+/// RE-STICK IT TO THE BOTTOM of the thread: ✅ header, final checklist, keyboard
+/// stripped (explicit EMPTY `inline_keyboard`; omitting `reply_markup` leaves
+/// stale buttons attached per Bot API semantics), footer noting the archive.
+/// The buried tracked card is deleted and a fresh completed card is posted at
+/// the conversation's current position, so the finished plan lands where the
+/// user is reading, not far up in history.
 ///
-/// One-shot by construction (#809 lesson): success UNTRACKS the card, so no
-/// later refresh or restart ever re-renders an archived plan as live. The
-/// "archived moments ago" gate (`recent_archived_plan`) lives in the caller:
-/// tool_loop archives at EVERY settling plan-turn, so mere archive existence
-/// would wrongly finalize unrelated later settles forever.
+/// Flood-safe: the fresh card is posted FIRST (paced through G3); only if the
+/// post fails do we fall back to editing the tracked card in place, so the
+/// completed form is never lost on a flood-controlled settle. A successful
+/// post then deletes the old card best-effort — a delete failure leaves the
+/// stale card visible, never a duplicate (the new one is what users see).
+///
+/// One-shot (#809 lesson): success UNTRACKS the card, so no later refresh or
+/// restart ever re-renders an archived plan as live. The "just archived THIS
+/// settle" gate (`take_plan_just_archived`) lives in the caller; tool_loop
+/// archives at EVERY settling plan-turn, so without that one-shot stamp a
+/// later settle would wrongly finalize an unrelated archive forever.
 pub(crate) async fn finalize_plan_card(
     bot: &Bot,
     chat: ChatId,
+    thread_id: Option<ThreadId>,
     state: &Arc<TelegramState>,
     session_id: Uuid,
 ) {
     // Same lock discipline as refresh/remove (#822): held across API calls.
     let card_lock = state.plan_card_lock(session_id).await;
     let _guard = card_lock.lock().await;
+    finalize_plan_card_locked(bot, chat, thread_id, state, session_id).await;
+}
+
+/// Finalization body, for callers already holding the per-session card lock.
+///
+/// `refresh_plan_card` runs the same lock and, on its no-live-plan path (the
+/// plan was just archived there), finalizes instead of deleting — calling the
+/// lock-taking `finalize_plan_card` from inside that locked scope would
+/// deadlock (the lock is not reentrant; same split as
+/// `remove_plan_card_locked`).
+async fn finalize_plan_card_locked(
+    bot: &Bot,
+    chat: ChatId,
+    thread_id: Option<ThreadId>,
+    state: &Arc<TelegramState>,
+    session_id: Uuid,
+) {
     let Some((mid, _sig)) = state.plan_card(session_id).await else {
         // Nothing tracked: finalized once already, or never posted. Either
         // way deliberately NOT reposting is what kills resurrection.
@@ -585,50 +621,116 @@ pub(crate) async fn finalize_plan_card(
     let (title, checklist) = super::flow_chrome::plan_document_sections(&doc);
     let empty_kb = serde_json::json!({ "inline_keyboard": [] });
 
-    // Rich path first, mirroring refresh_plan_card's dual rendering.
-    let mut edited = false;
-    if Config::current().channels.telegram.rich_messages
-        && let Some(mut rich) =
-            render_plan_card_rich_html(title.as_deref(), checklist.as_deref(), None, None).await
+    let use_rich = Config::current().channels.telegram.rich_messages;
+
+    // Completed forms, mirrored dual-path as in refresh_plan_card.
+    let rich = if use_rich {
+        render_plan_card_rich_html(title.as_deref(), checklist.as_deref(), None, None)
+            .await
+            .map(|mut r| {
+                r = r.replacen("📋", "✅", 1);
+                r.push_str("\n<i>Plan completed and archived.</i>");
+                r
+            })
+    } else {
+        None
+    };
+    let mut html = render_plan_card_html(title.as_deref(), checklist.as_deref(), None, None)
+        .await
+        .unwrap_or_else(|| "<b>Plan</b>".to_string());
+    html = html.replacen("📋", "✅", 1);
+    html.push_str("\n<i>Plan completed and archived.</i>");
+
+    // Restick-to-bottom (#1231): post the completed card fresh at the bottom
+    // FIRST, so a post failure can fall back to the card already present — the
+    // completed form is never lost.
+    let mut posted: Option<MessageId> = None;
+    if use_rich
+        && let Some(rich) = &rich
     {
-        rich = rich.replacen("📋", "✅", 1);
-        rich.push_str("\n<i>Plan completed and archived.</i>");
-        match super::rich::api::edit_rich_html(
+        // G3 send pacing (#1211): a fresh card is a full message post.
+        super::governor::pace_send(chat).await;
+        match super::rich::api::send_rich_html_id(
             bot.api_url().as_str(),
             bot.token(),
             chat.0,
-            mid.0,
-            &rich,
+            thread_id,
+            rich,
             Some(&empty_kb),
             "turn",
             "-",
         )
         .await
         {
-            Ok(()) => edited = true,
-            Err(e) => tracing::debug!("Telegram plan card rich finalize failed ({mid:?}): {e}"),
+            Ok(mid) => posted = Some(MessageId(mid)),
+            Err(e) => tracing::debug!("Telegram plan card rich restick failed: {e}"),
         }
     }
-    if !edited {
-        let mut html = render_plan_card_html(title.as_deref(), checklist.as_deref(), None, None)
-            .await
-            .unwrap_or_else(|| "<b>Plan</b>".to_string());
-        html = html.replacen("📋", "✅", 1);
-        html.push_str("\n<i>Plan completed and archived.</i>");
-        if let Err(e) = bot
-            .edit_message_text(chat, mid, html)
-            .parse_mode(teloxide::types::ParseMode::Html)
-            .reply_markup(teloxide::types::InlineKeyboardMarkup::new(Vec::<
-                Vec<teloxide::types::InlineKeyboardButton>,
-            >::new(
-            )))
-            .await
-        {
-            tracing::debug!("Telegram plan card finalize edit failed ({mid:?}): {e}");
+    if posted.is_none() {
+        // G3 send pacing (#1211): a fresh card is a full message post.
+        super::governor::pace_send(chat).await;
+        let mut req = message_in_thread(bot, chat, thread_id, html.clone()).parse_mode(ParseMode::Html);
+        match req.await {
+            Ok(m) => posted = Some(m.id),
+            Err(e) => tracing::debug!("Telegram plan card restick post failed ({mid:?}): {e}"),
         }
     }
-    // One-shot regardless of edit outcome: a card deleted by the user must
-    // not come back as a live card rendered from the archive either.
+
+    match posted {
+        Some(new_mid) => {
+            // Fresh completed card is at the bottom. Delete the buried tracked
+            // card best-effort; a delete failure leaves a stale card visible,
+            // never a duplicate.
+            if let Some((mid, _)) = state.plan_card(session_id).await
+                && new_mid != mid
+                && let Err(e) = bot.delete_message(chat, mid).await
+            {
+                tracing::debug!("Telegram plan card restick delete failed ({mid:?}): {e}");
+            }
+        }
+        None => {
+            // Post failed (flood/API): fall back to editing the tracked card in
+            // place so the completed form is still shown.
+            let Some((mid, _)) = state.plan_card(session_id).await else {
+                return;
+            };
+            let mut edited = false;
+            if use_rich
+                && let Some(rich) = &rich
+            {
+                match super::rich::api::edit_rich_html(
+                    bot.api_url().as_str(),
+                    bot.token(),
+                    chat.0,
+                    mid.0,
+                    rich,
+                    Some(&empty_kb),
+                    "turn",
+                    "-",
+                )
+                .await
+                {
+                    Ok(()) => edited = true,
+                    Err(e) => tracing::debug!("Telegram plan card rich finalize failed ({mid:?}): {e}"),
+                }
+            }
+            if !edited {
+                if let Err(e) = bot
+                    .edit_message_text(chat, mid, html.clone())
+                    .parse_mode(teloxide::types::ParseMode::Html)
+                    .reply_markup(teloxide::types::InlineKeyboardMarkup::new(Vec::<
+                        Vec<teloxide::types::InlineKeyboardButton>,
+                    >::new(
+                    )))
+                    .await
+                {
+                    tracing::debug!("Telegram plan card finalize edit failed ({mid:?}): {e}");
+                }
+            }
+        }
+    }
+    // One-shot regardless of outcome: a card deleted by the user must not come
+    // back as a live card rendered from the archive either.
     state.take_plan_card(session_id).await;
 }
 

--- a/src/utils/plan_files.rs
+++ b/src/utils/plan_files.rs
@@ -474,7 +474,60 @@ pub async fn is_pre_init_editing(session_id: Uuid) -> bool {
 /// Archive the session's plan artifacts (`.json` and `.md`) under
 /// `archive/` with a timestamp, returning the session to NoPlan.
 pub async fn archive_plan(session_id: Uuid) -> std::io::Result<()> {
-    archive_plan_files(&plan_json_read_path(session_id).await)
+    archive_plan_files(&plan_json_read_path(session_id).await)?;
+    // Explicit "completed THIS settle" stamp, durable in the archive dir so a
+    // flood-delayed settle (potentially minutes late) — or one that lands on
+    // a detached-resume path driving stream_loop instead of the handler's own
+    // settle gate — still observes that the completion happened now (#1231).
+    mark_plan_just_archived(session_id).await;
+    Ok(())
+}
+
+/// Path of the durable "just archived" sidecar for `session_id`.
+async fn plan_just_archived_path(session_id: Uuid) -> std::path::PathBuf {
+    archive_dir(session_id).await.join(format!("just_archived_{session_id}.flag"))
+}
+
+/// Stamp that this session's plan was archived on THIS settle.
+///
+/// Durable file, not an in-memory flag, so it survives a flood-throttled
+/// settle that lands minutes later AND a detached-resume settle that runs
+/// `stream_loop.rs`/`resume.rs` (which construct fresh state and drive
+/// `refresh_plan_card` directly, bypassing the handler settle gate). The old
+/// mtime recency guess (`recent_archived_plan`, 120s) could not handle that:
+/// a flood `retry_after` of 25–32s plus queued sends pushed completion
+/// settlement past the window, the gate missed, and the archived card was
+/// deleted instead of finalized.
+pub async fn mark_plan_just_archived(session_id: Uuid) {
+    let path = plan_just_archived_path(session_id).await;
+    if let Some(dir) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(dir)
+    {
+        tracing::warn!("plan just-archived flag mkdir failed: {e}");
+        return;
+    }
+    if let Err(e) = std::fs::write(&path, "1") {
+        tracing::warn!("plan just-archived flag write failed: {e}");
+    }
+}
+
+/// Consume the "just archived" stamp for `session_id`, one-shot.
+///
+/// Returns `true` exactly once for the settle that archived the plan; every
+/// later call returns `false` (and removes the stale sidecar). The single
+/// consumer (the settle gate, or the `refresh_plan_card` no-live-plan re-stick
+/// on the resume path) is the one that finalizes — the one-shot guard stops
+/// both from finalizing the same completion into duplicate cards.
+pub async fn take_plan_just_archived(session_id: Uuid) -> bool {
+    let path = plan_just_archived_path(session_id).await;
+    if path.exists() {
+        if let Err(e) = std::fs::remove_file(&path) {
+            tracing::debug!("plan just-archived flag remove failed: {e}");
+        }
+        true
+    } else {
+        false
+    }
 }
 
 /// True when the newest file under this session's `archive/` was written


### PR DESCRIPTION
Fixes #1231

## Problem

A completed plan's Telegram card could vanish instead of being finalized:

- The completion gate at settle compared archive mtime against a 120s recency window (`recent_archived_plan(session_id, 120s)`).
- Under flood throttle (429 retry-after 25–32s), a completing turn could settle **later than 120s** after the plan archived → gate missed.
- Worse, a completion that settled through the detached-resume / `stream_loop` path never consulted the gate at all: `refresh_plan_card`, finding no live plan, fell through to `remove_plan_card_locked` and silently deleted the archived plan's card. (Only failed deletes log, so nothing appeared in traces.)

Separately, even when the gate hit, `finalize_plan_card` edited the card **in place** — the ✅ marker landed wherever the old card happened to be buried in a busy forum topic, never back at the bottom where the user is reading.

## Fix

Two parts, one commit:

1. **Durable just-archived relay** (`plan_files.rs`): `archive_plan` stamps an explicit sidecar flag in the session's archive dir right after archiving; the settle gate consumes it one-shot via `take_plan_just_archived`. The flag survives arbitrary flood delays *and* the resume-path settle, because it lives on disk next to the artifacts instead of in mtime guesses or process memory. `recent_archived_plan` / `recent_archive_in_dir` are kept for existing tests.

2. **Re-stick to bottom** (`plan_card.rs`): `finalize_plan_card` now deletes the buried tracked card and posts a fresh completed card (✅ header, keyboard stripped) at the tail of the thread/topic — honoring the original card's thread routing — paced through the governor like every other send. On post failure it falls back to the current in-place edit, so a completed card can never be lost mid-flood. One-shot untrack semantics are unchanged.

## Verification

- Live smoke on a forum-enabled chat unit: a real mini-plan driven to completion resticked the fresh ✅ card to the bottom of its topic with the buried copy deleted; flag file observed created by archive and consumed exactly once by the gate.
- Existing `telegram_plan_finalize_test` suite passes unchanged; recency helpers retained because tests exercise them.
