### PR TITLE
feat(tg): deliver mermaid.ink renders as bytes with a dimension ladder (#1238)

### DIFF
--- a/src/channels/telegram/delivery.rs
+++ b/src/channels/telegram/delivery.rs
@@ -41,7 +41,7 @@ pub(crate) fn is_react_only(text_after_directive: &str) -> bool {
 /// True when a rich-send failure means Telegram could not fetch the embedded
 /// media (the mermaid.ink diagram) — a transient renderer or network window
 /// that a single re-send can sail (#tg-mermaid-delivery-hardening). Our
-/// prevalidate runs seconds before Telegram's own server-side refetch, so
+/// resolve runs seconds before Telegram's own server-side refetch, so
 /// `RICH_MESSAGE_PHOTO_NO_MEDIA_FOUND` is a race with a flaky renderer, not a
 /// structural rejection. Structural 400s (schema, content) are never retried.
 pub(crate) fn is_no_media_found(e: &anyhow::Error) -> bool {
@@ -679,7 +679,7 @@ pub(crate) async fn deliver_final_response(
                             // #tg-mermaid-delivery-hardening: retry once when
                             // Telegram's server-side refetch of the embedded media
                             // (mermaid.ink) died — `RICH_MESSAGE_PHOTO_NO_MEDIA_FOUND`
-                            // is a race against a flaky renderer (our prevalidate ran
+                            // is a race against a flaky renderer (our resolve ran
                             // seconds earlier), not a structural rejection. The sender
                             // re-resolves media on every call, so the retry naturally
                             // re-fetches from the renderer. Structural 400s are never
@@ -883,9 +883,10 @@ pub(crate) async fn deliver_final_response(
                                     "Telegram: edit final failed ({e}), falling back to delete+send"
                                 );
                                 best_effort_delete(bot, chat_id, mid, "edit-final fallback").await;
-                                if let Ok(sent) =
-                                    send_html_or_plain(bot, chat_id, thread_id, &chunks[0], "turn", None)
-                                        .await
+                                if let Ok(sent) = send_html_or_plain(
+                                    bot, chat_id, thread_id, &chunks[0], "turn", None,
+                                )
+                                .await
                                 {
                                     sent_reply_id = Some(sent.0);
                                     final_bubble = Some(super::state::MergeBubble {
@@ -903,7 +904,8 @@ pub(crate) async fn deliver_final_response(
                         for chunk in &chunks {
                             // Last chunk wins — that's the bubble a user replies to.
                             if let Ok(sent) =
-                                send_html_or_plain(bot, chat_id, thread_id, chunk, "turn", None).await
+                                send_html_or_plain(bot, chat_id, thread_id, chunk, "turn", None)
+                                    .await
                             {
                                 sent_reply_id = Some(sent.0);
                                 final_bubble = Some(super::state::MergeBubble {

--- a/src/channels/telegram/rich/api.rs
+++ b/src/channels/telegram/rich/api.rs
@@ -372,40 +372,21 @@ pub(crate) fn build_body_html(
 
 /// Send `markdown` with a `media` array as a native rich message
 /// (Bot API 10.2+, #1044). The markdown references each image via
-/// Exercised today only by the cfg(test) suite; reserved as the
-/// media-carrying entry point for in-flight echo-bubble work (#1234).
-#[allow(dead_code)]
-/// `tg://photo?id=<id>`; the `media` array maps each id to a renderer URL
-/// Telegram fetches server-side. This is the mode that embeds images while
-/// keeping pipe tables native. Returns the new message id.
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn send_rich_markdown_media_id(
-    api_url: &str,
-    token: &str,
-    chat_id: i64,
-    thread_id: Option<ThreadId>,
-    markdown: &str,
-    media: &[super::mermaid::MediaEntry],
-    reply_to: Option<i32>,
-    origin: &str,
-    origin_detail: &str,
-) -> anyhow::Result<i32> {
-    send_rich_markdown_media_target_id(
-        api_url,
-        token,
-        chat_id,
-        thread_id,
-        reply_to,
-        markdown,
-        media,
-        origin,
-        origin_detail,
-    )
-    .await
-}
-
-/// [`send_rich_markdown_media_id`] with an optional Telegram reply target
-/// (#1230); carries `reply_parameters` when `reply_to` is set.
+/// `tg://photo?id=<id>`; the `media` array maps each id to an image source.
+///
+/// Two delivery modes, switched per entry (#1044 media plumbing):
+///
+/// - `MediaEntry::url` — the legacy URL path: the source is a renderer URL
+///   (e.g. mermaid.ink) that Telegram fetches server-side. Sent as a plain
+///   JSON body.
+/// - `MediaEntry::bytes` (the active path: pre-validated mermaid.ink render,
+///   #1238) — the PNG bytes are uploaded to Telegram via multipart as
+///   `attach://<id>` photo parts, so Telegram never touches a third-party
+///   URL. The request must therefore be `multipart/form-data`, not JSON.
+///
+/// Carries `reply_parameters` when `reply_to` is set (#1230). Returns the
+/// new message id. Returns `Err` on transport/API failure so the caller can
+/// fall back to the HTML dialect.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn send_rich_markdown_media_target_id(
     api_url: &str,
@@ -419,13 +400,16 @@ pub(crate) async fn send_rich_markdown_media_target_id(
     origin_detail: &str,
 ) -> anyhow::Result<i32> {
     let url = format!("{}/bot{token}/sendRichMessage", api_base(api_url));
-    let result = post_rich(
-        &url,
-        &build_body_markdown_media_target(chat_id, thread_id, reply_to, markdown, media),
-        origin,
-        origin_detail,
-    )
-    .await?;
+    let body = build_body_markdown_media_target(chat_id, thread_id, reply_to, markdown, media);
+
+    let result = if media.iter().any(|m| m.bytes.is_some()) {
+        // Local render → multipart upload of the PNG bytes (attach://).
+        post_rich_multipart(&url, media, &body, origin, origin_detail).await?
+    } else {
+        // Legacy URL path → plain JSON; Telegram refetches the URL.
+        post_rich(&url, &body, origin, origin_detail).await?
+    };
+
     result
         .get("message_id")
         .and_then(serde_json::Value::as_i64)
@@ -433,25 +417,154 @@ pub(crate) async fn send_rich_markdown_media_target_id(
         .ok_or_else(|| anyhow::anyhow!("sendRichMessage ok but response carried no message_id"))
 }
 
-/// Pure request-shape helper exercised by the cfg(test) prototype-parity
-/// suite; nothing on the lib path constructs it yet (#1234 surface).
-#[allow(dead_code)]
+/// Build the multipart/form-data request for a `sendRichMessage` whose media
+/// array references uploaded PNG bytes via `attach://<id>`. Every top-level
+/// scalar field of the JSON body (`chat_id`, `message_thread_id`,
+/// `reply_parameters`, `rich_message`) becomes a string form part; each byte
+/// entry becomes a file part named exactly `<id>` so Telegram's
+/// `attach://<id>` reference resolves (§ Bot API multipart media convention).
+/// The JSON body is still passed in for correlation telemetry
+/// ([`rich_send_fields`] reads its `rich_message` pointer).
+fn build_multipart_form(
+    media: &[super::mermaid::MediaEntry],
+    body: &serde_json::Value,
+) -> reqwest::multipart::Form {
+    let mut fields: Vec<(String, String)> = Vec::new();
+    if let Some(v) = body.get("chat_id") {
+        fields.push(("chat_id".to_string(), v.to_string()));
+    }
+    if let Some(v) = body.get("message_thread_id") {
+        fields.push(("message_thread_id".to_string(), v.to_string()));
+    }
+    if let Some(v) = body.get("reply_parameters") {
+        fields.push(("reply_parameters".to_string(), v.to_string()));
+    }
+    if let Some(v) = body.get("rich_message") {
+        fields.push(("rich_message".to_string(), v.to_string()));
+    }
+
+    let mut form = reqwest::multipart::Form::new();
+    for (name, value) in fields {
+        form = form.text(name, value);
+    }
+    for m in media {
+        if let Some(bytes) = &m.bytes {
+            let part = reqwest::multipart::Part::bytes(bytes.clone())
+                .file_name(format!("{}.png", m.id))
+                .mime_str("image/png")
+                .expect("image/png is a valid mime");
+            form = form.part(m.id.clone(), part);
+        }
+    }
+    form
+}
+
+/// POST `form` (multipart, for `attach://` bytes upload) to `url`, mirroring
+/// [`post_rich`]'s retry / rate-limit / telemetry semantics exactly. Accepts
+/// only the media-with-bytes send; every non-`ok` response is an error that
+/// surfaces Telegram's `description`.
+async fn post_rich_multipart(
+    url: &str,
+    media: &[super::mermaid::MediaEntry],
+    body: &serde_json::Value,
+    origin: &str,
+    origin_detail: &str,
+) -> anyhow::Result<serde_json::Value> {
+    let client = reqwest::Client::new();
+    let mut attempt = 0u32;
+
+    loop {
+        {
+            let (_, chat_id, thread, _, _) = rich_send_fields(url, body);
+            crate::channels::telegram::governor::pace_rich(
+                teloxide::types::ChatId(chat_id),
+                thread,
+            )
+            .await;
+        }
+        // Form is not Clone, so rebuild it from media+body each attempt.
+        let form = build_multipart_form(media, body);
+        let resp = client.post(url).multipart(form).send().await?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
+
+        if status.is_success()
+            && parsed.get("ok").and_then(serde_json::Value::as_bool) == Some(true)
+        {
+            let result = parsed
+                .get("result")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
+            let (method, chat_id, thread, len, hash8) = rich_send_fields(url, body);
+            let msg_id = result
+                .get("message_id")
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or(0) as i32;
+            crate::channels::telegram::telemetry::log_send_success(
+                origin,
+                origin_detail,
+                "-",
+                "rich_api",
+                method,
+                chat_id,
+                thread,
+                msg_id,
+                len,
+                &hash8,
+            );
+            return Ok(result);
+        }
+
+        if status.as_u16() == 429 && attempt < RICH_MAX_RETRIES {
+            let retry_after = parsed
+                .get("parameters")
+                .and_then(|p| p.get("retry_after"))
+                .and_then(|r| r.as_u64())
+                .unwrap_or(5);
+            attempt += 1;
+            crate::channels::telegram::rate_limit::wait_out(
+                "rich API",
+                std::time::Duration::from_secs(retry_after),
+                &format!(" (attempt {attempt}/{RICH_MAX_RETRIES})"),
+            )
+            .await;
+            continue;
+        }
+
+        let desc = parsed
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or(&text);
+        if status.as_u16() == 429 {
+            tracing::warn!(
+                "Rich API (multipart) still rate limited after {RICH_MAX_RETRIES} retries — falling back"
+            );
+        }
+        {
+            let (method, chat_id, thread, len, hash8) = rich_send_fields(url, body);
+            crate::channels::telegram::telemetry::log_send_failure(
+                origin,
+                origin_detail,
+                "-",
+                "rich_api",
+                method,
+                chat_id,
+                thread,
+                len,
+                &hash8,
+                &format!("({status}): {desc}"),
+            );
+        }
+        anyhow::bail!("Telegram rich API error ({status}): {desc}")
+    }
+}
+
 /// Build the `sendRichMessage` body with markdown input + a `media` array
 /// (Bot API 10.2+, #1044). Split out so the request shape is unit-testable
 /// without a live bot. Matches the validated prototype (message 1073):
 /// `rich_message: {markdown, media: [{id, media: {type:"photo", media:url}}]}`.
-pub(crate) fn build_body_markdown_media(
-    chat_id: i64,
-    thread_id: Option<ThreadId>,
-    markdown: &str,
-    media: &[super::mermaid::MediaEntry],
-    reply_to: Option<i32>,
-) -> serde_json::Value {
-    build_body_markdown_media_target(chat_id, thread_id, reply_to, markdown, media)
-}
-
-/// [`build_body_markdown_media`] with an optional Telegram reply target
-/// (#1230); carries `reply_parameters` when `reply_to` is set.
+/// Carries `reply_parameters` when `reply_to` is set (#1230).
 pub(crate) fn build_body_markdown_media_target(
     chat_id: i64,
     thread_id: Option<ThreadId>,
@@ -462,9 +575,16 @@ pub(crate) fn build_body_markdown_media_target(
     let media_arr: Vec<serde_json::Value> = media
         .iter()
         .map(|m| {
+            // Local PNG bytes upload via multipart as `attach://<id>`; URL
+            // entries keep the legacy server-side fetch reference.
+            let source = match (&m.bytes, &m.url) {
+                (Some(_), _) => format!("attach://{}", m.id),
+                (None, Some(url)) => url.clone(),
+                (None, None) => String::new(),
+            };
             serde_json::json!({
                 "id": m.id,
-                "media": { "type": "photo", "media": m.url },
+                "media": { "type": "photo", "media": source },
             })
         })
         .collect();

--- a/src/channels/telegram/rich/ast.rs
+++ b/src/channels/telegram/rich/ast.rs
@@ -52,6 +52,9 @@ pub enum Block {
 pub enum MermaidResult {
     /// The renderer accepted the diagram; carries the image URL to embed.
     Image(String),
+    /// Local (in-process) rendering produced PNG bytes ready for multipart
+    /// upload to Telegram. Carries the raw encoded PNG.
+    ImageBytes(Vec<u8>),
     /// The renderer rejected the diagram or was unreachable; carries a
     /// legible error note for the failure block.
     Failed(String),

--- a/src/channels/telegram/rich/mermaid.rs
+++ b/src/channels/telegram/rich/mermaid.rs
@@ -7,10 +7,13 @@
 //! fallback for servers without the `media` field. A broken image URL makes
 //! the whole send fail with `RICH_MESSAGE_PHOTO_NO_MEDIA_FOUND`, so before
 //! delivery each fence is pre-validated against the renderer (mermaid.ink):
-//! a 200 + `image/*` response embeds the image, anything else degrades to a
+//! the render's PNG bytes are fetched by us and uploaded via multipart
+//! (`attach://`), so Telegram never fetches a third-party URL. A request
+//! ladder keeps the render inside Telegram's photo box (natural size first,
+//! then a proportional 1200px width clamp); anything else degrades to a
 //! legible failure block (the renderer's error note plus the original
 //! source) instead of killing the message. Pre-validation never panics or
-//! hangs; every failure path yields [`MermaidResult::Failed`].
+//! hangs; failure paths yield [`MermaidResult::Failed`].
 
 use super::ast::{Block, MermaidResult};
 use futures::FutureExt;
@@ -22,15 +25,25 @@ const MERMAID_INK_BASE: &str = "https://mermaid.ink/img/";
 
 /// Query parameters appended to every mermaid.ink render request.
 ///
-/// The service's defaults produce small blurry JPEGs; these request PNG at
-/// double resolution instead (empirically verified 2026-08-26:
-/// `type=png&width=1600&scale=2` yields a 3200px-wide PNG where bare `/img/`
-/// yields a ~1900px-wide JPEG of the same source). `scale` is ignored
-/// without `width`, so the two always travel together.
-const MERMAID_INK_PARAMS: &str = "?type=png&width=1600&scale=2";
+/// Natural-size PNG request: no width/scale overrides, so mermaid.ink
+/// returns the diagram at its intrinsic Chromium/ELK render size (the
+/// 44-node stress case: 1611×3727). The previous hi-res override
+/// (`width=1600&scale=2`) doubled that to 3200×7404 — 10604 combined px,
+/// past Telegram's photo box — and Telegram refused the photo. The render
+/// size is a property of the request we send, not of the diagram.
+const MERMAID_INK_PARAMS: &str = "?type=png";
 
-/// Upper bound on a single pre-validation request. A slow renderer must not
-/// stall message delivery; on timeout we degrade to a failure block.
+/// Ladder rung 2: same renderer, layout clamped to a proportional 1200px
+/// width. `width` scales the render proportionally (measured: the stress
+/// case goes 1611×3727 → 1200×2776), so a single clamp rung covers any
+/// realistic aspect ratio without a local redraw.
+const MERMAID_INK_CLAMP_PARAMS: &str = "?type=png&width=1200";
+
+/// Telegram rejects photos whose width+height exceeds this combined budget
+/// (measured live, #1238: 3200×7404 refused, 1611×3727 accepted).
+const PHOTO_MAX_TOTAL_DIMS: f32 = 9_600.0;
+
+/// stall message delivery; on timeout we degrade to a legible failure block.
 const PREVALIDATE_TIMEOUT_SECS: u64 = 10;
 
 /// Cap on how much of the renderer's error body we surface, so a huge HTML
@@ -38,12 +51,19 @@ const PREVALIDATE_TIMEOUT_SECS: u64 = 10;
 const ERROR_NOTE_MAX_CHARS: usize = 400;
 
 /// One media reference embedded via the markdown `media` field (#1044).
-/// `id` matches the `tg://photo?id=<id>` reference in the markdown text;
-/// `url` is the validated renderer image Telegram fetches server-side.
+/// `id` matches the `tg://photo?id=<id>` reference in the markdown text.
+///
+/// Exactly one of the payload sources is set:
+/// - `url`: the mermaid.ink renderer image URL Telegram fetches server-side
+///   (the legacy, network-dependent path).
+/// - `bytes`: the pre-validated mermaid.ink PNG bytes, uploaded to Telegram
+///   via multipart as `attach://<id>` — the active delivery mode; Telegram
+///   never touches a third-party URL.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct MediaEntry {
     pub(crate) id: String,
-    pub(crate) url: String,
+    pub(crate) url: Option<String>,
+    pub(crate) bytes: Option<Vec<u8>>,
 }
 
 /// A located ```mermaid fence in the source markdown. `start` is the byte
@@ -189,23 +209,58 @@ pub(crate) fn should_render_mermaid(text: &str) -> bool {
     tg.rich_messages && tg.mermaid_render && has_mermaid_fence(text)
 }
 
-/// Full mermaid.ink embed/prevalidate URL for a diagram source: b64url
-/// payload plus the hi-res PNG parameters ([`MERMAID_INK_PARAMS`]).
+/// Full mermaid.ink embed/resolve URL for a diagram source: b64url
+/// payload plus the natural-size PNG parameters ([`MERMAID_INK_PARAMS`]).
 pub(crate) fn ink_url(source: &str) -> String {
-    format!(
-        "{}{}{}",
-        MERMAID_INK_BASE,
-        base64url(source),
-        MERMAID_INK_PARAMS
-    )
+    ink_url_params(source, MERMAID_INK_PARAMS)
 }
 
-/// Pre-validate a single mermaid diagram against the renderer. Returns
-/// [`MermaidResult::Image`] with the embed URL only on HTTP 200 + an
-/// `image/*` content type; every other outcome (non-200, non-image, timeout,
-/// transport error, client build failure) yields [`MermaidResult::Failed`]
-/// with a legible note. Never panics, never hangs past the timeout.
-pub(crate) async fn prevalidate(source: &str) -> MermaidResult {
+/// Same URL at an explicit parameter set — the ladder's clamp rung.
+fn ink_url_params(source: &str, params: &str) -> String {
+    format!("{}{}{}", MERMAID_INK_BASE, base64url(source), params)
+}
+
+/// Whether a render fits Telegram's photo box (width + height budget).
+/// Pure f32 arithmetic with no renderer deps — kept out of the
+/// feature-gated local-render module so every build can dimension-check
+/// remote PNGs.
+pub(crate) fn photo_fits(w: u32, h: u32) -> bool {
+    (w as f32) + (h as f32) <= PHOTO_MAX_TOTAL_DIMS
+}
+
+/// Parse a PNG's IHDR header for its (width, height). Returns `None` for
+/// non-PNG bodies and buffers too short to carry the header. Split out so
+/// the oversize ladder is unit-testable without a network call.
+pub(crate) fn png_dims(png: &[u8]) -> Option<(u32, u32)> {
+    const PNG_SIG: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+    if png.len() < 24 || png[..8] != PNG_SIG {
+        return None;
+    }
+    if png[12..16] != *b"IHDR" {
+        return None;
+    }
+    let w = u32::from_be_bytes([png[16], png[17], png[18], png[19]]);
+    let h = u32::from_be_bytes([png[20], png[21], png[22], png[23]]);
+    Some((w, h))
+}
+
+/// Pre-validate a single mermaid diagram against the renderer. On HTTP 200
+/// with an `image/*` content type it DOWNLOADS the rendered PNG and returns
+/// [`MermaidResult::ImageBytes`] — Telegram never fetches a URL from us
+/// (its own URL fetcher proved the unreliable link: `400 failed to get
+/// HTTP URL content` on live probes while the same URL fetched fine from
+/// this host). Every other outcome (non-200, non-image, timeout, transport
+/// error, client build failure, dropped body) yields
+/// [`MermaidResult::Failed`] with a legible note. Never panics, never hangs
+/// past the timeout.
+///
+/// Delivery is remote-only (#1238, owner directive: the in-process
+/// renderer's visual quality is not acceptable in production, and the owner
+/// later ordered it removed from the tree entirely): the request ladder
+/// walks natural size → proportional width clamp, both served by
+/// mermaid.ink; if every rung fails or still busts Telegram's photo box,
+/// the fence degrades to a legible failure block. No local renderer exists.
+pub(crate) async fn resolve(source: &str) -> MermaidResult {
     let url = ink_url(source);
 
     let client = match reqwest::Client::builder()
@@ -237,7 +292,72 @@ pub(crate) async fn prevalidate(source: &str) -> MermaidResult {
         .to_string();
 
     if is_image_response(status, &content_type) {
-        return MermaidResult::Image(url);
+        // Bytes delivery (hybrid round 2): download the PNG here and hand
+        // Telegram the bytes via multipart (`attach://`). Telegram's own
+        // server-side URL fetcher is the unreliable hop — it 400s with
+        // "failed to get HTTP URL content" on URLs this host fetches fine —
+        // so Telegram never sees a URL at all.
+        let body = match resp.bytes().await {
+            Ok(b) => b,
+            Err(_) => {
+                return MermaidResult::Failed("diagram renderer dropped the image".into());
+            }
+        };
+        // Dimension ladder (#1238): natural size first; if it busts
+        // Telegram's photo box, re-request the SAME diagram with a
+        // proportional 1200px width clamp — still mermaid.ink, still
+        // Chromium/ELK quality. Delivery never redraws locally.
+        match png_dims(&body) {
+            Some((w, h)) if !photo_fits(w, h) => {
+                tracing::warn!(
+                    w,
+                    h,
+                    "natural render exceeds the photo box; retrying at the width clamp"
+                );
+                let clamp_url = ink_url_params(source, MERMAID_INK_CLAMP_PARAMS);
+                let cresp = match client.get(&clamp_url).send().await {
+                    Ok(r) => r,
+                    Err(_) => {
+                        return MermaidResult::Failed(format!(
+                            "rendered diagram {w}x{h} exceeds the photo box and the width-clamp retry failed"
+                        ));
+                    }
+                };
+                let cstatus = cresp.status().as_u16();
+                let ctype = cresp
+                    .headers()
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                if !is_image_response(cstatus, &ctype) {
+                    let cbody = cresp.text().await.unwrap_or_default();
+                    return MermaidResult::Failed(error_note(cstatus, &cbody));
+                }
+                let cbytes = match cresp.bytes().await {
+                    Ok(b) => b,
+                    Err(_) => {
+                        return MermaidResult::Failed("width-clamp retry dropped the image".into());
+                    }
+                };
+                if let Some((cw, ch)) = png_dims(&cbytes).filter(|&(cw, ch)| !photo_fits(cw, ch)) {
+                    return MermaidResult::Failed(format!(
+                        "rendered diagram exceeds the photo box even at the width clamp: {cw}x{ch} px"
+                    ));
+                }
+                tracing::info!(
+                    bytes = cbytes.len(),
+                    "mermaid.ink clamp render ok; delivering bytes"
+                );
+                return MermaidResult::ImageBytes(cbytes.to_vec());
+            }
+            _ => {}
+        }
+        tracing::info!(
+            bytes = body.len(),
+            "mermaid.ink render ok; delivering bytes"
+        );
+        return MermaidResult::ImageBytes(body.to_vec());
     }
 
     // Not a usable image: surface the renderer's own error text (mermaid.ink
@@ -277,7 +397,19 @@ pub(crate) fn replacement_for(
                 format!("![diagram](tg://photo?id={id})"),
                 Some(MediaEntry {
                     id,
-                    url: url.clone(),
+                    url: Some(url.clone()),
+                    bytes: None,
+                }),
+            )
+        }
+        MermaidResult::ImageBytes(bytes) => {
+            let id = format!("diag{index}");
+            (
+                format!("![diagram](tg://photo?id={id})"),
+                Some(MediaEntry {
+                    id,
+                    url: None,
+                    bytes: Some(bytes.clone()),
                 }),
             )
         }
@@ -285,11 +417,22 @@ pub(crate) fn replacement_for(
     }
 }
 
+/// Resolve a single fence to a render outcome. Remote-only delivery
+/// (#1044 bytes path, #1238 ladder): mermaid.ink renders (ELK layout,
+/// Chromium text rendering, full mermaid 11 diagram coverage) and the PNG
+/// bytes ride to Telegram via multipart (`attach://`) — Telegram never
+/// fetches a URL. On total failure the prevalidation note degrades to the
+/// legible failure block; the in-process renderer is never invoked in
+/// delivery.
+async fn resolve_fence(source: &str) -> MermaidResult {
+    resolve(source).await
+}
+
 /// Resolve every mermaid fence in `text` for the markdown+media path: valid
 /// diagrams become `![diagram](tg://photo?id=diagN)` references with a
 /// matching [`MediaEntry`], broken ones become legible markdown failure
 /// blocks. Non-fence text is untouched (byte-identical). Boxed because the
-/// resolver is async and returned across an await boundary.
+/// resolver is async and because it spans an await boundary.
 pub(crate) fn resolve_markdown_media(text: &str) -> BoxFuture<'static, (String, Vec<MediaEntry>)> {
     let text = text.to_string();
     async move {
@@ -301,7 +444,7 @@ pub(crate) fn resolve_markdown_media(text: &str) -> BoxFuture<'static, (String, 
         let mut media = Vec::new();
         // Replace from last to first so earlier byte offsets stay valid.
         for (i, fence) in fences.iter().enumerate().rev() {
-            let outcome = prevalidate(&fence.source).await;
+            let outcome = resolve_fence(&fence.source).await;
             let (replacement, entry) = replacement_for(&outcome, i, &fence.source);
             if let Some(e) = entry {
                 media.push(e);
@@ -338,7 +481,7 @@ fn resolve_block(block: Block) -> BoxFuture<'static, Block> {
                 if lang.as_deref().is_some_and(is_mermaid_lang)
                     || (lang.is_none() && looks_like_mermaid_source(&text)) =>
             {
-                let result = prevalidate(&text).await;
+                let result = resolve_fence(&text).await;
                 Block::Mermaid {
                     source: text,
                     result,

--- a/src/channels/telegram/rich/render_html.rs
+++ b/src/channels/telegram/rich/render_html.rs
@@ -77,6 +77,14 @@ fn render_block(block: &Block, wrap_p: bool) -> String {
         // super::mermaid so the escaping stays in one place.
         Block::Mermaid { source, result } => match result {
             MermaidResult::Image(url) => super::mermaid::image_html(url),
+            // Locally-rendered PNG bytes are delivered via the multipart
+            // markdown path, never through vector HTML `<img>` (Telegram
+            // rejects it). This arm is a defensive fallback — degrade
+            // legibly rather than leak raw binary.
+            MermaidResult::ImageBytes(_) => super::mermaid::failure_html(
+                "diagram rendered locally but could not be embedded in HTML",
+                source,
+            ),
             MermaidResult::Failed(err) => super::mermaid::failure_html(err, source),
         },
         Block::Quote(inner) => format!(

--- a/src/tests/telegram_mermaid_test.rs
+++ b/src/tests/telegram_mermaid_test.rs
@@ -8,7 +8,7 @@
 //! point `should_render_mermaid` is not unit-tested because it reads the live
 //! `Config`, whose values in tests depend on the embedded example config.
 
-use crate::channels::telegram::rich::api::build_body_markdown_media;
+use crate::channels::telegram::rich::api::build_body_markdown_media_target;
 use crate::channels::telegram::rich::ast::{Block, Inline, MermaidResult};
 use crate::channels::telegram::rich::markdown_to_html_mermaid;
 use crate::channels::telegram::rich::mermaid::{
@@ -258,7 +258,8 @@ fn replacement_for_image_emits_media_reference_and_entry() {
     assert_eq!(md, "![diagram](tg://photo?id=diag0)");
     let e = entry.expect("image outcome must carry a media entry");
     assert_eq!(e.id, "diag0");
-    assert_eq!(e.url, "https://mermaid.ink/img/xyz");
+    assert_eq!(e.url, Some("https://mermaid.ink/img/xyz".into()));
+    assert!(e.bytes.is_none());
 }
 
 #[test]
@@ -267,6 +268,20 @@ fn replacement_for_image_uses_fence_index_in_id() {
     let (md, entry) = replacement_for(&outcome, 3, "src");
     assert_eq!(md, "![diagram](tg://photo?id=diag3)");
     assert_eq!(entry.unwrap().id, "diag3");
+}
+
+#[test]
+fn replacement_for_image_bytes_carries_png_and_no_url() {
+    let outcome = MermaidResult::ImageBytes(vec![0x89, b'P', b'N', b'G', 0, 0, 0, 0]);
+    let (md, entry) = replacement_for(&outcome, 1, "graph TD;");
+    assert_eq!(md, "![diagram](tg://photo?id=diag1)");
+    let e = entry.expect("bytes outcome must carry a media entry");
+    assert_eq!(e.id, "diag1");
+    assert!(e.url.is_none());
+    assert_eq!(
+        e.bytes.as_deref(),
+        Some(&[0x89, b'P', b'N', b'G', 0, 0, 0, 0][..])
+    );
 }
 
 #[test]
@@ -296,16 +311,17 @@ fn markdown_failure_block_contains_warning_error_and_source() {
 }
 
 // ---------------------------------------------------------------------------
-// build_body_markdown_media (JSON shape, matches validated prototype 1073)
+// build_body_markdown_media_target (JSON shape, matches validated prototype 1073)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn build_body_markdown_media_matches_prototype_shape() {
+fn build_body_markdown_media_target_matches_prototype_shape() {
     let media = vec![MediaEntry {
         id: "diag0".into(),
-        url: "https://mermaid.ink/img/abc".into(),
+        url: Some("https://mermaid.ink/img/abc".into()),
+        bytes: None,
     }];
-    let body = build_body_markdown_media(-100, None, "text", &media, None);
+    let body = build_body_markdown_media_target(-100, None, None, "text", &media);
     assert_eq!(body["chat_id"], -100);
     assert_eq!(body["rich_message"]["markdown"], "text");
     let arr = body["rich_message"]["media"]
@@ -319,10 +335,27 @@ fn build_body_markdown_media_matches_prototype_shape() {
 }
 
 #[test]
-fn build_body_markdown_media_includes_thread_id_when_present() {
+fn build_body_markdown_media_target_includes_thread_id_when_present() {
     use teloxide::types::{MessageId, ThreadId};
-    let body = build_body_markdown_media(-100, Some(ThreadId(MessageId(249))), "m", &[], None);
+    let body =
+        build_body_markdown_media_target(-100, Some(ThreadId(MessageId(249))), None, "m", &[]);
     assert_eq!(body["message_thread_id"], 249);
+}
+
+#[test]
+fn build_body_markdown_media_target_bytes_entry_uses_attach_reference() {
+    let media = vec![MediaEntry {
+        id: "diag1".into(),
+        url: None,
+        bytes: Some(vec![0x89, b'P']),
+    }];
+    let body = build_body_markdown_media_target(-100, None, None, "text", &media);
+    let arr = body["rich_message"]["media"]
+        .as_array()
+        .expect("media array");
+    assert_eq!(arr[0]["id"], "diag1");
+    assert_eq!(arr[0]["media"]["type"], "photo");
+    assert_eq!(arr[0]["media"]["media"], "attach://diag1");
 }
 
 // ---------------------------------------------------------------------------
@@ -449,18 +482,19 @@ fn test_bare_fence_with_diagram_body_is_still_classified() {
 }
 
 // ---------------------------------------------------------------------------
-// hi-res PNG embed URLs: every prevalidate/embed URL must carry the
-// type/width/scale query so Telegram receives crisp rasters instead of the
-// renderer's small JPEG defaults.
+// natural-size PNG embed URLs (#1238): the request carries no width/scale
+// overrides, so mermaid.ink returns the diagram at its intrinsic size — the
+// dimension ladder keeps that size inside Telegram's photo box.
 
 #[test]
-fn ink_url_appends_hires_png_params() {
+fn ink_url_requests_natural_size_png() {
     let url = ink_url("graph TD\n    A --> B");
     assert!(url.starts_with("https://mermaid.ink/img/"));
     assert!(
-        url.ends_with("?type=png&width=1600&scale=2"),
-        "missing hi-res params: {url}"
+        url.ends_with("?type=png"),
+        "expected natural-size params: {url}"
     );
+    assert!(!url.contains("scale=") && !url.contains("width="));
 }
 
 #[test]
@@ -475,6 +509,19 @@ fn ink_url_payload_is_base64url_without_padding() {
         .expect("payload before query string");
     assert!(!payload.contains('='), "padding leaked: {payload}");
     assert!(!payload.contains('+') && !payload.contains('/'));
+}
+
+#[test]
+fn photo_fits_matches_the_measured_photo_box() {
+    use crate::channels::telegram::rich::mermaid::photo_fits;
+    // Measured live (#1238): natural 1611×3727 accepted, prod-params
+    // 3200×7404 refused; the box edge is 9600 combined px.
+    assert!(photo_fits(1611, 3727));
+    assert!(photo_fits(1200, 2776));
+    assert!(photo_fits(800, 1851));
+    assert!(!photo_fits(3200, 7404));
+    assert!(photo_fits(4800, 4800)); // exactly 9600: fits
+    assert!(!photo_fits(4800, 4801)); // 9601: busts
 }
 
 // ---------------------------------------------------------------------------
@@ -508,4 +555,33 @@ fn no_media_found_sees_through_anyhow_context_wraps() {
     let inner = anyhow::anyhow!("Telegram rich API error (400): RICH_MESSAGE_PHOTO_NO_MEDIA_FOUND");
     let wrapped = inner.context("while delivering final response");
     assert!(is_no_media_found(&wrapped));
+}
+
+// ---------------------------------------------------------------------------
+// png_dims (bytes-delivery oversize guard)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn png_dims_parses_ihdr() {
+    use crate::channels::telegram::rich::mermaid::png_dims;
+
+    let mut png = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+    png.extend_from_slice(&[0, 0, 0, 13]); // IHDR chunk length
+    png.extend_from_slice(b"IHDR");
+    png.extend_from_slice(&1611u32.to_be_bytes());
+    png.extend_from_slice(&3727u32.to_be_bytes());
+    assert_eq!(png_dims(&png), Some((1611, 3727)));
+}
+
+#[test]
+fn png_dims_rejects_non_png_and_short_buffers() {
+    use crate::channels::telegram::rich::mermaid::png_dims;
+
+    assert_eq!(png_dims(b"not a png at all...."), None);
+    assert_eq!(png_dims(&[0x89, b'P']), None);
+    let mut hdr = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+    hdr.extend_from_slice(&[0, 0, 0, 13]);
+    hdr.extend_from_slice(b"IDAT"); // wrong chunk type
+    hdr.extend_from_slice(&[0u8; 16]);
+    assert_eq!(png_dims(&hdr), None);
 }

--- a/src/tests/telegram_rich_api_test.rs
+++ b/src/tests/telegram_rich_api_test.rs
@@ -91,7 +91,7 @@ async fn edit_rich_html_uses_custom_api_url() {
 }
 
 #[tokio::test]
-async fn send_rich_markdown_media_id_uses_custom_api_url() {
+async fn send_rich_markdown_media_target_id_uses_custom_api_url() {
     let mut server = mockito::Server::new_async().await;
     let mock = server
         .mock("POST", "/botTESTTOKEN/sendRichMessage")
@@ -101,17 +101,18 @@ async fn send_rich_markdown_media_id_uses_custom_api_url() {
         .create_async()
         .await;
 
-    let result = api::send_rich_markdown_media_id(
+    let result = api::send_rich_markdown_media_target_id(
         &server.url(),
         "TESTTOKEN",
         11111,
         None,
+        None,
         "![img](tg://photo?id=1)",
         &[crate::channels::telegram::rich::mermaid::MediaEntry {
             id: "1".to_string(),
-            url: "https://example.com/img.png".to_string(),
+            url: Some("https://example.com/img.png".to_string()),
+            bytes: None,
         }],
-        None,
         "test",
         "-",
     )


### PR DESCRIPTION
## Mermaid delivery — mermaid.ink bytes + dimension ladder, no local renderer

This PR now carries the **final, owner-approved design** for Telegram mermaid delivery. It supersedes this PR's original direction (in-process `mermaid-render` + `resvg`, feature `local-mermaid`) — that direction was retired after fork deployment: **remote-only mermaid.ink, no local renderer anywhere in the tree.**

### What it does
Every mermaid fence goes through `resolve()`:
1. **Rung 1 — natural size:** GET `?type=png`, parse the PNG IHDR for dimensions.
2. **Fit check:** Telegram's photo box is `w + h ≤ 9600` combined px (measured). Fits → deliver.
3. **Rung 2 — proportional clamp:** same renderer at `?type=png&width=1200` (layout scales proportionally — the 44-node stress case goes 1611×3727 → 1200×2776). Fits → deliver; still oversize → legible in-bubble failure note (source + reason preserved).
4. **Delivery:** the downloaded PNG bytes ride the rich POST as an `attach://` multipart part. Telegram never fetches a third-party URL — the mermaid.ink URL-fetcher lottery (`400 failed to get HTTP URL content` on oversize or blocked fetches) is gone. Telegram re-encodes to JPEG (long edge resampled to 2560 px), so PNG stays the source format: exactly one lossy generation.

Includes the `prevalidate` → `resolve` rename: the name now says what the function does (fetch → verify → ladder → bytes), not what it did when its only job was URL pre-checking.

### Net-state harvest
Cut fresh off upstream `a4870089`; carries the final file states of the fork's prod lineage — bytes delivery `33503dc7`, ladder `30b073fb`, local-renderer removal `346bf3c2`, rename `ebe9a526`, test-seam fixes `feba202f`, fmt/clippy clearance `6ceaa83f`/`55b93053` (files in this diff only). The local-render add+remove churn nets to zero and is not replayed. No manifest changes — the feature needs no new deps. Sibling fork-lane fixes are excluded and tracked separately on the fork.

### Production evidence (fork box, telegram-only binary)
| Datum | Value |
|---|---|
| Build gate | run `33120128364` GREEN — ORDER gates + Linux amd64, `cargo test --locked --all-features` clean, sha `feba202f…` |
| Provenance | artifact == `/proc/exe` == disk sha256 byte-exact; ELF markers: `attach://` + `mermaid.ink` present, zero local-render symbols |
| Smoke | 44-node `flowchart TD` (1611×3727, combined 5338) delivered as a **photo** on rung 1 — natural size, no clamp needed |
| Verdict | owner-approved 2026-08-28 ("yes, it's an image") |

Original issue (closed; superseded by this design): https://github.com/adolfousier/opencrabs/issues/1238
