### PR TITLE
feat(session_notify): interrupt failsafe gate for mid-flight targets

### DIFF
--- a/src/brain/agent/service/session_routes.rs
+++ b/src/brain/agent/service/session_routes.rs
@@ -121,7 +121,9 @@ static TURN_PROBES: Mutex<Option<HashMap<Uuid, TurnProbe>>> = Mutex::new(None);
 pub fn register_turn_probe(session_id: Uuid, probe: TurnProbe) {
     match TURN_PROBES.lock() {
         Ok(mut guard) => {
-            guard.get_or_insert_with(HashMap::new).insert(session_id, probe);
+            guard
+                .get_or_insert_with(HashMap::new)
+                .insert(session_id, probe);
         }
         Err(e) => {
             tracing::error!(
@@ -177,16 +179,15 @@ pub enum Delivery {
 /// state (no probe registered) delivers: the gate must never make a surface
 /// unnotifyable.
 pub fn deliver_to_session(session_id: Uuid, msg: QueuedUserMessage, interrupt: bool) -> Delivery {
-    if !interrupt {
-        if let Some(probe) = turn_probe(session_id) {
-            if probe() {
-                tracing::info!(
-                    target: "background_task",
-                    "Refusing delivery to session {session_id}: mid-turn and interrupt not set"
-                );
-                return Delivery::RefusedInFlight;
-            }
-        }
+    if !interrupt
+        && let Some(probe) = turn_probe(session_id)
+        && probe()
+    {
+        tracing::info!(
+            target: "background_task",
+            "Refusing delivery to session {session_id}: mid-turn and interrupt not set"
+        );
+        return Delivery::RefusedInFlight;
     }
     if let Some(route) = session_route(session_id) {
         route(session_id, msg);

--- a/src/brain/agent/service/session_routes.rs
+++ b/src/brain/agent/service/session_routes.rs
@@ -12,7 +12,7 @@
 //! unrelated concerns shared one file and one set of locks to reason about.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use uuid::Uuid;
 
@@ -105,6 +105,47 @@ pub fn register_local_route(enqueue: MessageEnqueueCallback) {
     }
 }
 
+/// Is `session_id` mid-turn right now?
+///
+/// Channels that expose turn state (telegram's #501/#845 gate) register a
+/// probe beside their delivery route; surfaces without one simply don't,
+/// which the gate below reads as "unknown" and fails open — a headless
+/// session must stay notifyable. The probe captures an `Arc` of the channel
+/// state, so it stays valid across route re-binds and reconnects.
+pub type TurnProbe = Arc<dyn Fn() -> bool + Send + Sync>;
+
+/// Per-session in-flight probes, keyed like [`SESSION_ROUTES`].
+static TURN_PROBES: Mutex<Option<HashMap<Uuid, TurnProbe>>> = Mutex::new(None);
+
+/// Register (or replace) the in-flight probe for `session_id`.
+pub fn register_turn_probe(session_id: Uuid, probe: TurnProbe) {
+    match TURN_PROBES.lock() {
+        Ok(mut guard) => {
+            guard.get_or_insert_with(HashMap::new).insert(session_id, probe);
+        }
+        Err(e) => {
+            tracing::error!(
+                target: "background_task",
+                "Could not register the in-flight probe for session {session_id}: {e}"
+            );
+        }
+    }
+}
+
+/// The session's in-flight probe, if its channel registered one.
+fn turn_probe(session_id: Uuid) -> Option<TurnProbe> {
+    match TURN_PROBES.lock() {
+        Ok(guard) => guard.as_ref()?.get(&session_id).cloned(),
+        Err(e) => {
+            tracing::error!(
+                target: "background_task",
+                "Could not read the in-flight probe for session {session_id}: {e}"
+            );
+            None
+        }
+    }
+}
+
 /// What happened to a message handed to [`deliver_to_session`].
 ///
 /// A bare bool used to be enough, because the only two outcomes were "went
@@ -120,11 +161,33 @@ pub enum Delivery {
     Parked,
     /// Nothing can receive it and nothing is holding it.
     NoRoute,
+    /// The target is mid-turn and the caller did not ask to interrupt
+    /// (fork #13). Nothing was delivered; the sender retries when the
+    /// target goes idle, or resends with `interrupt` set.
+    RefusedInFlight,
 }
 
 /// Deliver `msg` to whoever owns `session_id`, falling back to the booting
 /// surface, parking it when a channel owns the session but has not claimed it.
-pub fn deliver_to_session(session_id: Uuid, msg: QueuedUserMessage) -> Delivery {
+///
+/// `interrupt` is the failsafe valve (fork #13): a push into a streaming turn
+/// arrives in the receiver's context as a bare user message — receivers
+/// task-switch or skim past it. Unless the sender explicitly asked to
+/// interrupt, delivery is refused while the target is mid-turn. Unknown turn
+/// state (no probe registered) delivers: the gate must never make a surface
+/// unnotifyable.
+pub fn deliver_to_session(session_id: Uuid, msg: QueuedUserMessage, interrupt: bool) -> Delivery {
+    if !interrupt {
+        if let Some(probe) = turn_probe(session_id) {
+            if probe() {
+                tracing::info!(
+                    target: "background_task",
+                    "Refusing delivery to session {session_id}: mid-turn and interrupt not set"
+                );
+                return Delivery::RefusedInFlight;
+            }
+        }
+    }
     if let Some(route) = session_route(session_id) {
         route(session_id, msg);
         return Delivery::Delivered;

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -30,9 +30,11 @@ impl Tool for SessionNotifyTool {
     fn description(&self) -> &str {
         "Push a message to another session's queue in this process. The target \
          drains it at its next tool-loop boundary, or wakes immediately if idle. \
-         Every delivery carries a mechanical header [session-notify from=<sender \
-         session id>]; to reply, call session_notify with target_session set to \
-         that id. Discover target ids via session_search list/query."
+         Refuses while the target is mid-turn unless interrupt=true — do not \
+         derail a working session by default. Every delivery carries a \
+         mechanical header [session-notify from=<sender session id>]; to reply, \
+         call session_notify with target_session set to that id. Discover \
+         target ids via session_search list/query."
     }
 
     fn input_schema(&self) -> Value {
@@ -46,6 +48,10 @@ impl Tool for SessionNotifyTool {
                 "message": {
                     "type": "string",
                     "description": "Text to deliver to the target session"
+                },
+                "interrupt": {
+                    "type": "boolean",
+                    "description": "Deliver even if the target session is mid-turn. Default false: the tool REFUSES while the target is streaming, so a working session is never derailed. Set true only when the target must see this now; the message then queues for its next tool-loop boundary, framed as arrived-during-work."
                 }
             },
             "required": ["target_session", "message"]
@@ -87,9 +93,15 @@ impl Tool for SessionNotifyTool {
             origin: crate::brain::agent::PushOrigin::SessionNotify,
         };
 
+        // Failsafe default (fork #13): an unset interrupt must not derail a
+        // session that is mid-turn. The refusal names the remedy so the
+        // calling model learns the knob from the error itself — same pattern
+        // as the 429 RetryAfter help text.
+        let interrupt = input.get("interrupt").and_then(Value::as_bool).unwrap_or(false);
+
         use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};
 
-        match deliver_to_session(target, msg) {
+        match deliver_to_session(target, msg, interrupt) {
             Delivery::Delivered => Ok(ToolResult::success(format!(
                 "Delivered to session {target}. It will process the message on its next turn."
             ))),
@@ -100,6 +112,12 @@ impl Tool for SessionNotifyTool {
                 "Queued for session {target}. Its channel has not claimed it since the last \
                  restart, so it will be delivered as soon as that channel next binds the \
                  session."
+            ))),
+            Delivery::RefusedInFlight => Ok(ToolResult::error(format!(
+                "Refused: session {target} is mid-turn (a turn is streaming) and interrupt \
+                 was not set — delivering now would derail its current task. Retry when the \
+                 session goes idle, or resend with interrupt=true to queue the message for \
+                 its in-flight turn's next tool-loop boundary."
             ))),
             Delivery::NoRoute => Ok(ToolResult::error(format!(
                 "No live route for session {target} in this process — it has not messaged \

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -97,7 +97,10 @@ impl Tool for SessionNotifyTool {
         // session that is mid-turn. The refusal names the remedy so the
         // calling model learns the knob from the error itself — same pattern
         // as the 429 RetryAfter help text.
-        let interrupt = input.get("interrupt").and_then(Value::as_bool).unwrap_or(false);
+        let interrupt = input
+            .get("interrupt")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
 
         use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};
 

--- a/src/brain/tools/subagent/spawn.rs
+++ b/src/brain/tools/subagent/spawn.rs
@@ -114,6 +114,16 @@ pub(crate) fn push_result(
                  {parent_session_id}; the parent will not hear about it"
             );
         }
+        Delivery::RefusedInFlight => {
+            // Unreachable by construction: interrupt=true is passed above and
+            // the fork #13 gate refuses only when interrupt is unset. Arm kept
+            // explicit so a future call-site change cannot drop the outcome
+            // silently (port seam: upstream's match has no catch-all).
+            tracing::warn!(
+                "Sub-agent {agent_id}'s result was refused by the interrupt gate \
+                 for session {parent_session_id}; the parent will not hear about it"
+            );
+        }
     }
 }
 

--- a/src/brain/tools/subagent/spawn.rs
+++ b/src/brain/tools/subagent/spawn.rs
@@ -90,7 +90,10 @@ pub(crate) fn push_result(
     use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};
 
     let msg = completion_message(label, agent_id, outcome);
-    match deliver_to_session(parent_session_id, msg) {
+    // interrupt=true (fork #13): a sub-agent completion is the parent's own
+    // awaited work — it must reach the parent even mid-turn, exactly as
+    // before the gate existed.
+    match deliver_to_session(parent_session_id, msg, true) {
         Delivery::Delivered => {
             tracing::info!(
                 "Sub-agent {agent_id} reported its result to session {parent_session_id}"

--- a/src/brain/tools/telegram_send.rs
+++ b/src/brain/tools/telegram_send.rs
@@ -612,7 +612,9 @@ impl TelegramSendTool {
                 Err(e) => {
                     // Fall through to the HTML edit on any rich failure so
                     // the edit is never dropped.
-                    tracing::warn!("telegram_send edit: native rich edit failed ({e}) — falling back to HTML");
+                    tracing::warn!(
+                        "telegram_send edit: native rich edit failed ({e}) — falling back to HTML"
+                    );
                 }
             }
         }

--- a/src/channels/telegram/commands_tg.rs
+++ b/src/channels/telegram/commands_tg.rs
@@ -158,7 +158,8 @@ pub(crate) async fn handle_channel_command(
                     // A short delivery finishes publicly: dropping the tail
                     // would truncate the reply with nothing to show for it.
                     for chunk in chunks.iter().skip(delivered) {
-                        send_html_or_plain(bot, msg.chat.id, thread_id, chunk, "turn", None).await?;
+                        send_html_or_plain(bot, msg.chat.id, thread_id, chunk, "turn", None)
+                            .await?;
                     }
                     return Ok(CommandOutcome::Handled);
                 }

--- a/src/channels/telegram/delivery.rs
+++ b/src/channels/telegram/delivery.rs
@@ -883,9 +883,10 @@ pub(crate) async fn deliver_final_response(
                                     "Telegram: edit final failed ({e}), falling back to delete+send"
                                 );
                                 best_effort_delete(bot, chat_id, mid, "edit-final fallback").await;
-                                if let Ok(sent) =
-                                    send_html_or_plain(bot, chat_id, thread_id, &chunks[0], "turn", None)
-                                        .await
+                                if let Ok(sent) = send_html_or_plain(
+                                    bot, chat_id, thread_id, &chunks[0], "turn", None,
+                                )
+                                .await
                                 {
                                     sent_reply_id = Some(sent.0);
                                     final_bubble = Some(super::state::MergeBubble {
@@ -903,7 +904,8 @@ pub(crate) async fn deliver_final_response(
                         for chunk in &chunks {
                             // Last chunk wins — that's the bubble a user replies to.
                             if let Ok(sent) =
-                                send_html_or_plain(bot, chat_id, thread_id, chunk, "turn", None).await
+                                send_html_or_plain(bot, chat_id, thread_id, chunk, "turn", None)
+                                    .await
                             {
                                 sent_reply_id = Some(sent.0);
                                 final_bubble = Some(super::state::MergeBubble {

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -1855,6 +1855,18 @@ pub(crate) async fn handle_message(
         agent.message_enqueue_callback(),
     );
 
+    // Expose this session's turn state to the delivery gate (fork #13): a
+    // session_notify without interrupt=true must refuse while a turn is
+    // streaming instead of dropping a bare user message into it. The probe
+    // captures this state Arc, so it stays valid across route re-binds.
+    {
+        let probe_state = telegram_state.clone();
+        crate::brain::agent::service::session_routes::register_turn_probe(
+            session_id,
+            std::sync::Arc::new(move || probe_state.is_turn_active(session_id)),
+        );
+    }
+
     // Archive any shared images under the session's project files dir (when the
     // session is assigned to a project) so a project's media lives together and
     // survives the tmp purge. Rewrites the <<IMG:tmp>> marker to the archived

--- a/src/channels/telegram/plan_card.rs
+++ b/src/channels/telegram/plan_card.rs
@@ -645,9 +645,7 @@ async fn finalize_plan_card_locked(
     // FIRST, so a post failure can fall back to the card already present — the
     // completed form is never lost.
     let mut posted: Option<MessageId> = None;
-    if use_rich
-        && let Some(rich) = &rich
-    {
+    if use_rich && let Some(rich) = &rich {
         // G3 send pacing (#1211): a fresh card is a full message post.
         super::governor::pace_send(chat).await;
         match super::rich::api::send_rich_html_id(
@@ -695,9 +693,7 @@ async fn finalize_plan_card_locked(
                 return;
             };
             let mut edited = false;
-            if use_rich
-                && let Some(rich) = &rich
-            {
+            if use_rich && let Some(rich) = &rich {
                 match super::rich::api::edit_rich_html(
                     bot.api_url().as_str(),
                     bot.token(),
@@ -711,7 +707,9 @@ async fn finalize_plan_card_locked(
                 .await
                 {
                     Ok(()) => edited = true,
-                    Err(e) => tracing::debug!("Telegram plan card rich finalize failed ({mid:?}): {e}"),
+                    Err(e) => {
+                        tracing::debug!("Telegram plan card rich finalize failed ({mid:?}): {e}")
+                    }
                 }
             }
             if !edited

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -190,6 +190,17 @@ pub(crate) fn build_enqueue_callback(
                 // nothing will drain this between rounds and the end-of-turn
                 // flush has to know it needs a real tool loop, not a single
                 // toolless round.
+                // Framing for mid-flight drains (fork #13): the queued push
+                // arrives in the receiver's context as a bare user turn,
+                // indistinguishable from a fresh instruction — the confusion
+                // the interrupt gate's true-branch knowingly accepts. One
+                // plain string tells the receiver to re-anchor after reading.
+                let mut msg = msg;
+                msg.context_text = format!(
+                    "[queued while you were working — re-anchor to your current task after \
+                     reading this]\n\n{}",
+                    msg.context_text
+                );
                 state.enqueue_detached_result(session_id, msg);
                 return;
             };

--- a/src/channels/telegram/send.rs
+++ b/src/channels/telegram/send.rs
@@ -351,14 +351,9 @@ pub(crate) async fn send_markdown_outbox(
     let mut sent: Vec<(i32, String)> = Vec::new();
     for (i, chunk) in chunks.into_iter().enumerate() {
         match super::intermediates::send_html_or_plain(
-                bot,
-                chat_id,
-                thread_id,
-                chunk,
-                origin,
-                reply_to,
-            )
-            .await
+            bot, chat_id, thread_id, chunk, origin, reply_to,
+        )
+        .await
         {
             Ok(mid) => {
                 super::telemetry::log_send_success(

--- a/src/tests/channel_route_expectation_test.rs
+++ b/src/tests/channel_route_expectation_test.rs
@@ -140,7 +140,7 @@ fn a_sub_agent_result_for_a_revived_session_parks_too() {
     let session = Uuid::new_v4();
 
     expect_channel_route(session);
-    let outcome = deliver_to_session(session, msg("sub-agent result"));
+    let outcome = deliver_to_session(session, msg("sub-agent result"), true);
 
     assert_eq!(
         outcome,

--- a/src/tests/plan_completed_persist_test.rs
+++ b/src/tests/plan_completed_persist_test.rs
@@ -45,7 +45,11 @@ fn archive_as_stemmed(json_path: &std::path::Path, stamp: &str, title: &str) {
     let dir = json_path.parent().unwrap().join("archive");
     std::fs::create_dir_all(&dir).unwrap();
     let stem = json_path.file_stem().and_then(|s| s.to_str()).unwrap();
-    std::fs::write(dir.join(format!("{stem}-{stamp}.json")), finished_plan_json(title)).unwrap();
+    std::fs::write(
+        dir.join(format!("{stem}-{stamp}.json")),
+        finished_plan_json(title),
+    )
+    .unwrap();
 }
 
 #[test]

--- a/src/tests/session_notify_test.rs
+++ b/src/tests/session_notify_test.rs
@@ -9,7 +9,9 @@ use uuid::Uuid;
 
 use crate::brain::agent::QueuedUserMessage;
 use crate::brain::agent::service::restart_recovery::{expect_channel_route, test_guard};
-use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session, register_turn_probe};
+use crate::brain::agent::service::session_routes::{
+    Delivery, deliver_to_session, register_turn_probe,
+};
 use crate::brain::tools::subagent::SessionNotifyTool;
 use crate::brain::tools::r#trait::Tool;
 
@@ -162,6 +164,11 @@ fn test_no_probe_fails_open() {
 }
 
 #[tokio::test]
+// #13: the guard serializes suites touching the process-global route and
+// probe tables; holding it across the tool `.await` below is the entire
+// point — the awaited delivery must not interleave with another test's
+// registration. Same shape as the parked-queue tests above (#1206).
+#[allow(clippy::await_holding_lock)]
 async fn test_tool_reports_refusal_with_remedy() {
     let _guard = test_guard();
     let session = Uuid::new_v4();
@@ -176,7 +183,10 @@ async fn test_tool_reports_refusal_with_remedy() {
         )
         .await;
     let result = outcome.expect("tool executes");
-    assert!(!result.success, "#13: refusal must read as failure to the sender");
+    assert!(
+        !result.success,
+        "#13: refusal must read as failure to the sender"
+    );
     let error = result.error.expect("#13: refusal carries an explanation");
     assert!(
         error.contains("interrupt=true"),
@@ -185,12 +195,15 @@ async fn test_tool_reports_refusal_with_remedy() {
 }
 
 #[tokio::test]
+// Same serialization contract as the refusal test above (#13): the guard
+// must outlive the awaited delivery, or another test could re-register the
+// route mid-flight.
+#[allow(clippy::await_holding_lock)]
 async fn test_tool_interrupt_param_reaches_delivery() {
     let _guard = test_guard();
     let session = Uuid::new_v4();
-    let captured: std::sync::Arc<
-        std::sync::Mutex<Option<QueuedUserMessage>>,
-    > = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let captured: std::sync::Arc<std::sync::Mutex<Option<QueuedUserMessage>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(None));
     let sink = captured.clone();
     crate::brain::agent::service::session_routes::register_session_route(
         session,
@@ -211,10 +224,15 @@ async fn test_tool_interrupt_param_reaches_delivery() {
             &context,
         )
         .await;
-    assert!(outcome.expect("tool executes").success, "interrupt=true must deliver");
+    assert!(
+        outcome.expect("tool executes").success,
+        "interrupt=true must deliver"
+    );
     let queued = captured.lock().unwrap().take().expect("message enqueued");
     assert!(
-        !queued.context_text.contains("queued while you were working"),
+        !queued
+            .context_text
+            .contains("queued while you were working"),
         "framing is added by the channel queue branch, not by the tool"
     );
 }

--- a/src/tests/session_notify_test.rs
+++ b/src/tests/session_notify_test.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::brain::agent::QueuedUserMessage;
 use crate::brain::agent::service::restart_recovery::{expect_channel_route, test_guard};
-use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};
+use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session, register_turn_probe};
 use crate::brain::tools::subagent::SessionNotifyTool;
 use crate::brain::tools::r#trait::Tool;
 
@@ -86,7 +86,7 @@ fn test_a_parked_delivery_is_not_a_missing_route() {
 
     expect_channel_route(session);
 
-    let outcome = deliver_to_session(session, msg());
+    let outcome = deliver_to_session(session, msg(), false);
     assert_eq!(
         outcome,
         Delivery::Parked,
@@ -99,5 +99,122 @@ fn test_a_parked_delivery_is_not_a_missing_route() {
 fn test_an_unroutable_session_is_reported_as_such() {
     let _guard = test_guard();
     // No local route is registered in tests, so nothing can take it.
-    assert_eq!(deliver_to_session(Uuid::new_v4(), msg()), Delivery::NoRoute);
+    assert_eq!(
+        deliver_to_session(Uuid::new_v4(), msg(), false),
+        Delivery::NoRoute
+    );
+}
+
+// ── In-flight gate (fork #13) ────────────────────────────────────────────
+
+#[test]
+fn test_inflight_target_refuses_without_interrupt() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    expect_channel_route(session);
+    register_turn_probe(session, std::sync::Arc::new(|| true));
+    assert_eq!(
+        deliver_to_session(session, msg(), false),
+        Delivery::RefusedInFlight,
+        "#13: default-false must refuse a mid-turn target, not derail it"
+    );
+}
+
+#[test]
+fn test_interrupt_true_delivers_to_inflight_target() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    expect_channel_route(session);
+    register_turn_probe(session, std::sync::Arc::new(|| true));
+    // Parked, not delivered: the channel route is expected but unclaimed, so
+    // the point here is only that the gate let the message THROUGH.
+    assert_eq!(
+        deliver_to_session(session, msg(), true),
+        Delivery::Parked,
+        "#13: interrupt=true rides today's queue-for-boundary semantics"
+    );
+}
+
+#[test]
+fn test_idle_target_delivers_without_interrupt() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    expect_channel_route(session);
+    register_turn_probe(session, std::sync::Arc::new(|| false));
+    assert_eq!(
+        deliver_to_session(session, msg(), false),
+        Delivery::Parked,
+        "#13: idle target — the gate never engages"
+    );
+}
+
+#[test]
+fn test_no_probe_fails_open() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    expect_channel_route(session);
+    // No probe registered: a surface without turn state must stay notifyable.
+    assert_eq!(
+        deliver_to_session(session, msg(), false),
+        Delivery::Parked,
+        "#13: unknown turn state fails open — never refuse on missing semantics"
+    );
+}
+
+#[tokio::test]
+async fn test_tool_reports_refusal_with_remedy() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    expect_channel_route(session);
+    register_turn_probe(session, std::sync::Arc::new(|| true));
+
+    let context = crate::brain::tools::r#trait::ToolExecutionContext::new(Uuid::new_v4());
+    let outcome = SessionNotifyTool
+        .execute(
+            serde_json::json!({"target_session": session.to_string(), "message": "ping"}),
+            &context,
+        )
+        .await;
+    let result = outcome.expect("tool executes");
+    assert!(!result.success, "#13: refusal must read as failure to the sender");
+    let error = result.error.expect("#13: refusal carries an explanation");
+    assert!(
+        error.contains("interrupt=true"),
+        "#13: the error must name the remedy so the sender learns the knob: {error}"
+    );
+}
+
+#[tokio::test]
+async fn test_tool_interrupt_param_reaches_delivery() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    let captured: std::sync::Arc<
+        std::sync::Mutex<Option<QueuedUserMessage>>,
+    > = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let sink = captured.clone();
+    crate::brain::agent::service::session_routes::register_session_route(
+        session,
+        std::sync::Arc::new(move |_id, queued| {
+            *sink.lock().unwrap() = Some(queued);
+        }),
+    );
+    register_turn_probe(session, std::sync::Arc::new(|| true));
+
+    let context = crate::brain::tools::r#trait::ToolExecutionContext::new(Uuid::new_v4());
+    let outcome = SessionNotifyTool
+        .execute(
+            serde_json::json!({
+                "target_session": session.to_string(),
+                "message": "ping",
+                "interrupt": true
+            }),
+            &context,
+        )
+        .await;
+    assert!(outcome.expect("tool executes").success, "interrupt=true must deliver");
+    let queued = captured.lock().unwrap().take().expect("message enqueued");
+    assert!(
+        !queued.context_text.contains("queued while you were working"),
+        "framing is added by the channel queue branch, not by the tool"
+    );
 }

--- a/src/tests/telegram_rich_test.rs
+++ b/src/tests/telegram_rich_test.rs
@@ -54,7 +54,12 @@ fn rich_structure_whitespace_only_false() {
 
 #[test]
 fn rich_request_body_with_thread_id() {
-    let body = build_body(99, Some(ThreadId(MessageId(42))), "| A |\n| - |\n| 1 |", None);
+    let body = build_body(
+        99,
+        Some(ThreadId(MessageId(42))),
+        "| A |\n| - |\n| 1 |",
+        None,
+    );
     assert_eq!(body["chat_id"], 99);
     assert_eq!(body["message_thread_id"], 42);
     assert_eq!(body["rich_message"]["markdown"], "| A |\n| - |\n| 1 |");

--- a/src/utils/plan_files.rs
+++ b/src/utils/plan_files.rs
@@ -485,7 +485,9 @@ pub async fn archive_plan(session_id: Uuid) -> std::io::Result<()> {
 
 /// Path of the durable "just archived" sidecar for `session_id`.
 async fn plan_just_archived_path(session_id: Uuid) -> std::path::PathBuf {
-    archive_dir(session_id).await.join(format!("just_archived_{session_id}.flag"))
+    archive_dir(session_id)
+        .await
+        .join(format!("just_archived_{session_id}.flag"))
 }
 
 /// Stamp that this session's plan was archived on THIS settle.


### PR DESCRIPTION
## What

Adds an opt-in `interrupt` parameter to the `session_notify` tool: a failsafe against derailing sessions that are mid-turn. Default `false` — when the target session is currently streaming a turn, the tool call is refused with a structured explanation instead of injecting the message mid-flight. Explicit `interrupt=true` delivers anyway, queueing the message for the in-flight turn's next tool-loop boundary with a re-anchoring framing prefix. Idle targets deliver unchanged.

## Why

When a notification from one session lands in another session that is mid-turn, the receiving session often loses track of its current task or silently ignores the injected message. Before this change, `deliver_to_session` had no notion of turn activity — every notification was injected immediately regardless of receiver state, and senders had no way to know they had just derailed a running task.

## Design

- The gate lives at the single delivery choke point: `deliver_to_session(session_id, msg, interrupt)` in `src/brain/agent/service/session_routes.rs`.
- Turn activity is observed through a `TURN_PROBES` registry: channels register a probe closure at turn-claim time (Telegram registers one backed by its existing `active_turns` set, so the check is O(1) and reuses the permit machinery from the detach/attach work). Sessions with no registered probe fail open — delivery proceeds exactly as before, so the change is inert for channels that have not wired a probe yet.
- New `Delivery::RefusedInFlight` variant. `session_notify` surfaces it as a tool error whose text states why delivery was refused and names both remedies: retry when the session goes idle, or resend with `interrupt=true`.
- Internal machinery keeps its old behaviour by passing `interrupt=true` explicitly: `spawn_agent`'s result push into the parent session uses the explicit knob, so sub-agent completion delivery is unaffected.
- Messages queued into an in-flight turn get a framing prefix when they drain, so the receiver knows the text arrived late and can re-anchor: `[queued while you were working — re-anchor to your current task after reading this]`.

## Behaviour matrix

| Target state | interrupt | Outcome |
|---|---|---|
| Idle | false (default) | delivered immediately |
| Mid-turn | false | refused with explanation + remedy |
| Mid-turn | true | queued for next tool-loop boundary, framing prefix added |
| Unknown session / no probe | either | fail-open, delivered as before |

## Tests

Six new tests in `src/tests/session_notify_test.rs` — refuse path, interrupt-through path, idle delivery, fail-open on unknown session, refusal-message content, and tool-parameter wiring — plus call-site updates across the existing suite.

## Verification

- PR-lane gates on the exact head branch (fmt + clippy `--locked --all-features -D warnings` + `cargo test --locked --all-features`, flags verbatim from upstream ci.yml): https://github.com/leshchenko1979/opencrabs/actions/run/33133927869 — green.
- Smoke-tested against a live swapped binary carrying this change:
  1. A notify into a mid-turn session without `interrupt` returned the structured refusal (tool error, not a delivery).
  2. The same notify with `interrupt=true` was accepted and queued.
  3. The queued payload drained at the turn boundary carrying the framing prefix verbatim.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/13
