### PR TITLE
fix(tg): scope archived-plan lookup to the owning session (#1239)

### DIFF
--- a/src/tests/plan_completed_persist_test.rs
+++ b/src/tests/plan_completed_persist_test.rs
@@ -38,6 +38,16 @@ fn archive_as(json_path: &std::path::Path, stamp: &str, title: &str) {
     .unwrap();
 }
 
+/// Archive beside `json_path` under THAT path's own stem, exactly as
+/// `archive_plan_files` renames (`{stem}-{ts}.json`) — needed by the
+/// multi-session test where readers are addressed by distinct plan names.
+fn archive_as_stemmed(json_path: &std::path::Path, stamp: &str, title: &str) {
+    let dir = json_path.parent().unwrap().join("archive");
+    std::fs::create_dir_all(&dir).unwrap();
+    let stem = json_path.file_stem().and_then(|s| s.to_str()).unwrap();
+    std::fs::write(dir.join(format!("{stem}-{stamp}.json")), finished_plan_json(title)).unwrap();
+}
+
 #[test]
 fn the_last_archived_plan_is_recovered() {
     let tmp = tempfile::tempdir().unwrap();
@@ -127,4 +137,29 @@ fn a_non_json_file_in_the_archive_is_ignored() {
 
     let found = latest_archived_plan_from_path(&live).expect("the .md must not shadow the .json");
     assert_eq!(found.title, "Ship the fix");
+}
+
+#[test]
+fn another_sessions_archive_never_wins() {
+    // Every session shares one flat `archive/` dir on the box (#1239). The
+    // reader must pick ITS OWN newest, not whichever session id sorts last:
+    // here the foreign session's id sorts greater AND its stamp is newer,
+    // which is exactly how session B's completion rendered session A's card.
+    let tmp = tempfile::tempdir().unwrap();
+    let live_mine = tmp
+        .path()
+        .join("opencrabs_plan_11111111-2222-3333-4444-555555555555.json");
+    let foreign = tmp
+        .path()
+        .join("opencrabs_plan_ffffffff-8888-7777-6666-555555555555.json");
+
+    archive_as_stemmed(&live_mine, "20260826-100000", "Mine");
+    archive_as_stemmed(&foreign, "20260826-230000", "Foreign sorts last");
+
+    assert_eq!(
+        latest_archived_plan_from_path(&live_mine)
+            .expect("own archive must stay readable")
+            .title,
+        "Mine"
+    );
 }

--- a/src/utils/plan_files.rs
+++ b/src/utils/plan_files.rs
@@ -553,13 +553,33 @@ fn archive_plan_files(json_path: &Path) -> std::io::Result<()> {
 ///
 /// Path-based and synchronous to match `archive_plan_files`, so the TUI's
 /// synchronous reload can call it.
+///
+/// Scopes to THIS session's entries (#1239): every channel session shares one
+/// flat `archive/` dir on this box, so a lexicographic max across ALL entries
+/// picks whichever session id sorts last — observed live, session B's
+/// completion rendered session A's checklist card.
 pub fn latest_archived_plan_from_path(json_path: &Path) -> Option<PlanDocument> {
     let dir = json_path.parent()?.join("archive");
+    // Only this session's own archives qualify (#1239). archive_plan_files
+    // renames into `{live-stem}-{ts}.json`, so the live file's stem prefixes
+    // precisely its session's entries no matter which layout dir holds them.
+    let prefix = format!(
+        "{}-",
+        json_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("plan")
+    );
     let newest = std::fs::read_dir(dir)
         .ok()?
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with(&prefix))
+        })
         .max_by_key(|p| {
             p.file_name()
                 .map(|n| n.to_string_lossy().to_string())


### PR DESCRIPTION
Fixes #1239

## Problem

`latest_archived_plan_from_path` picks the lexicographically-greatest `*.json` in the plan `archive/` dir. Its docstring assumes one archive dir per session ("the greatest name is the newest"), but on real deployments every channel session shares **one flat dir** — sessions are distinguished only by the embedded uuid in the filename, and uuids don't sort by recency.

Observed live in a single evening: three different plans completed on the same unit (three different sessions/topics) and **each completion resticked the same foreign "Recipes library" card**, because that session's uuid (`db7defbd…`) sorted last among all archived filenames.

## Fix

Scope the reader to its own session before comparing names: filter entries to those starting with `<live-plan-stem>-` (exactly how `archive_plan_files` renames: `{stem}-{ts}.json`), then take the newest stamp within that prefix as before. The signature stays path-based and synchronous — no churn for the TUI's synchronous reload or existing callers; two callers confirmed unaffected beyond correctness.

- Live name `.opencrabs_plan_<uuid>.json` → archives `.opencrabs_plan_<uuid>-<ts>.json`: prefix isolates precisely that session's history regardless of which layout dir holds it.
- Legacy fallback path derives its stem identically, so pre-migration archives still resolve.

## Regression test

`another_sessions_archive_never_wins`: foreign id sorts greater **and** carries a newer stamp — reproduces the incident exactly; own archive must win. Existing six tests pass unchanged (`plan-{stamp}.json` fixtures already follow the stem-prefix naming).
