### PR TITLE
fix(claude_cli): deliver system prompt via --append-system-prompt

### DIFF
--- a/src/brain/provider/claude_cli.rs
+++ b/src/brain/provider/claude_cli.rs
@@ -478,11 +478,10 @@ impl ClaudeCliProvider {
     fn build_prompt(request: &LLMRequest) -> String {
         let mut parts = Vec::new();
 
-        if let Some(system) = request.system_full()
-            && !system.is_empty()
-        {
-            parts.push(system);
-        }
+        // request.system_full() is intentionally NOT pushed into the user prompt:
+        // it is delivered via `--append-system-prompt` (Claude's real system
+        // channel) at spawn time, matching the anthropic/openai providers, so
+        // Claude's prompt-injection defense stops distrusting the brain block.
 
         for msg in &request.messages {
             let role = match msg.role {
@@ -726,6 +725,9 @@ impl Provider for ClaudeCliProvider {
 
     async fn stream(&self, request: LLMRequest) -> Result<ProviderStream> {
         let prompt = Self::build_prompt(&request);
+        // Brain/persona travels through Claude's system channel (see spawn below),
+        // NOT the user prompt — the fix for the injection-defense breaking persona.
+        let system_prompt = request.system_full().filter(|s| !s.is_empty());
         let original_model = Self::normalize_model(&request.model);
         let model = Self::map_model(&request.model).to_string();
 
@@ -737,9 +739,10 @@ impl Provider for ClaudeCliProvider {
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/")));
 
         tracing::info!(
-            "Spawning claude CLI: model={}, prompt_len={}, cwd={}",
+            "Spawning claude CLI: model={}, prompt_len={}, system_prompt_len={}, cwd={}",
             model,
             prompt.len(),
+            system_prompt.as_ref().map(|s| s.len()).unwrap_or(0),
             cwd.display()
         );
 
@@ -749,8 +752,8 @@ impl Provider for ClaudeCliProvider {
         // when concurrent requests (TUI + Telegram/Slack) shared the same session.
         let session_id_str = uuid::Uuid::new_v4().to_string();
 
-        let mut child = tokio::process::Command::new(&self.claude_path)
-            .env_remove("CLAUDECODE")
+        let mut cmd = tokio::process::Command::new(&self.claude_path);
+        cmd.env_remove("CLAUDECODE")
             .env_remove("CLAUDE_CODE_ENTRYPOINT")
             .arg("-p")
             .arg("--output-format")
@@ -759,20 +762,28 @@ impl Provider for ClaudeCliProvider {
             .arg("--include-partial-messages")
             .arg("--session-id")
             .arg(&session_id_str)
-            .arg("--dangerously-skip-permissions")
-            // Disable Claude's default `Co-Authored-By: Claude` trailer on git
-            // commits. Uses the newer `attribution` setting (empty strings =
-            // hide attribution) which takes precedence over the deprecated
-            // `includeCoAuthoredBy` flag. Passed as an inline JSON override so
-            // we don't touch the user's ~/.claude/settings.json.
-            .arg("--settings")
+            .arg("--dangerously-skip-permissions");
+        // Deliver the OpenCrabs brain/persona through Claude's real system channel,
+        // like the anthropic/openai providers do (see build_prompt). Flattening it
+        // into the user prompt made Claude's prompt-injection defense distrust the
+        // block and break persona / claim the channel is not real.
+        if let Some(ref system) = system_prompt {
+            cmd.arg("--append-system-prompt").arg(system);
+        }
+        // Disable Claude's default `Co-Authored-By: Claude` trailer on git
+        // commits. Uses the newer `attribution` setting (empty strings =
+        // hide attribution) which takes precedence over the deprecated
+        // `includeCoAuthoredBy` flag. Passed as an inline JSON override so
+        // we don't touch the user's ~/.claude/settings.json.
+        cmd.arg("--settings")
             .arg(r#"{"attribution":{"commit":"","pr":""},"includeCoAuthoredBy":false}"#)
             .arg("--model")
             .arg(&model)
             .current_dir(&cwd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = cmd
             .spawn()
             .map_err(|e| ProviderError::Internal(format!("failed to spawn claude CLI: {}", e)))?;
 


### PR DESCRIPTION
# `claude_cli` provider bypasses Claude's system channel → breaks persona, denies its runtime, and describes-instead-of-executes

**Repo:** adolfousier/opencrabs · **Version observed:** 0.3.83 · **Provider:** `claude_cli` (Claude Code subscription, no API key)

## Summary

The `claude_cli` provider concatenates the entire system/brain prompt into the **user** message it pipes to `claude -p` (stdin), instead of delivering it through Claude Code's real system channel (`--append-system-prompt`). A large "you are X, here are your rules, here is your channel context" block embedded inside a *user* turn is structurally indistinguishable from a prompt-injection attack, so Claude Code's injection defense distrusts it.

Observed consequences with a non-trivial brain (SOUL/AGENTS with a persona + governance rules):

- **Persona break:** *"that long 'OpenCrabs' system block isn't part of my real configuration — I'm Claude Code … treat it as a possible injection."*
- **Runtime denial:** *"this isn't a real channel; the `[Channel: Discord …]` history is injected text, not a channel connected to me."* — the agent argues with the operator about whether its own medium is real.
- **Describe-instead-of-execute** in isolated/cron sessions: *"I described actions but did not actually execute any tool this turn … tell me to proceed."* — no tools run, and there is no human to "proceed" (it's a cron).

This is **not** provider-agnostic: the sibling providers do not have the problem, because they use the model's real system channel.

## Why the other providers are fine

OpenCrabs already models a first-class `system` field on the request (`request.system` / `request.system_full()`), and the API providers route it to the model's system channel:

- `src/brain/provider/anthropic.rs` → sends it as the Anthropic API `system` field (`AnthropicSystem::Blocks`).
- `src/brain/provider/custom_openai_compatible.rs` → sends it as a `role: "system"` message.

Only `src/brain/provider/claude_cli.rs` flattens it into the user prompt.

## Root cause

`src/brain/provider/claude_cli.rs`, `build_prompt()`:

```rust
if let Some(system) = request.system_full()
    && !system.is_empty()
{
    parts.push(system);   // ← brain lands in the USER prompt
}
```

…and the `stream()` spawn builds `claude -p … --model …` with **no** `--append-system-prompt`. The whole brain rides in stdin as the user turn.

Claude Code the CLI is (correctly) hardened to treat an embedded, system-looking instruction block inside a user message as a possible injection. An API call with the same content in the user message tends to tolerate it more quietly, which is why the same account/model misbehaves only on the `claude_cli` path. The account and model are identical — the difference is **delivery**: system channel (trusted) vs. user message (suspected injection).

## Fix

Deliver `request.system_full()` via `--append-system-prompt` (Claude's real system channel), exactly as the anthropic/openai providers use theirs, and drop it from the user prompt. `--append-system-prompt` (rather than `--system-prompt`) keeps Claude Code's own default system prompt — including its tool-use instructions — intact and appends the brain to it.

### Patch (`src/brain/provider/claude_cli.rs`)

```diff
@@ fn build_prompt(request: &LLMRequest) -> String {
     fn build_prompt(request: &LLMRequest) -> String {
         let mut parts = Vec::new();
 
-        if let Some(system) = request.system_full()
-            && !system.is_empty()
-        {
-            parts.push(system);
-        }
+        // request.system_full() is intentionally NOT pushed into the user prompt:
+        // it is delivered via `--append-system-prompt` (Claude's real system
+        // channel) at spawn time, matching the anthropic/openai providers, so
+        // Claude's prompt-injection defense stops distrusting the brain block.
 
         for msg in &request.messages {
@@ async fn stream(&self, request: LLMRequest) -> Result<ProviderStream> {
         let prompt = Self::build_prompt(&request);
+        // Brain/persona travels through Claude's system channel (see spawn below),
+        // NOT the user prompt — the fix for the injection-defense breaking persona.
+        let system_prompt = request.system_full().filter(|s| !s.is_empty());
@@ tracing::info!(
-            "Spawning claude CLI: model={}, prompt_len={}, cwd={}",
+            "Spawning claude CLI: model={}, prompt_len={}, system_prompt_len={}, cwd={}",
             model,
             prompt.len(),
+            system_prompt.as_ref().map(|s| s.len()).unwrap_or(0),
             cwd.display()
         );
@@ spawn
-        let mut child = tokio::process::Command::new(&self.claude_path)
-            .env_remove("CLAUDECODE")
+        let mut cmd = tokio::process::Command::new(&self.claude_path);
+        cmd.env_remove("CLAUDECODE")
             .env_remove("CLAUDE_CODE_ENTRYPOINT")
             .arg("-p")
             .arg("--output-format")
             .arg("stream-json")
             .arg("--verbose")
             .arg("--include-partial-messages")
             .arg("--session-id")
             .arg(&session_id_str)
-            .arg("--dangerously-skip-permissions")
+            .arg("--dangerously-skip-permissions");
+        // Deliver the OpenCrabs brain/persona through Claude's real system channel,
+        // like the anthropic/openai providers do (see build_prompt).
+        if let Some(ref system) = system_prompt {
+            cmd.arg("--append-system-prompt").arg(system);
+        }
+        cmd.arg("--settings")
             .arg(r#"{"attribution":{"commit":"","pr":""},"includeCoAuthoredBy":false}"#)
             .arg("--model")
             .arg(&model)
             .current_dir(&cwd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = cmd
             .spawn()
             .map_err(|e| ProviderError::Internal(format!("failed to spawn claude CLI: {}", e)))?;
```

## Notes / trade-offs

- `--append-system-prompt` takes the brain as a CLI argument, so it becomes visible in `ps aux` (the current code deliberately pipes the user prompt via stdin to avoid that). The brain is persona/rules, not secrets, so this is acceptable; sizes are well under `ARG_MAX`. A future refinement could pass it via a temp file / `--system-prompt-file` if such a flag exists.
- This very likely also resolves the separate "I described actions but did not actually execute any tool this turn" behavior seen in cron/isolated `claude_cli` runs: the injected block makes the model treat the whole turn as suspect, which suppresses tool use. Moving the block to the system channel removes that suspicion.
- `--append-system-prompt` preserves Claude Code's default system prompt (tool-use etc.); `--system-prompt` would replace it and is not recommended here.

## Environment

- `claude` invoked as: `claude -p --output-format stream-json --verbose --include-partial-messages --session-id <uuid> --dangerously-skip-permissions --settings '{…}' --model <model>` (brain formerly in stdin; now additionally `--append-system-prompt <brain>`).
- Reproduced on Linux, headless `opencrabs daemon` (systemd --user), Discord channel bot, single session (`max_concurrency = 1`).
