### PR TITLE
Telegram bg-completion and session-notify receipt cards with From sender labels

### DIFF
--- a/src/brain/agent/mod.rs
+++ b/src/brain/agent/mod.rs
@@ -11,7 +11,7 @@ pub mod service;
 pub use context::AgentContext;
 pub use error::{AgentError, Result, format_user_error};
 pub use service::{
-    AgentResponse, AgentService, AgentStreamResponse, ApprovalCallback, BrainRebuild,
+    AgentResponse, AgentService, AgentStreamResponse, ApprovalCallback, BgTaskMeta, BrainRebuild,
     ChannelSessionEvent, MessageQueueCallback, ProgressCallback, ProgressEvent, PushOrigin,
     QueuedUserMessage, SshPasswordCallback, SudoCallback, ToolApprovalInfo,
 };

--- a/src/brain/agent/service/background_tasks.rs
+++ b/src/brain/agent/service/background_tasks.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 
 use uuid::Uuid;
 
-use super::types::{MessageEnqueueCallback, PushOrigin, QueuedUserMessage};
+use super::types::{BgTaskMeta, MessageEnqueueCallback, PushOrigin, QueuedUserMessage};
 
 /// Result of a finished background command.
 #[derive(Debug, Clone)]
@@ -143,6 +143,9 @@ impl BackgroundTaskManager {
             }
             let started = std::time::Instant::now();
             let result = run_detached(&command, &cwd).await;
+            // Capture ONCE: the log line, the status file and the receipt
+            // payload (#15) must all report the same runtime.
+            let elapsed_secs = started.elapsed().as_secs_f32();
             // Exit code and elapsed time, not just a boolean: how long a task
             // actually took is the only way to tell a correct detach from a
             // wasteful one, and it was nowhere in the log.
@@ -152,7 +155,7 @@ impl BackgroundTaskManager {
                  (success={}, exit={}, elapsed={:.1}s)",
                 result.success,
                 result.code,
-                started.elapsed().as_secs_f32()
+                elapsed_secs
             );
             // Gap 2 (#1160): rewrite the status file with exit info, so any
             // reader between process-exit and session-resume sees the
@@ -165,11 +168,11 @@ impl BackgroundTaskManager {
                 DetachedFinish {
                     success: result.success,
                     code: result.code,
-                    elapsed_secs: started.elapsed().as_secs_f32(),
+                    elapsed_secs,
                     output_bytes: result.output.len(),
                 },
             );
-            let msg = completion_message(&label, &command, &result);
+            let msg = completion_message(&label, &command, &result, elapsed_secs);
             if let Some(repo) = task_repo()
                 && let Err(e) = repo.clear(task_id).await
             {
@@ -273,11 +276,15 @@ pub(crate) fn tail_lines(text: &str, n: usize) -> String {
 }
 
 /// Build the resume message from a finished background command (#722). Pure so
-/// the framing is unit-testable without spawning anything.
+/// the framing is unit-testable without spawning anything. `elapsed_secs` is
+/// the detached command's wall-clock runtime; it rides along in the typed
+/// `BgTaskMeta` payload (#15) so the receipt card renders a duration without
+/// parsing the context text.
 pub(crate) fn completion_message(
     label: &str,
     command: &str,
     result: &CmdResult,
+    elapsed_secs: f32,
 ) -> QueuedUserMessage {
     let status = if result.success {
         "exit 0 (success)".to_string()
@@ -301,5 +308,26 @@ pub(crate) fn completion_message(
     let mut msg = QueuedUserMessage::system(context, display);
     // #1221: marks this delivery for the Telegram collapsible echo bubble.
     msg.origin = PushOrigin::BackgroundTask;
+    // #15: typed receipt payload — the echo renders the card from this,
+    // never from the `[System: ...]` context text.
+    msg.bg_meta = Some(BgTaskMeta {
+        success: result.success,
+        label: label.to_string(),
+        elapsed_secs,
+        tail,
+    });
     msg
+}
+
+/// Human duration for the receipt card (#15): `42s`, `3m 5s`, `1h 12m`.
+/// Rounds to whole seconds; sub-second tasks show `0s`.
+pub(crate) fn format_elapsed(secs: f32) -> String {
+    let total = secs.max(0.0).round() as u64;
+    if total < 60 {
+        format!("{total}s")
+    } else if total < 3600 {
+        format!("{}m {}s", total / 60, total % 60)
+    } else {
+        format!("{}h {}m", total / 3600, (total % 3600) / 60)
+    }
 }

--- a/src/brain/agent/service/mod.rs
+++ b/src/brain/agent/service/mod.rs
@@ -43,7 +43,7 @@ pub use phantom::{
     is_delivery_intent, is_stuck_in_intent_loop, looks_truncated_mid_sentence,
 };
 pub use types::{
-    AgentResponse, AgentStreamResponse, ApprovalCallback, ChannelSessionEvent,
+    AgentResponse, AgentStreamResponse, ApprovalCallback, BgTaskMeta, ChannelSessionEvent,
     MessageEnqueueCallback, MessageQueueCallback, ProgressCallback, ProgressEvent, PushOrigin,
     QueuedUserMessage, SshPasswordCallback, SudoCallback, ToolApprovalInfo,
 };

--- a/src/brain/agent/service/restart_recovery.rs
+++ b/src/brain/agent/service/restart_recovery.rs
@@ -337,6 +337,7 @@ fn interrupted_message(row: &crate::db::BackgroundTaskRow) -> QueuedUserMessage 
         context_text,
         display_text: format!("⚠️ Background task interrupted by restart: {}", row.label),
         origin: PushOrigin::Recovery,
+        bg_meta: None,
     }
 }
 
@@ -421,5 +422,6 @@ fn subagent_interrupted_message(
         context_text,
         display_text: format!("⚠️ Sub-agent interrupted by restart: {}", status.label),
         origin: PushOrigin::Recovery,
+        bg_meta: None,
     }
 }

--- a/src/brain/agent/service/types.rs
+++ b/src/brain/agent/service/types.rs
@@ -211,6 +211,25 @@ pub enum PushOrigin {
     Other,
 }
 
+/// Typed receipt payload for a background-task completion push (#15).
+///
+/// The rendering surface (Telegram resume echo) builds the collapsible
+/// receipt card from these fields instead of parsing `context_text` — the
+/// `[System: ...]` shape belongs to the LLM and must stay free to evolve
+/// without breaking the bubble.
+#[derive(Debug, Clone)]
+pub struct BgTaskMeta {
+    /// Exit 0 — the sole outcome signal the receipt card shows (the exit
+    /// code itself stays in the context text, for the model only).
+    pub success: bool,
+    /// Short roster label (`short_label` form: ≤60 chars + ellipsis).
+    pub label: String,
+    /// Wall-clock runtime of the detached command, seconds.
+    pub elapsed_secs: f32,
+    /// Last 50 lines of merged stdout+stderr, verbatim.
+    pub tail: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct QueuedUserMessage {
     /// Full text injected into the LLM context for the live turn.
@@ -219,6 +238,9 @@ pub struct QueuedUserMessage {
     pub display_text: String,
     /// Which producer built this message (#1221).
     pub origin: PushOrigin,
+    /// Receipt payload for BackgroundTask-origin pushes (#15); `None` for
+    /// every other producer.
+    pub bg_meta: Option<BgTaskMeta>,
 }
 
 impl QueuedUserMessage {
@@ -228,6 +250,7 @@ impl QueuedUserMessage {
             context_text: text.clone(),
             display_text: text,
             origin: PushOrigin::Other,
+            bg_meta: None,
         }
     }
 
@@ -239,6 +262,7 @@ impl QueuedUserMessage {
             context_text: context,
             display_text: display,
             origin: PushOrigin::Other,
+            bg_meta: None,
         }
     }
 
@@ -264,6 +288,9 @@ impl QueuedUserMessage {
             // #1221: a joined batch inherits the head message's origin — the
             // first-completed task dominates what the echo announces.
             origin: msgs[0].origin,
+            // #15: same dominance rule for the receipt payload — the head
+            // task's card is the one the echo renders.
+            bg_meta: msgs[0].bg_meta.clone(),
         })
     }
 }

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -85,6 +85,7 @@ impl Tool for SessionNotifyTool {
             context_text: format!("[session-notify from={from}]\n\n{message}"),
             display_text: format!("📨 notify from {}:\n{message}", short_id(from)),
             origin: crate::brain::agent::PushOrigin::SessionNotify,
+            bg_meta: None,
         };
 
         use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};

--- a/src/brain/tools/subagent/spawn.rs
+++ b/src/brain/tools/subagent/spawn.rs
@@ -66,6 +66,7 @@ pub(crate) fn completion_message(
         context_text,
         display_text,
         origin: crate::brain::agent::PushOrigin::SubAgent,
+        bg_meta: None,
     }
 }
 

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -3034,6 +3034,7 @@ pub(crate) async fn handle_reaction(
                     context_text: midturn,
                     display_text: format!("[System: {user_name} reacted with {emoji} mid-turn]"),
                     origin: crate::brain::agent::PushOrigin::Ingress,
+                    bg_meta: None,
                 },
             );
             tracing::info!(
@@ -3279,6 +3280,7 @@ pub(crate) fn build_midturn_queued_message(
             ),
             display_text: invocation.to_string(),
             origin: crate::brain::agent::PushOrigin::Ingress,
+            bg_meta: None,
         },
         None => crate::brain::agent::QueuedUserMessage {
             context_text: format!(
@@ -3288,6 +3290,7 @@ pub(crate) fn build_midturn_queued_message(
             ),
             display_text: display_text.to_string(),
             origin: crate::brain::agent::PushOrigin::Ingress,
+            bg_meta: None,
         },
     }
 }

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -889,13 +889,16 @@ pub(crate) fn background_task_title(display_text: &str) -> String {
 }
 
 /// Human-readable sender label for a session_notify push (Alexey's rule):
-/// sender chat == recipient chat → the sender's topic name; a different
-/// non-forum chat → chat name; a different forum → chat + topic name;
-/// the card summary renders it as `From <name>:`. Topic names come from
-/// the local `channel_messages.topic_name` store (the Bot API has no method
-/// to query them), chat names from `getChat`. Best-effort: any lookup
-/// failure falls back to the short session id (the same prefix
-/// `session_search list` displays).
+/// sender chat == recipient chat → the sender's topic name; a DM session
+/// (positive chat id) → the BOT's username from the startup get_me cache
+/// (the reader IS the chat's human side — handing their own name back as
+/// the sender is useless); a different non-forum chat → chat name; a
+/// different forum → chat + topic name. The card summary renders it as
+/// `From <name>:`. Topic names come from the local
+/// `channel_messages.topic_name` store (the Bot API has no method to query
+/// them), chat names from `getChat`. Best-effort: any lookup failure falls
+/// back to the short session id (the same prefix `session_search list`
+/// displays).
 async fn sender_label(
     state: &TelegramState,
     bot: &teloxide::Bot,
@@ -912,6 +915,11 @@ async fn sender_label(
             Some(tid) => local_topic_name(sc, tid).await,
             None => None,
         },
+        // DM with the bot (positive chat id = private chat): label the bot
+        // itself from the startup get_me cache — zero network. An empty
+        // cache (shouldn't happen post-boot) falls through to the short-id
+        // fallback below.
+        Some(sc) if sc > 0 => state.bot_username().await,
         Some(sc) => {
             let chat =
                 super::titles::chat_title(&api_url, &token, teloxide::types::ChatId(sc)).await;
@@ -948,4 +956,41 @@ async fn local_topic_name(chat_id: i64, thread_id: i32) -> Option<String> {
 /// list's short-id prefix display).
 fn short_session_id(uuid: Uuid) -> String {
     uuid.simple().to_string()[..8].to_owned()
+}
+
+#[cfg(test)]
+mod sender_label_dm_tests {
+    use super::*;
+
+    /// Owner ruling 2026-08-28: a session sitting in a DM with the bot must
+    /// be labelled with the BOT's username, never the reader's own name —
+    /// the reader IS the chat's human side, so handing it back as the
+    /// sender is useless.
+    #[tokio::test]
+    async fn dm_session_labels_the_bot_not_the_reader() {
+        let state = TelegramState::new();
+        state.set_bot_username("test_bot".to_owned()).await;
+        let sender = Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        state.register_session_chat(sender, 12345, None).await;
+        let bot = teloxide::Bot::new("42:TEST");
+        assert_eq!(
+            sender_label(&state, &bot, sender, -100_999).await,
+            "test_bot"
+        );
+    }
+
+    /// Empty get_me cache (shouldn't happen post-boot): the DM arm must
+    /// degrade to the short session id, never to a getChat lookup that
+    /// would return the reader's own profile.
+    #[tokio::test]
+    async fn dm_session_without_cached_bot_username_falls_back_to_short_id() {
+        let state = TelegramState::new();
+        let sender = Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        state.register_session_chat(sender, 12345, None).await;
+        let bot = teloxide::Bot::new("42:TEST");
+        assert_eq!(
+            sender_label(&state, &bot, sender, -100_999).await,
+            short_session_id(sender)
+        );
+    }
 }

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -846,7 +846,7 @@ fn first_line_preview(body: &str) -> String {
 }
 
 /// Session-notify receipt card (#15 amendment, owner-locked shape N4): ONE
-/// collapsed `<details>`. Summary = `<sub>📨 <b>{sender}</b>: {preview}</sub>`
+/// collapsed `<details>`. Summary = `<sub>📨 From <b>{sender}</b>: {preview}</sub>`
 /// — fixed 📨 (notifies carry no success/failure semantics), sender label in
 /// bold, preview = truncated first line of the body. Body = the notify
 /// content as rendered markdown: prose and pipe tables stay native for the
@@ -866,10 +866,10 @@ pub(crate) fn build_notify_receipt_card(sender_label: &str, body: &str) -> (Stri
     let body = crate::utils::string::truncate_chars(body, BG_ECHO_BODY_CAP_CHARS);
     let suffix = if truncated { " (truncated)" } else { "" };
     let markdown = format!(
-        "<details><summary><sub>📨 <b>{sender}</b>: {preview}</sub></summary>\n\n\
+        "<details><summary><sub>📨 From <b>{sender}</b>: {preview}</sub></summary>\n\n\
          {body}{suffix}\n\n</details>"
     );
-    let flat_title = format!("📨 {sender}: {preview}");
+    let flat_title = format!("📨 From {sender}: {preview}");
     let (_, classic_html) = build_bg_echo_bubble(&format!("{body}{suffix}"), &flat_title);
     (markdown, classic_html)
 }
@@ -890,9 +890,12 @@ pub(crate) fn background_task_title(display_text: &str) -> String {
 
 /// Human-readable sender label for a session_notify push (Alexey's rule):
 /// sender chat == recipient chat → the sender's topic name; a different
-/// non-forum chat → chat name; a different forum → chat + topic name.
-/// Best-effort: any lookup failure falls back to the short session id
-/// (the same prefix `session_search list` displays).
+/// non-forum chat → chat name; a different forum → chat + topic name;
+/// the card summary renders it as `From <name>:`. Topic names come from
+/// the local `channel_messages.topic_name` store (the Bot API has no method
+/// to query them), chat names from `getChat`. Best-effort: any lookup
+/// failure falls back to the short session id (the same prefix
+/// `session_search list` displays).
 async fn sender_label(
     state: &TelegramState,
     bot: &teloxide::Bot,
@@ -906,40 +909,39 @@ async fn sender_label(
     let label = match sender_chat {
         None => None,
         Some(sc) if sc == recipient_chat => match sender_topic {
-            Some(tid) => {
-                super::titles::topic_title(
-                    &api_url,
-                    &token,
-                    teloxide::types::ChatId(sc),
-                    teloxide::types::ThreadId(teloxide::types::MessageId(tid)),
-                )
-                .await
-            }
+            Some(tid) => local_topic_name(sc, tid).await,
             None => None,
         },
         Some(sc) => {
             let chat =
                 super::titles::chat_title(&api_url, &token, teloxide::types::ChatId(sc)).await;
             match (chat, sender_topic) {
-                (Some(c), Some(tid)) => {
-                    match super::titles::topic_title(
-                        &api_url,
-                        &token,
-                        teloxide::types::ChatId(sc),
-                        teloxide::types::ThreadId(teloxide::types::MessageId(tid)),
-                    )
-                    .await
-                    {
-                        Some(t) => Some(format!("{c} / {t}")),
-                        None => Some(c),
-                    }
-                }
+                (Some(c), Some(tid)) => match local_topic_name(sc, tid).await {
+                    Some(t) => Some(format!("{c} / {t}")),
+                    None => Some(c),
+                },
                 (Some(c), None) => Some(c),
                 (None, _) => None,
             }
         }
     };
     label.unwrap_or_else(|| short_session_id(sender))
+}
+
+/// Forum-topic display name, resolved LOCALLY: the Bot API has no method to
+/// query a topic's title (`getForumTopic` does not exist — bots can only
+/// learn names passively; telegram-bot-api issues #634/#356). The handler
+/// already stores every observed topic name in `channel_messages.topic_name`,
+/// so the card builder reads the newest one for (chat, thread). Any miss —
+/// DB unavailable, topic never observed, empty name — feeds the short-id
+/// fallback in `sender_label` like every other lookup failure.
+async fn local_topic_name(chat_id: i64, thread_id: i32) -> Option<String> {
+    let pool = crate::db::global_pool()?;
+    let repo = ChannelMessageRepository::new(pool.clone());
+    repo.latest_topic_name("telegram", &chat_id.to_string(), &thread_id.to_string())
+        .await
+        .ok()
+        .flatten()
 }
 
 /// Short session id: first 8 hex chars of the uuid (matches `session_search`

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -119,9 +119,9 @@ pub(crate) fn build_enqueue_callback(
                     teloxide::types::ChatId(chat_id),
                     thread_id,
                     &echo_md,
-                    None,
                     "bg-resume",
                     "-",
+                    None,
                 )
                 .await
                 {

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -8,6 +8,7 @@ use super::TelegramState;
 #[allow(unused_imports)]
 use super::handler::*;
 use super::send::{best_effort_delete, fire_chat_action};
+use crate::brain::agent::service::background_tasks;
 use crate::brain::agent::{AgentService, ProgressCallback, ProgressEvent};
 use crate::config::Config;
 use crate::db::ChannelMessageRepository;
@@ -77,41 +78,47 @@ pub(crate) fn build_enqueue_callback(
                 crate::brain::agent::PushOrigin::BackgroundTask
                     | crate::brain::agent::PushOrigin::SessionNotify
             ) {
+                // #15: receipt cards. A bg completion carries the typed
+                // payload (icon/label/duration/tail) in `bg_meta` — the card
+                // renders from it, never by parsing the `[System: ...]`
+                // context text. Notify pushes carry no meta: the card is
+                // built from the sender label + markdown body (N4 shape).
                 // #1225: session_notify pushes carry a mechanical
-                // `[session-notify from=<uuid>]` header — replace the raw id
-                // with a human label (topic name for same-chat pushes, chat
-                // name / chat+topic for cross-chat, per Alexey's rule), so the
-                // bubble reads "📨 From: Ops / Push to session", not a UUID
-                // spray. Background-task pushes have no sender: the title
-                // names the task from the producer's display line instead of
-                // the generic "⚙️ background task result" (Alexey 2026-08-26).
-                let (sender, body) = split_bg_echo_parts(&msg.context_text);
-                let title = if let Some(s) = sender {
-                    format!("📨 {}", sender_label(&state, &bot, s, chat_id).await)
-                } else if msg.origin == crate::brain::agent::PushOrigin::BackgroundTask {
-                    // Borrow: `msg` is moved wholesale later in this callback.
-                    background_task_title(&msg.display_text)
+                // `[session-notify from=<uuid>]` header — the raw id is
+                // replaced with a human label (topic name for same-chat
+                // pushes, chat name / chat+topic for cross-chat, per
+                // Alexey's rule).
+                let (echo_md, classic_html) = if let Some(meta) = msg.bg_meta.clone() {
+                    build_bg_receipt_card(&meta)
                 } else {
-                    "⚙️ background task result".to_owned()
+                    let (sender, body) = split_bg_echo_parts(&msg.context_text);
+                    match sender {
+                        Some(s) => {
+                            let label = sender_label(&state, &bot, s, chat_id).await;
+                            build_notify_receipt_card(&label, &body)
+                        }
+                        // Defensive: a BackgroundTask push without meta
+                        // (parked by an older binary, #1242 redelivery) keeps
+                        // the #1234 flat bold-title shape. Borrow note:
+                        // `msg` is moved wholesale later in this callback.
+                        None if msg.origin == crate::brain::agent::PushOrigin::BackgroundTask => {
+                            let title = background_task_title(&msg.display_text);
+                            build_bg_echo_bubble(&body, &title)
+                        }
+                        None => build_bg_echo_bubble(&body, "⚙️ background task result"),
+                    }
                 };
-                let (_, classic_html) = build_bg_echo_bubble(&body, &title);
-                // Rich dialect needs the RICH envelope: `<details><summary>`
-                // collapsibles (RichBlockDetails, Bot API 10.1) — the same card
-                // component plan_card renders. The classic
-                // `<blockquote expandable>` markup is the sendMessage dialect;
-                // under sendRichMessage it renders as a flat quote, not a rich
-                // card (user-verified 2026-08-26).
-                let rich_html = build_bg_echo_bubble_rich(&body, &title);
-
-                // Rich-first: route the echo bubble through the same canonical
-                // rich send plan_card uses. Any send failure degrades to the
-                // classic HTML blockquote below.
-                let sent_rich = match super::rich::api::send_rich_html_id(
-                    bot.api_url().as_str(),
-                    bot.token(),
-                    chat_id,
+                // #1234/#15: the card rides the CANONICAL markdown→rich
+                // outbox (the same pipeline as every cron/kanal message);
+                // the native-rich route renders the <details> collapse, the
+                // fenced tail and pipe tables server-side. The classic
+                // blockquote above is the degraded-path source: computed up
+                // front, only touched if the outbox send fails.
+                let sent_rich = match super::send::send_markdown_outbox(
+                    &bot,
+                    teloxide::types::ChatId(chat_id),
                     thread_id,
-                    &rich_html,
+                    &echo_md,
                     None,
                     "bg-resume",
                     "-",
@@ -775,23 +782,96 @@ pub(crate) fn build_bg_echo_bubble(body: &str, title: &str) -> (String, String) 
     (markdown, html)
 }
 
-/// RICH dialect envelope for the echo bubble: `<details><summary>` collapsible
-/// — the exact card component plan_card renders via `send_rich_html_id`
-/// (Bot API 10.1 RichBlockDetails). The classic
-/// `<blockquote expandable>` markup from [`build_bg_echo_bubble`] belongs to
-/// the sendMessage dialect and renders flat under `sendRichMessage`.
-/// Mirrors plan_card.rs `CollapsibleStyle::DetailsSummary`:
-/// `<details><summary><b>{title}</b></summary>{body}</details>`.
-pub(crate) fn build_bg_echo_bubble_rich(body: &str, title: &str) -> String {
+/// The bg-receipt tail fence (#15): three backticks normally, but ONE MORE
+/// than the longest backtick run when the tail itself carries a ``` run, so
+/// raw output can never escape the code block and corrupt the card.
+fn receipt_fence(tail: &str) -> String {
+    let (mut longest, mut run) = (0usize, 0usize);
+    for ch in tail.chars() {
+        if ch == '`' {
+            run += 1;
+            longest = longest.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    "`".repeat(if longest >= 3 { longest + 1 } else { 3 })
+}
+
+/// Background-task receipt card (#15, owner-locked shape P3f): ONE collapsed
+/// `<details>`. Summary = `<sub>{✅|❌} `{label}` 🕒 {duration}</sub>` — icon
+/// by exit 0 / non-zero as the sole outcome signal (no exit code, no
+/// wording), label = the roster `short_label` form in inline code. Body =
+/// ONE fenced code block with the output tail verbatim. Returns (rich
+/// markdown, classic HTML fallback). The markdown leg feeds
+/// [`super::send::send_markdown_outbox`], whose native-rich route renders
+/// the collapsible + code block server-side — the shape the owner-approved
+/// prototypes proved on screen (topic 31847).
+pub(crate) fn build_bg_receipt_card(meta: &crate::brain::agent::BgTaskMeta) -> (String, String) {
+    let icon = if meta.success { "✅" } else { "❌" };
+    // The label sits inside an inline-code span: backticks would escape the
+    // span and break the summary, so they are stripped.
+    let stripped = meta.label.replace('`', "");
+    let label = stripped.trim();
+    let label = if label.is_empty() {
+        "background task"
+    } else {
+        label
+    };
+    let duration = background_tasks::format_elapsed(meta.elapsed_secs);
+    let fence = receipt_fence(&meta.tail);
+    let markdown = format!(
+        "<details><summary><sub>{icon} `{label}` 🕒 {duration}</sub></summary>\n\n\
+         {fence}\n{tail}\n{fence}\n\n</details>",
+        tail = meta.tail
+    );
+    // Degraded path: same content as a classic blockquote (non-collapsible
+    // on this wire), computed up front and only touched if the outbox send
+    // fails (#1234 fallback discipline).
+    let flat_title = format!("{icon} {label} 🕒 {duration}");
+    let fenced_body = format!("{fence}\n{tail}\n{fence}", tail = meta.tail);
+    let (_, classic_html) = build_bg_echo_bubble(&fenced_body, &flat_title);
+    (markdown, classic_html)
+}
+
+/// The notify-card peek (#15 amendment): the body's first line, truncated
+/// ~45 chars + ellipsis. Deterministic at compose time — no new metadata.
+fn first_line_preview(body: &str) -> String {
+    let line = body.lines().next().unwrap_or("").trim();
+    if line.chars().count() > 45 {
+        format!("{}…", crate::utils::string::truncate_chars(line, 45))
+    } else {
+        line.to_string()
+    }
+}
+
+/// Session-notify receipt card (#15 amendment, owner-locked shape N4): ONE
+/// collapsed `<details>`. Summary = `<sub>📨 <b>{sender}</b>: {preview}</sub>`
+/// — fixed 📨 (notifies carry no success/failure semantics), sender label in
+/// bold, preview = truncated first line of the body. Body = the notify
+/// content as rendered markdown: prose and pipe tables stay native for the
+/// rich parser — no code fence, a notify is a document, not a log.
+pub(crate) fn build_notify_receipt_card(sender_label: &str, body: &str) -> (String, String) {
+    // The sender sits inside a <b> tag: angle brackets are neutralized so a
+    // label containing '<' cannot open a tag and corrupt the summary.
+    let sanitized = sender_label.replace('<', "‹").replace('>', "›");
+    let sender = sanitized.trim();
+    let sender = if sender.is_empty() {
+        "session notify"
+    } else {
+        sender
+    };
+    let preview = first_line_preview(body);
     let truncated = body.chars().count() > BG_ECHO_BODY_CAP_CHARS;
     let body = crate::utils::string::truncate_chars(body, BG_ECHO_BODY_CAP_CHARS);
     let suffix = if truncated { " (truncated)" } else { "" };
-    format!(
-        "<details><summary><b>{}{}</b></summary>{}</details>",
-        super::markdown::escape_html(title),
-        suffix,
-        super::rich::markdown_to_html(body),
-    )
+    let markdown = format!(
+        "<details><summary><sub>📨 <b>{sender}</b>: {preview}</sub></summary>\n\n\
+         {body}{suffix}\n\n</details>"
+    );
+    let flat_title = format!("📨 {sender}: {preview}");
+    let (_, classic_html) = build_bg_echo_bubble(&format!("{body}{suffix}"), &flat_title);
+    (markdown, classic_html)
 }
 
 /// Bubble header for a background-task echo: reuse the producer's display

--- a/src/channels/telegram/rich/mod.rs
+++ b/src/channels/telegram/rich/mod.rs
@@ -70,7 +70,10 @@ pub(crate) fn should_send_native_rich(text: &str) -> bool {
 
 /// Whether `text` contains block-level markdown structure that native rich
 /// rendering handles meaningfully better than plain/HTML: a table, ATX
-/// heading, list item, fenced code block, or block math. Plain prose (even
+/// heading, list item, fenced code block, block math, or a `<details>`
+/// collapse block — matched by `<details>` line prefix so the inline
+/// `<details><summary>` opener the #15 receipt cards emit counts too.
+/// Plain prose (even
 /// with inline emphasis) returns false, so it stays on the existing path and
 /// is never reinterpreted by Telegram's markdown parser. Gates the native
 /// `sendRichMessage` path (together with the config flag).
@@ -88,8 +91,7 @@ pub(crate) fn has_rich_structure(text: &str) -> bool {
                 || list::is_item(t)
                 || t.starts_with("```")
                 || t == "$$"
-                || t == "<details>"
-                || t == "<details open>"
+                || t.starts_with("<details>")
                 || t.starts_with("<details ")
         })
 }

--- a/src/channels/telegram/titles.rs
+++ b/src/channels/telegram/titles.rs
@@ -2,11 +2,15 @@
 //! session_notify echo bubbles (#1225). Raw HTTP, same wire style as
 //! `rich/api.rs`, kept on one tiny code path.
 //!
-//! Only `getChat` lives here: it is a real Bot API method and covers groups,
-//! channels and private chats. Forum-TOPIC names do NOT belong here — the
-//! Bot API has no method to query a topic's title (bots can only learn names
-//! passively; telegram-bot-api issues #634/#356), so `resume.rs` resolves
-//! those from the local `channel_messages.topic_name` store instead.
+//! Only `getChat` lives here: it is a real Bot API method and covers groups
+//! and channels. Forum-TOPIC names do NOT belong here — the Bot API has no
+//! method to query a topic's title (bots can only learn names passively;
+//! telegram-bot-api issues #634/#356), so `resume.rs` resolves those from
+//! the local `channel_messages.topic_name` store instead. Private chats
+//! (DM sessions) never reach here either: the reader IS the chat's human
+//! side, so their own name back as the sender is useless — `sender_label`
+//! labels the BOT itself from the startup `get_me` cache (owner ruling
+//! 2026-08-28).
 //!
 //! Every lookup is best-effort — `None` on any failure feeds the short-id
 //! fallback in `resume.rs`, never an error bubble.
@@ -39,8 +43,9 @@ async fn post_api(
     }
 }
 
-/// Chat display name: `title` for groups/channels; on private chats (no
-/// title) the account's `username`, else its first/last name.
+/// Chat display name: `title` for groups/channels, else the account's
+/// `username`. Private chats never reach this function — DM sessions are
+/// labelled with the bot's own username in `resume.rs::sender_label`.
 pub(crate) async fn chat_title(api_url: &str, token: &str, chat_id: ChatId) -> Option<String> {
     let result = post_api(
         api_url,
@@ -58,16 +63,5 @@ pub(crate) async fn chat_title(api_url: &str, token: &str, chat_id: ChatId) -> O
                 .get("username")
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_owned)
-        })
-        .or_else(|| {
-            // Private chats have no `title` and not every account has a
-            // username — fall back to the account's display name.
-            let first = result.get("first_name").and_then(serde_json::Value::as_str);
-            let last = result.get("last_name").and_then(serde_json::Value::as_str);
-            match (first, last) {
-                (Some(f), Some(l)) => Some(format!("{f} {l}")),
-                (Some(f), None) => Some(f.to_owned()),
-                _ => None,
-            }
         })
 }

--- a/src/channels/telegram/titles.rs
+++ b/src/channels/telegram/titles.rs
@@ -1,14 +1,18 @@
 //! Best-effort Bot API title lookups for human-readable sender labels on
 //! session_notify echo bubbles (#1225). Raw HTTP, same wire style as
-//! `rich/api.rs`: teloxide 0.17 has no `getForumTopic` binding (docs.rs 404,
-//! verified) and a uniform raw call keeps `getChat` and `getForumTopic` on
-//! one tiny code path.
+//! `rich/api.rs`, kept on one tiny code path.
+//!
+//! Only `getChat` lives here: it is a real Bot API method and covers groups,
+//! channels and private chats. Forum-TOPIC names do NOT belong here — the
+//! Bot API has no method to query a topic's title (bots can only learn names
+//! passively; telegram-bot-api issues #634/#356), so `resume.rs` resolves
+//! those from the local `channel_messages.topic_name` store instead.
 //!
 //! Every lookup is best-effort — `None` on any failure feeds the short-id
 //! fallback in `resume.rs`, never an error bubble.
 
 use std::time::Duration;
-use teloxide::types::{ChatId, ThreadId};
+use teloxide::types::ChatId;
 
 fn api_base(api_url: &str) -> &str {
     api_url.trim_end_matches('/')
@@ -35,8 +39,8 @@ async fn post_api(
     }
 }
 
-/// Chat display name: `title` for groups/channels, `username` as fallback
-/// for private chats (getChat leaves `title` absent on Private).
+/// Chat display name: `title` for groups/channels; on private chats (no
+/// title) the account's `username`, else its first/last name.
 pub(crate) async fn chat_title(api_url: &str, token: &str, chat_id: ChatId) -> Option<String> {
     let result = post_api(
         api_url,
@@ -55,24 +59,15 @@ pub(crate) async fn chat_title(api_url: &str, token: &str, chat_id: ChatId) -> O
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_owned)
         })
-}
-
-/// Forum topic display name: getForumTopic → `result.name`.
-pub(crate) async fn topic_title(
-    api_url: &str,
-    token: &str,
-    chat_id: ChatId,
-    topic_id: ThreadId,
-) -> Option<String> {
-    let result = post_api(
-        api_url,
-        token,
-        "getForumTopic",
-        serde_json::json!({ "chat_id": chat_id.0, "message_thread_id": topic_id.0.0 }),
-    )
-    .await?;
-    result
-        .get("name")
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_owned)
+        .or_else(|| {
+            // Private chats have no `title` and not every account has a
+            // username — fall back to the account's display name.
+            let first = result.get("first_name").and_then(serde_json::Value::as_str);
+            let last = result.get("last_name").and_then(serde_json::Value::as_str);
+            match (first, last) {
+                (Some(f), Some(l)) => Some(format!("{f} {l}")),
+                (Some(f), None) => Some(f.to_owned()),
+                _ => None,
+            }
+        })
 }

--- a/src/tests/background_tasks_test.rs
+++ b/src/tests/background_tasks_test.rs
@@ -4,7 +4,7 @@
 use crate::brain::agent::service::MessageEnqueueCallback;
 use crate::brain::agent::service::QueuedUserMessage;
 use crate::brain::agent::service::background_tasks::{
-    BackgroundTaskManager, CmdResult, completion_message, short_label, tail_lines,
+    BackgroundTaskManager, CmdResult, completion_message, format_elapsed, short_label, tail_lines,
 };
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
@@ -31,11 +31,18 @@ fn completion_message_reflects_success_and_failure() {
             code: 0,
             output: "test result: ok. 5 passed".into(),
         },
+        12.0,
     );
     assert!(ok.context_text.contains("exit 0 (success)"));
     assert!(ok.context_text.contains("cargo test --all-features"));
     assert!(ok.context_text.contains("Do not re-run"));
     assert!(ok.display_text.contains("finished"));
+    // #15: the typed receipt payload rides along for the echo card.
+    let meta = ok.bg_meta.expect("bg completion carries BgTaskMeta");
+    assert!(meta.success);
+    assert_eq!(meta.label, "cargo test");
+    assert_eq!(meta.elapsed_secs, 12.0);
+    assert_eq!(meta.tail, "test result: ok. 5 passed");
 
     let fail = completion_message(
         "build",
@@ -45,9 +52,23 @@ fn completion_message_reflects_success_and_failure() {
             code: 101,
             output: "error[E0001]".into(),
         },
+        3.0,
     );
     assert!(fail.context_text.contains("exit 101 (failure)"));
     assert!(fail.display_text.contains("failed"));
+    let meta = fail.bg_meta.expect("failed completion still carries meta");
+    assert!(!meta.success);
+    assert_eq!(meta.elapsed_secs, 3.0);
+}
+
+#[test]
+fn format_elapsed_buckets_match_the_spec() {
+    assert_eq!(format_elapsed(0.4), "0s");
+    assert_eq!(format_elapsed(42.0), "42s");
+    assert_eq!(format_elapsed(59.6), "1m 0s"); // rounds up into the minute bucket
+    assert_eq!(format_elapsed(185.0), "3m 5s");
+    assert_eq!(format_elapsed(3599.4), "59m 59s");
+    assert_eq!(format_elapsed(3720.0), "1h 2m");
 }
 
 #[test]

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -228,10 +228,10 @@ fn notify_receipt_card_matches_the_locked_n4_shape() {
     let (md, classic) = build_notify_receipt_card("Compiler", body);
     assert!(
         md.starts_with(
-            "<details><summary><sub>📨 <b>Compiler</b>: RECEIPT CONTRACT DELIVERED — swap \
+            "<details><summary><sub>📨 From <b>Compiler</b>: RECEIPT CONTRACT DELIVERED — swap \
              verified, a…</sub></summary>"
         ),
-        "summary = 📨 + bold sender + colon + 45-char first-line preview, whole line subbed: {md}"
+        "summary = 📨 + From + bold sender + colon + 45-char first-line preview, whole line subbed: {md}"
     );
     assert!(
         md.contains("|---|---|"),

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -229,9 +229,9 @@ fn notify_receipt_card_matches_the_locked_n4_shape() {
     assert!(
         md.starts_with(
             "<details><summary><sub>📨 <b>Compiler</b>: RECEIPT CONTRACT DELIVERED — swap \
-             verified, all…</sub></summary>"
+             verified, a…</sub></summary>"
         ),
-        "summary = 📨 + bold sender + colon + first-line preview, whole line subbed: {md}"
+        "summary = 📨 + bold sender + colon + 45-char first-line preview, whole line subbed: {md}"
     );
     assert!(
         md.contains("|---|---|"),

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -4,9 +4,10 @@
 //! HTML fallback), truncation discipline (raw text cut BEFORE conversion,
 //! wrapper tags stay intact).
 
+use crate::brain::agent::BgTaskMeta;
 use crate::channels::telegram::resume::{
-    background_task_title, build_bg_echo_bubble, build_bg_echo_bubble_md, split_bg_echo_parts,
-    split_notify_header, strip_system_framing,
+    background_task_title, build_bg_echo_bubble, build_bg_receipt_card, build_notify_receipt_card,
+    split_bg_echo_parts, split_notify_header, strip_system_framing,
 };
 use uuid::Uuid;
 

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -5,7 +5,7 @@
 //! wrapper tags stay intact).
 
 use crate::channels::telegram::resume::{
-    background_task_title, build_bg_echo_bubble, build_bg_echo_bubble_rich, split_bg_echo_parts,
+    background_task_title, build_bg_echo_bubble, build_bg_echo_bubble_md, split_bg_echo_parts,
     split_notify_header, strip_system_framing,
 };
 use uuid::Uuid;
@@ -144,43 +144,125 @@ fn html_fallback_escapes_dynamic_title() {
     assert!(html.contains("<b>📨 Ops &lt;script&gt; / Push</b>"));
     assert!(!html.contains("<script>"), "title must not inject raw HTML");
 }
-#[test]
-fn rich_bubble_uses_details_summary_envelope() {
-    let rich = build_bg_echo_bubble_rich("some output", "📨 Ops / Push to session");
-    assert!(
-        rich.starts_with("<details><summary><b>"),
-        "rich envelope must open details+summary"
-    );
-    assert!(
-        rich.contains("</summary>"),
-        "summary must close before body"
-    );
-    assert!(
-        rich.ends_with("</details>"),
-        "rich envelope must close details"
-    );
-    assert!(
-        !rich.contains("blockquote"),
-        "classic dialect must not leak into rich bubble"
-    );
-    assert!(rich.contains("<b>📨 Ops / Push to session</b>"));
-    assert!(rich.contains("some output"));
-}
 
 #[test]
-fn rich_bubble_escapes_dynamic_title() {
-    let rich = build_bg_echo_bubble_rich("body", "📨 Ops <script> / Push");
-    assert!(rich.contains("<b>📨 Ops &lt;script&gt; / Push</b>"));
-    assert!(!rich.contains("<script>"), "title must not inject raw HTML");
-}
-
-#[test]
-fn classic_and_rich_builders_stay_separate() {
-    let (_, classic) = build_bg_echo_bubble("body", "T");
-    let rich = build_bg_echo_bubble_rich("body", "T");
+fn bubble_md_and_classic_stay_separate() {
+    let (md, classic) = build_bg_echo_bubble("body", "T");
     assert!(
         classic.contains("blockquote expandable"),
         "fallback stays classic-dialect"
     );
-    assert!(rich.contains("details"), "primary stays rich-dialect");
+    assert!(
+        !md.contains('<'),
+        "markdown leg stays tag-free for the rich parser"
+    );
+}
+
+// ---- #15 receipt cards (owner-locked shapes P3f / N4) ----
+
+fn meta(success: bool, label: &str, secs: f32, tail: &str) -> BgTaskMeta {
+    BgTaskMeta {
+        success,
+        label: label.to_string(),
+        elapsed_secs: secs,
+        tail: tail.to_string(),
+    }
+}
+
+#[test]
+fn bg_receipt_card_matches_the_locked_p3f_shape() {
+    let (md, classic) = build_bg_receipt_card(&meta(
+        true,
+        "gh run watch 33117665576",
+        1646.0,
+        "line one\nline two",
+    ));
+    assert!(
+        md.starts_with(
+            "<details><summary><sub>✅ `gh run watch 33117665576` 🕒 27m 26s</sub></summary>"
+        ),
+        "summary = icon + monospace roster label + clock + duration, whole line subbed: {md}"
+    );
+    assert!(
+        md.contains("```\nline one\nline two\n```"),
+        "body is ONE fenced block with the tail verbatim"
+    );
+    assert!(md.ends_with("</details>"));
+    assert!(!md.contains("exit"), "no exit code / wording in the bubble");
+    // Degraded path stays a classic blockquote carrying the same content.
+    assert!(classic.starts_with("<blockquote expandable>"));
+    assert!(classic.contains("gh run watch 33117665576"));
+    assert!(classic.contains("line one"));
+}
+
+#[test]
+fn bg_receipt_card_failure_uses_the_cross_icon() {
+    let (md, _) = build_bg_receipt_card(&meta(false, "cargo test", 3.0, "boom"));
+    assert!(md.starts_with("<details><summary><sub>❌ `cargo test` 🕒 3s</sub></summary>"));
+}
+
+#[test]
+fn bg_receipt_card_strips_backticks_from_the_label() {
+    let (md, _) = build_bg_receipt_card(&meta(true, "cat `file`.md", 1.0, "ok"));
+    assert!(
+        md.contains("`cat file.md`"),
+        "label backticks stripped so the code span stays intact: {md}"
+    );
+}
+
+#[test]
+fn bg_receipt_card_fence_outgrows_backtick_runs_in_the_tail() {
+    let tail = "look:\n```\nnested fence\n```\ndone";
+    let (md, _) = build_bg_receipt_card(&meta(true, "cat README.md", 2.0, tail));
+    assert!(
+        md.contains("````\nlook:"),
+        "fence grows past the tail's longest backtick run"
+    );
+}
+
+#[test]
+fn notify_receipt_card_matches_the_locked_n4_shape() {
+    let body = "RECEIPT CONTRACT DELIVERED — swap verified, all three clauses journal-anchored.\n\n\
+                | Clause | Anchor |\n|---|---|\n| Build | run 1 |";
+    let (md, classic) = build_notify_receipt_card("Compiler", body);
+    assert!(
+        md.starts_with(
+            "<details><summary><sub>📨 <b>Compiler</b>: RECEIPT CONTRACT DELIVERED — swap \
+             verified, all…</sub></summary>"
+        ),
+        "summary = 📨 + bold sender + colon + first-line preview, whole line subbed: {md}"
+    );
+    assert!(
+        md.contains("|---|---|"),
+        "markdown body keeps pipe tables native for the rich parser"
+    );
+    assert!(!md.contains("```"), "notify body is never fenced");
+    assert!(md.ends_with("</details>"));
+    assert!(classic.starts_with("<blockquote expandable>"));
+    assert!(classic.contains("Compiler"));
+}
+
+#[test]
+fn notify_receipt_card_sanitizes_angle_brackets_in_sender() {
+    let (md, _) = build_notify_receipt_card("Ops <script>", "body line");
+    assert!(
+        md.contains("<b>Ops ‹script›</b>: body line"),
+        "angle brackets neutralized so the sender can't open a tag: {md}"
+    );
+    assert!(!md.contains("<script>"));
+}
+
+#[test]
+fn notify_preview_truncates_the_first_line_only() {
+    let body = format!("{}\nsecond line stays in the body", "x".repeat(80));
+    let (md, _) = build_notify_receipt_card("Worker", &body);
+    let preview = format!("{}…", "x".repeat(45));
+    assert!(
+        md.contains(&format!(": {preview}</sub>")),
+        "preview = first line truncated to 45 chars + ellipsis: {md}"
+    );
+    assert!(
+        md.contains("second line stays in the body"),
+        "the full body survives inside the fold"
+    );
 }

--- a/src/tests/channel_route_expectation_test.rs
+++ b/src/tests/channel_route_expectation_test.rs
@@ -46,6 +46,7 @@ fn msg(text: &str) -> QueuedUserMessage {
         context_text: text.to_string(),
         display_text: text.to_string(),
         origin: crate::brain::agent::PushOrigin::Other,
+        bg_meta: None,
     }
 }
 

--- a/src/tests/restart_recovery_test.rs
+++ b/src/tests/restart_recovery_test.rs
@@ -37,6 +37,7 @@ fn msg(text: &str) -> QueuedUserMessage {
         context_text: text.to_string(),
         display_text: text.to_string(),
         origin: crate::brain::agent::PushOrigin::Other,
+        bg_meta: None,
     }
 }
 

--- a/src/tests/session_notify_test.rs
+++ b/src/tests/session_notify_test.rs
@@ -18,6 +18,7 @@ fn msg() -> QueuedUserMessage {
         context_text: "[session-notify from=x]\n\nbody".to_string(),
         display_text: "notify".to_string(),
         origin: crate::brain::agent::PushOrigin::Other,
+        bg_meta: None,
     }
 }
 

--- a/src/tests/telegram_queued_origin_test.rs
+++ b/src/tests/telegram_queued_origin_test.rs
@@ -22,6 +22,7 @@ fn msg(text: &str) -> QueuedUserMessage {
         context_text: text.to_string(),
         display_text: text.to_string(),
         origin: crate::brain::agent::PushOrigin::Other,
+        bg_meta: None,
     }
 }
 

--- a/src/tests/telegram_rich_parse_test.rs
+++ b/src/tests/telegram_rich_parse_test.rs
@@ -285,6 +285,16 @@ fn has_rich_structure_gates_native_rich_path() {
     assert!(has_rich_structure("- [ ] task"));
     assert!(has_rich_structure("```\ncode\n```"));
     assert!(has_rich_structure("$$\nx^2\n$$"));
+    // <details> collapse blocks — standalone, attributed, and the inline
+    // `<details><summary>` opener the #15 receipt cards emit on ONE line.
+    // Before the #15 fix the gate only matched a standalone `<details>`
+    // line, so the fence-less notify card fell to the HTML ladder and
+    // rendered as literal tag soup on screen (owner screenshot 2026-08-28).
+    assert!(has_rich_structure("<details>\nbody\n</details>"));
+    assert!(has_rich_structure("<details open>\nbody\n</details>"));
+    assert!(has_rich_structure(
+        "<details><summary>peek</summary>\n\nbody\n\n</details>"
+    ));
     // Plain prose — even with inline emphasis — stays on the existing path.
     assert!(!has_rich_structure("Just a normal reply."));
     assert!(!has_rich_structure(
@@ -292,6 +302,28 @@ fn has_rich_structure_gates_native_rich_path() {
     ));
     assert!(!has_rich_structure("Compute 5 * 3 = 15 and move on."));
     assert!(!has_rich_structure("A #hashtag is not a heading."));
+}
+
+#[test]
+fn receipt_card_md_is_rich_structured_issue_15() {
+    // Regression for the 2026-08-28 owner screenshot: the N4 notify card
+    // is fence-less by design ("a notify is a document, not a log"), so its
+    // rich verdict must come from the inline `<details><summary>` opener
+    // alone. When the gate missed it, the card fell to the HTML ladder and
+    // Telegram escaped the unknown tags to literal soup. Both receipt
+    // shapes must stay rich-eligible end-to-end.
+    let (notify_md, _notify_html) =
+        crate::channels::telegram::resume::build_notify_receipt_card("Compiler", "body text");
+    assert!(has_rich_structure(&notify_md));
+
+    let meta = crate::brain::agent::BgTaskMeta {
+        success: true,
+        label: "cmd".to_string(),
+        elapsed_secs: 1.0,
+        tail: "ok".to_string(),
+    };
+    let (bg_md, _bg_html) = crate::channels::telegram::resume::build_bg_receipt_card(&meta);
+    assert!(has_rich_structure(&bg_md));
 }
 
 #[test]


### PR DESCRIPTION
## What this does

Renders background-task completions and `session_notify` receipts on Telegram as
collapsible rich cards (Telegram-native `<details><summary>`, rendered by the
server-side rich parser) with a **From** sender label whose identity adapts to
the reader's relation to the sender. Two owner-locked shapes:

### P3f — bg-completion receipt card

Summary line: `📣 <b>{title}</b> ({elapsed})` — bold human-readable title plus
wall-clock elapsed. Body: the fenced output tail (last N lines) wrapped in a
code fence, truncated at the configured cap. A classic blockquote-expandable
fallback shape is computed up front and only touched if the rich outbox send
fails.

Routing: the card rides the canonical markdown→rich outbox
(`send_markdown_outbox`) shared with every other rich message — the native-rich
route renders the `<details>` collapse, fenced tail and pipe tables server-side.
This replaces the interim rich-HTML echo-bubble route: that bubble builder and
its tests are removed.

### N4 — session-notify receipt card

Summary line: `📨 From <b>{sender}</b>: {preview}` (45-char preview + `…`).
Body: the full notification text under the collapsible summary.

### Sender-label ladder (both shapes)

- No route/chat context → short session id.
- DM session → the **bot's** username (never the reader's own name).
- Same chat, topic present → local topic name from the channel-message store
  (no extra API call; the Bot API has no getForumTopic).
- Same chat, no topic → short session id.
- Cross-chat → getChat title (→ @username fallback), optional `/ topic` suffix.

`<`/`>` in dynamic label/preview text are sanitized to `‹`/`›` before the HTML
parser sees them.

## Commits (fork sha → head sha)

| # | Fork sha | Head sha | Subject |
|---|----------|----------|---------|
| 1 | `5c931276` | `87882b8e` | feat(agent): carry bg-task receipt metadata through the push envelope |
| 2 | `aba7019f` | `a38ec557` | feat(tg): render bg-completion and session-notify pushes as receipt cards |
| 3 | `d03d7e01` | `23c00a36` | fix(test): point bg_push_echo_test imports at the receipt-card builders |
| 4 | `71e58ce5` | `f8f2538a` | fix(test): align N4 shape expectation with the 45-char preview boundary |
| 5 | `2d643146` | `3d0b42ef` | fix(tg): count inline details/summary openers as rich structure |
| 6 | `e9a0fa80` | `c14e07e4` | From-name sender labels on notify cards — local topic names, DM display names |
| 7 | `c6e66d7a` | `aabc3bc3` | fix(tg): label DM sessions with the bot's username, not the reader's name |
| 8 | — | `d9d6960c` | fix(tg): match upstream send_markdown_outbox arg order on the receipt-card route |

All harvested commits carry `Issue-Ref: #15` (fork tracker) and `Session-Id`
trailers. Commit 8 is the only new code on this branch: upstream moved
`reply_to` to the outbox call's last parameter after the fork's receipt route
was written; the one-line call-site fix restores compilation (first pr-checks
cycle caught it, this commit is the fix, second cycle is green).

## Verification

- pr-checks GREEN on head `d9d6960c` (fmt + clippy `-D warnings` +
  `cargo test --locked --all-features`):
  https://github.com/leshchenko1979/opencrabs/actions/runs/33226572606
  (the red first cycle: https://github.com/leshchenko1979/opencrabs/actions/runs/33226340693)
- Live smoke on a deployed build of the final harvested tip: `session notify`
  rendered in-forum as `📨 From **CLI tooling**: …` with the full body under
  the collapsible summary; bg-completion receipt cards exercised the same
  outbox route in the live box's daily operation.

## Notes

- The API-based `topic_title` lookup is dropped in favor of the local
  channel-message store (Bot API has no getForumTopic); `chat_title` no longer
  falls back to a first/last-name ladder — DM sessions label the bot, not the
  reader.
- Harvested from a diverged fork: fork-only parking/wake code from other lanes
  that shared files with these commits is NOT included here.

Tracked as fork issue https://github.com/leshchenko1979/opencrabs/issues/15
