### PR TITLE
feat(a2a): session/notify — CLI action to send a notification to a session

### DIFF
--- a/src/a2a/handler/mod.rs
+++ b/src/a2a/handler/mod.rs
@@ -1,10 +1,12 @@
 //! JSON-RPC 2.0 handler for A2A protocol operations.
 //!
 //! Dispatches JSON-RPC methods:
-//! - `message/send` → create task + process message via AgentService
-//! - `tasks/get`    → retrieve task by ID
-//! - `tasks/cancel` → cancel a running task
+//! - `message/send`   → create task + process message via AgentService
+//! - `session/notify` → post a notification into a live session's queue (#23)
+//! - `tasks/get`      → retrieve task by ID
+//! - `tasks/cancel`   → cancel a running task
 
+pub(crate) mod notify;
 mod send;
 pub mod stream;
 pub(crate) mod tasks;
@@ -52,6 +54,9 @@ pub async fn dispatch(
                 service_context,
             )
             .await
+        }
+        "session/notify" => {
+            notify::handle_session_notify(req.id, req.params, service_context).await
         }
         "tasks/get" => tasks::handle_get_task(req.id, req.params, store).await,
         "tasks/cancel" => {

--- a/src/a2a/handler/notify.rs
+++ b/src/a2a/handler/notify.rs
@@ -1,0 +1,196 @@
+//! `session/notify` — mechanical session notifications for tooling (#23).
+//!
+//! Thin JSON-RPC wrapper over `session_routes::deliver_to_session`, the SAME
+//! route the agent's `session_notify` tool uses, so external tooling (the
+//! `opencrabs session notify` CLI verb and, on top of it, deploy fan-out)
+//! can post into a live session's queue.
+//!
+//! Zombie-wake guard (#17 class): the target must exist as a row in the
+//! sessions table before the route table is touched at all. An unknown or
+//! dead uuid (NO row — never one that merely changed state) yields
+//! `no_route` without ever reaching `deliver_to_session`, whose local-route
+//! fallback would otherwise inject the message into this process's own boot
+//! channel — traffic resurrected for a session that is gone.
+//!
+//! ARCHIVED rows are NOT dead: they pass the gate like any live session and
+//! flow through the route table exactly as anywhere else. The gate checks
+//! existence only, never activity.
+//!
+//! SENDER FRAMING (owner amendment 2026-08-28, "Overridable"): the CLI lane
+//! has no sender session (it is a separate process), so instead of the
+//! agent tool's `from=<uuid>` the header stamps `from=cli:<label>` —
+//! default [`DEFAULT_CLI_SENDER_LABEL`], overridable via the `sender`
+//! param (CLI: `--sender`). The telegram echo surface renders the label
+//! verbatim; the recipient's model still reads the mechanical frame.
+
+use crate::a2a::types::*;
+use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};
+use crate::brain::agent::{PushOrigin, QueuedUserMessage};
+use crate::services::{ServiceContext, SessionService};
+
+/// The CLI lane's prefix inside the mechanical `[session-notify from=…]`
+/// header (#23). The CLI verb runs as a separate process with no sender
+/// session, so it stamps `cli:<label>` instead of a uuid; the telegram echo
+/// surface (`channels::telegram::resume::split_notify_header`) recognizes
+/// the prefix and renders the carried label verbatim. Agent-to-agent pushes
+/// keep the bare-uuid shape (#1203/#1225).
+pub(crate) const CLI_SENDER_PREFIX: &str = "cli:";
+
+/// Default sender label for CLI notifications (#23) — overridable via the
+/// `sender` JSON-RPC param / the `--sender` CLI flag (owner amendment
+/// 2026-08-28).
+pub(crate) const DEFAULT_CLI_SENDER_LABEL: &str = "CLI tooling";
+
+/// Cap for an overridden sender label: the label rides inside the echo
+/// bubble title, so a pathological value must not eat the preview budget.
+pub(crate) const CLI_SENDER_LABEL_MAX_CHARS: usize = 64;
+
+/// Handle a `session/notify` JSON-RPC call (#23).
+///
+/// Business outcomes are returned as JSON-RPC SUCCESSES carrying
+/// `{outcome, detail}` — the caller maps them to exit codes. The only
+/// JSON-RPC errors this method emits are protocol-level (malformed params,
+/// lookup failure), never delivery results.
+pub async fn handle_session_notify(
+    req_id: serde_json::Value,
+    params: serde_json::Value,
+    service_context: ServiceContext,
+) -> JsonRpcResponse {
+    let session_id = match params.get("session_id").and_then(serde_json::Value::as_str) {
+        Some(raw) => match raw.parse::<uuid::Uuid>() {
+            Ok(id) => id,
+            Err(_) => {
+                return JsonRpcResponse::error(
+                    req_id,
+                    error_codes::INVALID_PARAMS,
+                    format!("'session_id' is not a valid UUID: {raw}"),
+                );
+            }
+        },
+        None => {
+            return JsonRpcResponse::error(
+                req_id,
+                error_codes::INVALID_PARAMS,
+                "'session_id' is required",
+            );
+        }
+    };
+    let message = match params.get("message").and_then(serde_json::Value::as_str) {
+        Some(m) if !m.trim().is_empty() => m.to_string(),
+        _ => {
+            return JsonRpcResponse::error(
+                req_id,
+                error_codes::INVALID_PARAMS,
+                "'message' is required and must be non-empty",
+            );
+        }
+    };
+    let title = params
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string);
+    // Parsed for wire-contract stability: the CLI always sends it, and the
+    // #13 in-flight failsafe harvest will consume it. Upstream
+    // `deliver_to_session` has no refusal path yet, so it stays inert here.
+    let _interrupt = params
+        .get("interrupt")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    // Sender label (#23): no sender session exists for the CLI lane, so the
+    // label is carried verbatim — default DEFAULT_CLI_SENDER_LABEL,
+    // overridable by the caller. Validation: the label rides inside
+    // `[session-notify from=cli:<label>]`, so it may not contain the closing
+    // bracket or newlines, and it is capped to keep the echo title readable.
+    let sender = match params.get("sender").and_then(serde_json::Value::as_str) {
+        Some(raw) => {
+            let label = raw.trim();
+            if label.is_empty() {
+                DEFAULT_CLI_SENDER_LABEL.to_string()
+            } else if label.contains(']') || label.contains('\n') || label.contains('\r') {
+                return JsonRpcResponse::error(
+                    req_id,
+                    error_codes::INVALID_PARAMS,
+                    "'sender' must not contain ']' or newlines",
+                );
+            } else if label.chars().count() > CLI_SENDER_LABEL_MAX_CHARS {
+                return JsonRpcResponse::error(
+                    req_id,
+                    error_codes::INVALID_PARAMS,
+                    format!("'sender' must be at most {CLI_SENDER_LABEL_MAX_CHARS} chars"),
+                );
+            } else {
+                label.to_string()
+            }
+        }
+        None => DEFAULT_CLI_SENDER_LABEL.to_string(),
+    };
+
+    // Zombie-wake guard (#23, #17 class): only a session with a DB row may
+    // be notified. `deliver_to_session` is never touched for a uuid with NO
+    // row — its local-route fallback would hand the message to this
+    // process's own boot channel, resurrecting traffic for a session that no
+    // longer exists. An ARCHIVED row passes: the gate checks existence only,
+    // never activity.
+    let session_svc = SessionService::new(service_context);
+    match session_svc.get_session(session_id).await {
+        Ok(Some(_session)) => {}
+        Ok(None) => {
+            return JsonRpcResponse::success(
+                req_id,
+                serde_json::json!({
+                    "outcome": "no_route",
+                    "detail": format!(
+                        "session {session_id} does not exist — nothing sent, nothing created"
+                    ),
+                }),
+            );
+        }
+        Err(e) => {
+            return JsonRpcResponse::error(
+                req_id,
+                error_codes::INTERNAL_ERROR,
+                format!("session lookup failed: {e}"),
+            );
+        }
+    }
+
+    // Same message shape as the agent's session_notify tool: SessionNotify
+    // origin so the topic-echo surface renders the push (#1221), and a
+    // mechanical sender frame. The CLI lane stamps `cli:<label>` instead of
+    // a uuid — there is no sender session; the echo renders the label
+    // verbatim.
+    let header = match &title {
+        Some(t) => format!("📨 {t} (from {sender}):"),
+        None => format!("📨 notify from {sender}:"),
+    };
+    let msg = QueuedUserMessage {
+        context_text: format!("[session-notify from={CLI_SENDER_PREFIX}{sender}]\n\n{message}"),
+        display_text: format!("{header}\n{message}"),
+        origin: PushOrigin::SessionNotify,
+    };
+
+    let (outcome, detail) = match deliver_to_session(session_id, msg) {
+        Delivery::Delivered => ("delivered", format!("delivered to session {session_id}")),
+        // Queued, not lost: the session's channel has not claimed it since
+        // the last restart (#1206). Reporting this as a failure would be the
+        // opposite of what happened — same reading as the agent tool.
+        Delivery::Parked => (
+            "parked",
+            format!(
+                "queued for session {session_id}: its channel has not claimed it since \
+                 the last restart (#1206) — it delivers on the next claim"
+            ),
+        ),
+        Delivery::NoRoute => (
+            "no_route",
+            format!("no live route for session {session_id} and nothing is holding it"),
+        ),
+    };
+
+    JsonRpcResponse::success(
+        req_id,
+        serde_json::json!({ "outcome": outcome, "detail": detail }),
+    )
+}

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -8,6 +8,7 @@ use super::TelegramState;
 #[allow(unused_imports)]
 use super::handler::*;
 use super::send::{best_effort_delete, fire_chat_action};
+use crate::a2a::handler::notify::CLI_SENDER_PREFIX;
 use crate::brain::agent::{AgentService, ProgressCallback, ProgressEvent};
 use crate::config::Config;
 use crate::db::ChannelMessageRepository;
@@ -78,21 +79,25 @@ pub(crate) fn build_enqueue_callback(
                     | crate::brain::agent::PushOrigin::SessionNotify
             ) {
                 // #1225: session_notify pushes carry a mechanical
-                // `[session-notify from=<uuid>]` header — replace the raw id
-                // with a human label (topic name for same-chat pushes, chat
-                // name / chat+topic for cross-chat, per Alexey's rule), so the
-                // bubble reads "📨 From: Ops / Push to session", not a UUID
-                // spray. Background-task pushes have no sender: the title
-                // names the task from the producer's display line instead of
-                // the generic "⚙️ background task result" (Alexey 2026-08-26).
+                // `[session-notify from=<uuid>]` header — the raw id is
+                // replaced with a human label (topic name for same-chat
+                // pushes, chat name / chat+topic for cross-chat, per
+                // Alexey's rule). CLI notifications (#23) stamp
+                // `from=cli:<label>` instead — no sender session exists,
+                // so the carried label renders verbatim.
                 let (sender, body) = split_bg_echo_parts(&msg.context_text);
-                let title = if let Some(s) = sender {
-                    format!("📨 {}", sender_label(&state, &bot, s, chat_id).await)
-                } else if msg.origin == crate::brain::agent::PushOrigin::BackgroundTask {
-                    // Borrow: `msg` is moved wholesale later in this callback.
-                    background_task_title(&msg.display_text)
-                } else {
-                    "⚙️ background task result".to_owned()
+                let title = match sender {
+                    Some(NotifySender::Session(s)) => {
+                        format!("📨 {}", sender_label(&state, &bot, s, chat_id).await)
+                    }
+                    // CLI lane (#23): no sender session to humanize — the
+                    // carried label renders verbatim, zero API lookups.
+                    Some(NotifySender::CliTooling(label)) => format!("📨 {label}"),
+                    None if msg.origin == crate::brain::agent::PushOrigin::BackgroundTask => {
+                        // Borrow: `msg` is moved wholesale later in this callback.
+                        background_task_title(&msg.display_text)
+                    }
+                    None => "⚙️ background task result".to_owned(),
                 };
                 let (_, classic_html) = build_bg_echo_bubble(&body, &title);
                 // Rich dialect needs the RICH envelope: `<details><summary>`
@@ -686,9 +691,27 @@ pub(crate) async fn resume_session_inner(
 /// chars; header, tags and Telegram's own margin eat the rest of the budget.
 const BG_ECHO_BODY_CAP_CHARS: usize = 3200;
 
+/// Producer stamped into a `[session-notify from=…]` header.
+///
+/// Cross-session pushes name the real sender session uuid (the agent tool,
+/// #1203) — the echo humanizes it via [`sender_label`]. The CLI lane (#23)
+/// has NO sender session (the verb runs as a separate process), so it
+/// stamps `cli:<label>` ([`CLI_SENDER_PREFIX`]); the echo renders the
+/// carried label verbatim instead of a session lookup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NotifySender<'a> {
+    /// A real sender session (`from=<uuid>`).
+    Session(Uuid),
+    /// The CLI lane (`from=cli:<label>`, #23): the label renders verbatim.
+    CliTooling(&'a str),
+}
+
 /// Split the mechanical `[session-notify from=<uuid>]` header (#1203) off a
 /// push's context text. Absent or malformed header → `(None, whole text)`.
-pub(crate) fn split_notify_header(context_text: &str) -> (Option<Uuid>, &str) {
+/// A `cli:`-prefixed sender (#23) yields [`NotifySender::CliTooling`]
+/// carrying the label after the prefix; an EMPTY label is malformed and
+/// falls through to `(None, whole text)`.
+pub(crate) fn split_notify_header(context_text: &str) -> (Option<NotifySender<'_>>, &str) {
     let trimmed = context_text.trim_start();
     let Some(after_open) = trimmed.strip_prefix("[session-notify from=") else {
         return (None, trimmed);
@@ -697,8 +720,15 @@ pub(crate) fn split_notify_header(context_text: &str) -> (Option<Uuid>, &str) {
         return (None, trimmed);
     };
     let rest = after_open[close + 1..].trim_start();
-    match Uuid::parse_str(&after_open[..close]) {
-        Ok(sender) => (Some(sender), rest),
+    let candidate = &after_open[..close];
+    if let Some(label) = candidate.strip_prefix(CLI_SENDER_PREFIX) {
+        let label = label.trim();
+        if !label.is_empty() {
+            return (Some(NotifySender::CliTooling(label)), rest);
+        }
+    }
+    match Uuid::parse_str(candidate) {
+        Ok(sender) => (Some(NotifySender::Session(sender)), rest),
         Err(_) => (None, trimmed),
     }
 }
@@ -725,7 +755,7 @@ pub(crate) fn strip_system_framing(text: &str) -> &str {
 /// is the real payload. Strip the wrapper, keep inner content + tail (#1225
 /// leftover: the squash shipped tests asserting this shape but the old
 /// whole-string-only strip could never satisfy them).
-pub(crate) fn split_bg_echo_parts(context_text: &str) -> (Option<Uuid>, String) {
+pub(crate) fn split_bg_echo_parts(context_text: &str) -> (Option<NotifySender<'_>>, String) {
     let (sender, rest) = split_notify_header(context_text);
     (sender, strip_push_scaffolding(rest))
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -339,6 +339,26 @@ pub enum SessionCommands {
         #[arg(long)]
         all: bool,
     },
+    /// Send a notification to a session (#23)
+    Notify {
+        /// Target session UUID
+        id: String,
+        /// Message text
+        #[arg(long)]
+        text: String,
+        /// Optional title header
+        #[arg(long)]
+        title: Option<String>,
+        /// Sender label shown to the recipient (default: "CLI tooling")
+        #[arg(long)]
+        sender: Option<String>,
+        /// Deliver even if the session is mid-turn (#13 failsafe)
+        #[arg(long)]
+        interrupt: bool,
+        /// CLI output format
+        #[arg(short, long, default_value = "text")]
+        format: OutputFormat,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1611,6 +1611,26 @@ pub(crate) async fn cmd_session(
             }
             Ok(())
         }
+        SessionCommands::Notify {
+            id,
+            text,
+            title,
+            sender,
+            interrupt,
+            format,
+        } => {
+            crate::cli::session_notify::run(
+                config,
+                &id,
+                &text,
+                title.as_deref(),
+                sender.as_deref(),
+                interrupt,
+                format,
+            )
+            .await?;
+            Ok(())
+        }
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod daemon_health;
 pub(crate) mod doctor_fix;
 pub(crate) mod headless_callbacks;
 pub(crate) mod migrate;
+pub(crate) mod session_notify;
 pub(crate) mod session_set_model;
 pub(crate) mod tool_setup;
 mod ui;

--- a/src/cli/session_notify.rs
+++ b/src/cli/session_notify.rs
@@ -1,0 +1,249 @@
+//! `opencrabs session notify` — mechanical session notifications for
+//! tooling (#23).
+//!
+//! The CLI is a SEPARATE PROCESS from the daemon that owns the in-memory
+//! route table, so the verb posts over the profile's A2A gateway — the
+//! daemon's HTTP surface — where the `session/notify` method hands the
+//! message to `deliver_to_session`, the same route the agent's
+//! session_notify tool uses (including #1206 parking).
+//!
+//! Exit codes are the machine contract for tooling (deploy fan-out):
+//!
+//! | exit | meaning                                             |
+//! |------|-----------------------------------------------------|
+//! | 0    | delivered / parked — the message is safe            |
+//! | 2    | unknown or dead uuid — nothing sent, nothing created |
+//! | 3    | refused: target mid-turn and `--interrupt` not set (reserved: rides with the #13 in-flight failsafe harvest — upstream `deliver_to_session` never refuses yet) |
+//! | 4    | transport/config: a2a disabled, unreachable, bad response |
+//!
+//! SENDER LABEL (#23, owner amendment "Overridable"): the CLI lane has no
+//! sender session, so the recipient's echo shows the carried label —
+//! default "CLI tooling", overridable with `--sender`.
+
+use crate::a2a::handler::notify::CLI_SENDER_LABEL_MAX_CHARS;
+use crate::cli::args::OutputFormat;
+use crate::config::Config;
+use anyhow::Result;
+
+pub const EXIT_OK: i32 = 0;
+pub const EXIT_NO_ROUTE: i32 = 2;
+pub const EXIT_REFUSED: i32 = 3;
+pub const EXIT_TRANSPORT: i32 = 4;
+
+pub(crate) async fn run(
+    config: &Config,
+    id_raw: &str,
+    text: &str,
+    title: Option<&str>,
+    sender: Option<&str>,
+    interrupt: bool,
+    format: OutputFormat,
+) -> Result<()> {
+    // Local usage errors: the gateway would reject these with INVALID_PARAMS
+    // anyway, but failing here keeps the journal honest about who noticed.
+    let target: uuid::Uuid = match id_raw.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            return finish(
+                format,
+                id_raw,
+                "no_route",
+                EXIT_NO_ROUTE,
+                &format!("'{id_raw}' is not a valid session UUID"),
+            );
+        }
+    };
+    if text.trim().is_empty() {
+        return finish(
+            format,
+            &target.to_string(),
+            "transport_error",
+            EXIT_TRANSPORT,
+            "--text must not be empty",
+        );
+    }
+    // Local mirror of the handler's sender validation: failing here keeps
+    // the journal honest about who noticed. The label rides inside
+    // `[session-notify from=cli:<label>]` — no `]`, no newlines, capped.
+    if let Some(raw) = sender {
+        let label = raw.trim();
+        if label.is_empty() {
+            return finish(
+                format,
+                &target.to_string(),
+                "transport_error",
+                EXIT_TRANSPORT,
+                "--sender must not be empty",
+            );
+        }
+        if label.contains(']') || label.contains('\n') || label.contains('\r') {
+            return finish(
+                format,
+                &target.to_string(),
+                "transport_error",
+                EXIT_TRANSPORT,
+                "--sender must not contain ']' or newlines",
+            );
+        }
+        if label.chars().count() > CLI_SENDER_LABEL_MAX_CHARS {
+            return finish(
+                format,
+                &target.to_string(),
+                "transport_error",
+                EXIT_TRANSPORT,
+                &format!("--sender must be at most {CLI_SENDER_LABEL_MAX_CHARS} chars"),
+            );
+        }
+    }
+    if !config.a2a.enabled {
+        return finish(
+            format,
+            &target.to_string(),
+            "transport_error",
+            EXIT_TRANSPORT,
+            "the [a2a] gateway is disabled in this profile's config — the daemon cannot be reached",
+        );
+    }
+
+    // A bind of 0.0.0.0/:: is a listening address, not a connectable one —
+    // same-box callers always dial loopback.
+    let host = match config.a2a.bind.as_str() {
+        "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
+        other => other,
+    };
+    let url = format!("http://{}:{}/a2a/v1", host, config.a2a.port);
+    let mut params = serde_json::json!({
+        "session_id": target.to_string(),
+        "message": text,
+        "interrupt": interrupt,
+    });
+    if let Some(t) = title {
+        params["title"] = serde_json::json!(t);
+    }
+    if let Some(s) = sender {
+        params["sender"] = serde_json::json!(s.trim());
+    }
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "session/notify",
+        "params": params,
+    });
+
+    let mut req = reqwest::Client::new()
+        .post(&url)
+        .timeout(std::time::Duration::from_secs(10))
+        .json(&body);
+    if let Some(key) = config.a2a.api_key.as_deref() {
+        req = req.bearer_auth(key);
+    }
+
+    let (outcome, exit_code, detail) = match req.send().await {
+        Err(e) => (
+            "transport_error".to_string(),
+            EXIT_TRANSPORT,
+            format!("cannot reach the A2A gateway at {url}: {e}"),
+        ),
+        Ok(resp) => {
+            let status = resp.status();
+            match resp.json::<crate::a2a::types::JsonRpcResponse>().await {
+                Err(e) => (
+                    "transport_error".into(),
+                    EXIT_TRANSPORT,
+                    format!("gateway at {url} returned HTTP {status} without a JSON-RPC body: {e}"),
+                ),
+                Ok(rpc) => {
+                    if let Some(err) = rpc.error {
+                        (
+                            "transport_error".into(),
+                            EXIT_TRANSPORT,
+                            format!("gateway error {}: {}", err.code, err.message),
+                        )
+                    } else if let Some(result) = rpc.result {
+                        let outcome = result
+                            .get("outcome")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("unknown")
+                            .to_string();
+                        let detail = result
+                            .get("detail")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("")
+                            .to_string();
+                        let code = match outcome.as_str() {
+                            "delivered" | "parked" => EXIT_OK,
+                            "no_route" => EXIT_NO_ROUTE,
+                            "refused_in_flight" => EXIT_REFUSED,
+                            _ => EXIT_TRANSPORT,
+                        };
+                        (outcome, code, detail)
+                    } else {
+                        (
+                            "transport_error".into(),
+                            EXIT_TRANSPORT,
+                            "gateway response carried neither result nor error".into(),
+                        )
+                    }
+                }
+            }
+        }
+    };
+
+    finish(format, &target.to_string(), &outcome, exit_code, &detail)
+}
+
+/// Journal + output + exit. One append-only journal line per invocation,
+/// written BEFORE the process exits — the journal, not the exit code, is the
+/// durable record (tool-logging law).
+fn finish(
+    format: OutputFormat,
+    target: &str,
+    outcome: &str,
+    exit_code: i32,
+    detail: &str,
+) -> Result<()> {
+    journal_line(target, outcome, exit_code, detail);
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "ok": exit_code == EXIT_OK,
+                    "target": target,
+                    "outcome": outcome,
+                    "detail": detail,
+                    "exit": exit_code,
+                }))?
+            );
+        }
+        _ => {
+            if exit_code == EXIT_OK {
+                println!("✅ {outcome}: {detail}");
+            } else {
+                eprintln!("❌ {outcome}: {detail} (exit {exit_code})");
+            }
+        }
+    }
+    std::process::exit(exit_code)
+}
+
+fn journal_line(target: &str, outcome: &str, exit_code: i32, detail: &str) {
+    use std::io::Write;
+
+    let path = crate::logging::log_dir().join("session-notify.journal");
+    let ts = chrono::Utc::now().to_rfc3339();
+    let caller = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+    // Truncate detail so one pathological message cannot bloat the line.
+    let detail: String = detail.chars().take(500).collect();
+    let line = format!(
+        "{ts}\tcaller={caller}\ttarget={target}\toutcome={outcome}\texit={exit_code}\tdetail={detail}\n"
+    );
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut f| f.write_all(line.as_bytes()));
+}

--- a/src/tests/a2a_session_notify_test.rs
+++ b/src/tests/a2a_session_notify_test.rs
@@ -1,0 +1,172 @@
+//! `session/notify` JSON-RPC handler tests (#23) — the tooling-facing twin
+//! of `session_notify_test` (which covers the agent-tool surface).
+//!
+//! What matters here: the zombie-wake existence gate (a dead uuid yields
+//! `no_route` without touching the route table), live-route delivery
+//! through the same `deliver_to_session` path the agent tool uses, the
+//! sender-label override riding the `cli:` header, and that malformed
+//! params are protocol errors while business outcomes are JSON-RPC
+//! successes. (The archived-session auto-route case rides with the #19
+//! channel-ownership harvest.)
+
+use crate::a2a::handler::notify::{
+    handle_session_notify, CLI_SENDER_PREFIX, DEFAULT_CLI_SENDER_LABEL,
+};
+use crate::a2a::test_helpers::helpers::placeholder_service_context;
+use crate::a2a::types::{error_codes, JsonRpcResponse};
+use crate::brain::agent::service::restart_recovery::test_guard;
+use crate::brain::agent::service::session_routes::register_session_route;
+use crate::brain::agent::QueuedUserMessage;
+use crate::services::SessionService;
+use std::sync::{Arc, Mutex};
+
+fn params(session_id: &str, message: &str) -> serde_json::Value {
+    serde_json::json!({ "session_id": session_id, "message": message })
+}
+
+fn outcome_of(resp: &JsonRpcResponse) -> String {
+    resp.result
+        .as_ref()
+        .expect("success response")
+        .get("outcome")
+        .and_then(serde_json::Value::as_str)
+        .expect("outcome field")
+        .to_string()
+}
+
+#[tokio::test]
+async fn dead_uuid_is_refused_without_touching_the_route_table() {
+    // #23 acceptance: unknown uuid → no_route, nothing created. The DB
+    // is empty, so the zombie-wake guard must fire BEFORE
+    // deliver_to_session — no route is registered, and if the guard were
+    // skipped the local-route fallback would still yield a non-no_route
+    // outcome only when LOCAL_ROUTE is set; the DB gate makes the result
+    // deterministic either way.
+    let ctx = placeholder_service_context().await;
+    let dead = uuid::Uuid::new_v4();
+    let resp =
+        handle_session_notify(serde_json::json!(1), params(&dead.to_string(), "ping"), ctx).await;
+    assert!(
+        resp.error.is_none(),
+        "dead uuid is a business outcome, not a protocol error: {resp:?}"
+    );
+    assert_eq!(outcome_of(&resp), "no_route");
+}
+
+#[tokio::test]
+// test_guard serializes suites touching the process-global route table;
+// holding it across the delivery `.await`s below is the entire point —
+// this suite's registered route must not interleave with another test's
+// (session_notify_test precedent).
+#[allow(clippy::await_holding_lock)]
+async fn live_uuid_delivers_through_the_claimed_route() {
+    // #23 acceptance: live uuid → delivered via the same
+    // deliver_to_session path the agent tool uses.
+    let _guard = test_guard();
+    let ctx = placeholder_service_context().await;
+    let session = SessionService::new(ctx.clone())
+        .create_session(Some("#23 test session".to_string()))
+        .await
+        .expect("session row created");
+    let sid = session.id;
+
+    let captured: Arc<Mutex<Option<QueuedUserMessage>>> = Arc::new(Mutex::new(None));
+    let sink = captured.clone();
+    register_session_route(
+        sid,
+        Arc::new(move |_id, queued| {
+            *sink.lock().unwrap() = Some(queued);
+        }),
+    );
+
+    let resp =
+        handle_session_notify(serde_json::json!(2), params(&sid.to_string(), "ping"), ctx).await;
+    assert!(resp.error.is_none(), "{resp:?}");
+    assert_eq!(outcome_of(&resp), "delivered");
+    let queued = captured.lock().unwrap().take().expect("message enqueued");
+    assert_eq!(queued.origin, crate::brain::agent::PushOrigin::SessionNotify);
+    assert!(queued.context_text.contains(&format!(
+        "[session-notify from={CLI_SENDER_PREFIX}{DEFAULT_CLI_SENDER_LABEL}]"
+    )));
+}
+
+#[tokio::test]
+// test_guard: same serialization rationale as the suite above — the
+// registered route must survive the delivery `.await`s untouched.
+#[allow(clippy::await_holding_lock)]
+async fn sender_override_rides_the_header() {
+    // #23 owner amendment ("Overridable"): the sender label is overridable
+    // via the `sender` param (CLI: `--sender`), and the echo surface reads
+    // it off the cli:-prefixed header verbatim.
+    let _guard = test_guard();
+    let ctx = placeholder_service_context().await;
+    let session = SessionService::new(ctx.clone())
+        .create_session(Some("#23 sender override".to_string()))
+        .await
+        .expect("session row created");
+    let sid = session.id;
+
+    let captured: Arc<Mutex<Option<QueuedUserMessage>>> = Arc::new(Mutex::new(None));
+    let sink = captured.clone();
+    register_session_route(
+        sid,
+        Arc::new(move |_id, queued| {
+            *sink.lock().unwrap() = Some(queued);
+        }),
+    );
+
+    let mut p = params(&sid.to_string(), "ping");
+    p["sender"] = serde_json::json!("oc-deploy");
+    let resp = handle_session_notify(serde_json::json!(7), p, ctx).await;
+    assert!(resp.error.is_none(), "{resp:?}");
+    assert_eq!(outcome_of(&resp), "delivered");
+    let queued = captured.lock().unwrap().take().expect("message enqueued");
+    assert!(
+        queued
+            .context_text
+            .contains("[session-notify from=cli:oc-deploy]"),
+        "override must ride the cli:-prefixed header: {}",
+        queued.context_text
+    );
+    assert!(
+        queued.display_text.contains("from oc-deploy"),
+        "display frame names the overridden sender: {}",
+        queued.display_text
+    );
+}
+
+#[tokio::test]
+async fn malformed_params_are_protocol_errors() {
+    let ctx = placeholder_service_context().await;
+    let bad_uuid = handle_session_notify(
+        serde_json::json!(3),
+        params("not-a-uuid", "ping"),
+        ctx.clone(),
+    )
+    .await;
+    assert_eq!(
+        bad_uuid.error.expect("error response").code,
+        error_codes::INVALID_PARAMS
+    );
+
+    let empty_msg = handle_session_notify(
+        serde_json::json!(4),
+        params(&uuid::Uuid::new_v4().to_string(), "   "),
+        ctx.clone(),
+    )
+    .await;
+    assert_eq!(
+        empty_msg.error.expect("error response").code,
+        error_codes::INVALID_PARAMS
+    );
+
+    // A sender label that would break the `[session-notify from=cli:<label>]`
+    // framing is a protocol error, not a delivery result.
+    let mut bad_sender = params(&uuid::Uuid::new_v4().to_string(), "ping");
+    bad_sender["sender"] = serde_json::json!("bad]label");
+    let bad_sender_resp = handle_session_notify(serde_json::json!(5), bad_sender, ctx).await;
+    assert_eq!(
+        bad_sender_resp.error.expect("error response").code,
+        error_codes::INVALID_PARAMS
+    );
+}

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -5,8 +5,8 @@
 //! wrapper tags stay intact).
 
 use crate::channels::telegram::resume::{
-    background_task_title, build_bg_echo_bubble, build_bg_echo_bubble_rich, split_bg_echo_parts,
-    split_notify_header, strip_system_framing,
+    NotifySender, background_task_title, build_bg_echo_bubble, build_bg_echo_bubble_rich,
+    split_bg_echo_parts, split_notify_header, strip_system_framing,
 };
 use uuid::Uuid;
 
@@ -16,8 +16,38 @@ const SENDER: &str = "6c1c9cb9-8243-4def-abe5-d926d0ca8bed";
 fn strips_notify_header_and_returns_sender() {
     let ctx = format!("[session-notify from={SENDER}]\n\nhello from the other topic");
     let (sender, body) = split_bg_echo_parts(&ctx);
-    assert_eq!(sender, Some(Uuid::parse_str(SENDER).unwrap()));
+    assert_eq!(
+        sender,
+        Some(NotifySender::Session(Uuid::parse_str(SENDER).unwrap()))
+    );
     assert_eq!(body, "hello from the other topic");
+}
+
+#[test]
+fn cli_sender_label_is_carried_verbatim() {
+    // #23 (owner amendment "Overridable"): the CLI lane stamps
+    // `from=cli:<label>` — no sender session exists, so the label rides the
+    // header verbatim and the echo renders it without a session lookup.
+    let ctx = "[session-notify from=cli:oc-deploy]\n\nbuild green";
+    let (sender, body) = split_bg_echo_parts(ctx);
+    assert_eq!(sender, Some(NotifySender::CliTooling("oc-deploy")));
+    assert_eq!(body, "build green");
+}
+
+#[test]
+fn cli_label_survives_surrounding_whitespace() {
+    let ctx = "[session-notify from=cli: CI runner ]\n\nbody";
+    let (sender, body) = split_notify_header(ctx);
+    assert_eq!(sender, Some(NotifySender::CliTooling("CI runner")));
+    assert_eq!(body, "body");
+}
+
+#[test]
+fn empty_cli_label_is_malformed_framing() {
+    let ctx = "[session-notify from=cli:]\n\nbody";
+    let (sender, body) = split_notify_header(ctx);
+    assert_eq!(sender, None, "an empty cli: label is not a sender");
+    assert_eq!(body, ctx, "malformed header passes whole text through");
 }
 
 #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -20,6 +20,7 @@ pub mod a2a_context_continuity_test;
 pub mod a2a_debate_test;
 pub mod a2a_handler_tasks_test;
 pub mod a2a_handler_test;
+pub mod a2a_session_notify_test;
 pub mod a2a_server_test;
 pub mod a2a_types_test;
 pub mod active_skill_tracking_test;


### PR DESCRIPTION
## What

Adds a `session/notify` JSON-RPC method to the A2A gateway and a matching `opencrabs session notify` CLI verb, letting tooling deliver a mechanical notification to a live session queue — the same `deliver_to_session` path the agent's own notify tool uses — without creating an A2A task or running an agent turn.

## Why

CLI-side tooling (deploy fan-out, monitoring, supervisors) needs to notify sessions — e.g. "your build just shipped, smoke-test your part". Today the only A2A entry point is `message/send`, which creates a task and runs a full agent turn; that's the wrong shape for a fire-and-forget notification. This adds a thin notify lane with a stable exit contract so scripts can act on the outcome.

## Implementation notes

**Daemon** (`src/a2a/handler/notify.rs`):
- Params: `session_id` (UUID, required), `message` (required, non-empty), `title` (optional), `sender` (optional label), `interrupt` (parsed, currently inert — the in-flight failsafe that would consume it is tracked separately and not included here).
- Zombie-wake gate: a UUID with no sessions-table row is refused as `no_route` **without touching the route table** — prevents the local-route fallback from resurrecting traffic into a vanished session. An archived row passes the gate: existence, not liveness, is what's checked.
- Sender framing: the CLI lane has no sender session, so the mechanical header stamps `from=cli:<label>` — default label `CLI tooling`, overridable via `sender`. Labels are validated: no `]` or newlines, 64 chars max.
- Business outcomes (`delivered` / `parked` / `no_route`) are JSON-RPC **successes** carrying `{outcome, detail}`; only malformed params and lookup failures are protocol errors.

**CLI** (`src/cli/session_notify.rs`): `opencrabs session notify <id> --text ... [--title ...] [--sender ...] [--interrupt] [--format text|json|markdown]` POSTs to the profile's A2A gateway. Exit contract: **0** delivered/parked, **2** no route, **3** refused mid-turn (inert until the failsafe lands), **4** transport/config. Every invocation writes an append-only journal line to `<logs>/session-notify.journal` before exiting.

**Telegram echo** (`src/channels/telegram/resume.rs`): the bg/notify echo header split now returns a `NotifySender` enum. `Session(uuid)` keeps the existing humanization (label lookup); `CliTooling(label)` renders the carried label verbatim — no API lookups for CLI notifications.

**Tests**: `src/tests/a2a_session_notify_test.rs` (zombie-wake gate, live-route delivery, sender override, malformed params) plus CLI-lane regressions in `src/tests/bg_push_echo_test.rs` (label carried verbatim, whitespace trim, empty label = malformed). An archived-session auto-routing case is deliberately **not** included: it would require channel-ownership machinery that isn't upstream yet.

## Verification

- Fork pr-checks (full upstream triad: fmt, clippy `--all-features -- -D warnings`, `cargo test --locked --all-features`) GREEN on this exact head — run 33225722827, conclusion `success`, checkout sha `dc71bc8ce1a90d42d57ab648931d021072bf45f4` proven from the job log.
- Carrier pre-flight compile gate (step 2b): waived by the fork owner for this PR — the carrier's ORDER containment gate pins the build sha to fork `main`, which a PR head can never satisfy by design; the ruling is recorded at https://github.com/leshchenko1979/opencrabs/issues/23#issuecomment-5459579803
- Live smoke on a deployed build of this delta: exit paths 0 (delivered — `📨` card landed in the target topic), 2 (dead uuid → `no_route`), 3 (mid-turn refusal) and 4 (wrong-profile daemon → method-not-found) all exercised.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/23