### PR TITLE
test(telegram): governor drainer wire-test hardening — kill the 4 flake modes

### DIFF
--- a/src/channels/telegram/governor.rs
+++ b/src/channels/telegram/governor.rs
@@ -722,6 +722,12 @@ async fn deliver_final(chat_id: i64, msg_id: i32, mut pending: PendingFinal) {
     let verdict = {
         let mut map = peers().lock().unwrap_or_else(|e| e.into_inner());
         let Some(peer) = map.get_mut(&chat_id) else {
+            // The peer vanished between pop and verdict: no counter will ever
+            // move for this final. Still fire the settle hook so a parked
+            // converge loop wakes to observe the 0/0/0 shape instead of
+            // waiting out its watchdog (#28 mode 4).
+            #[cfg(test)]
+            test_support::notify_settled();
             return;
         };
         match result {
@@ -769,6 +775,11 @@ async fn deliver_final(chat_id: i64, msg_id: i32, mut pending: PendingFinal) {
             }
         }
     }
+    // Test hook (#28 mode 4): every verdict exit ends the silence — wake a
+    // parked converge loop. Precedent: the `test_support::advance` hooks in
+    // this file for the paused-clock sleeps.
+    #[cfg(test)]
+    test_support::notify_settled();
 }
 
 /// The two wire shapes a queued final can take, mirroring the call sites that
@@ -1042,6 +1053,28 @@ pub(crate) mod test_support {
     /// sleeping anywhere — mocked passage of time per the #1211 test brief.
     pub(crate) fn advance(ms: u64) {
         CLOCK_OFFSET_MS.fetch_add(ms, Ordering::Relaxed);
+    }
+
+    /// Process-wide settle notifier for the drainer wire tests (#28 mode 4).
+    /// `deliver_final` fires [`notify_settled`] on EVERY exit (delivered,
+    /// abandoned, retried, and the peer-vanished early return); a converge
+    /// loop parks on `settle_notifier().notified()` instead of pumping
+    /// virtual-time sleeps. With no tokio timer left pending in the test
+    /// task, the paused runtime performs a REAL reactor park, so the
+    /// in-flight mockito response lands in real time and the drainer's
+    /// verdict wakes the loop — the wait is event-driven, not a lottery.
+    pub(crate) fn settle_notifier() -> &'static tokio::sync::Notify {
+        static SETTLED: std::sync::OnceLock<tokio::sync::Notify> = std::sync::OnceLock::new();
+        SETTLED.get_or_init(tokio::sync::Notify::new)
+    }
+
+    /// Wake any converge loop parked on [`settle_notifier`]. `notify_one`
+    /// permit semantics: a notify with no waiter stores one permit that the
+    /// next `notified()` consumes — at worst one spurious re-check (the loop
+    /// always re-reads the settle counters before parking again), never a
+    /// lost wakeup.
+    pub(crate) fn notify_settled() {
+        settle_notifier().notify_one();
     }
 
     /// Mark a chat as an already-seen forum peer WITHOUT consuming budget,

--- a/src/tests/governor_gates_test.rs
+++ b/src/tests/governor_gates_test.rs
@@ -273,7 +273,15 @@ async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
         .create_async()
         .await;
 
-    let bot = Bot::new("TESTTOKEN").set_api_url(server.url().parse().unwrap());
+    // Not Bot::new: that applies teloxide's default_reqwest_settings(),
+    // which includes a 17s request timeout built from tokio timers. Under
+    // this test's paused clock the deadline sits on VIRTUAL time, so the
+    // converge loop's advances can cancel an in-flight request that mockito
+    // already counted -> the drainer sees Err, requeues, retries -> second
+    // wire hit -> .expect(1) flakes (~50% of runs). A client with no
+    // timeout leaves nothing for the virtual clock to race.
+    let bot = Bot::with_client("TESTTOKEN", reqwest::Client::builder().build().unwrap())
+        .set_api_url(server.url().parse().unwrap());
     assert!(
         !governor::edit_admission(
             &bot,

--- a/src/tests/governor_gates_test.rs
+++ b/src/tests/governor_gates_test.rs
@@ -232,8 +232,30 @@ async fn edit_ladder_drops_in_priority_order_and_queues_latest_wins_finals() {
     );
 }
 
+/// Install (once per process) a warn-level tracing subscriber writing to
+/// stderr, so the governor drainer's abandonment `warn!` — which carries the
+/// underlying wire error string — lands in the failing test's captured
+/// output instead of vanishing (the default test binary installs no
+/// subscriber). The drainer runs as a spawned task on this test's own
+/// current-thread runtime, so libtest attaches its stderr to THIS test.
+/// Without this a red drainer run leaves no receipt for why the wire attempt
+/// failed (#28 mode 3).
+fn ensure_tracing_capture() {
+    use std::sync::OnceLock;
+    static HOOK: OnceLock<()> = OnceLock::new();
+    HOOK.get_or_init(|| {
+        // Best effort: only the first caller in the process may install the
+        // global default; a later Err means one is already in place.
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(std::io::stderr)
+            .try_init();
+    });
+}
+
 #[tokio::test(start_paused = true)]
 async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
+    ensure_tracing_capture();
     let _guard = ts::registry_guard().await;
     ts::reset(5_000);
     rl_config!(
@@ -340,12 +362,25 @@ async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
     delivered.assert(); // wire hits within the retry budget, body matched above
     let snap = ts::snapshot(CHAT).unwrap();
     // The exactly-once invariant lives in the governor's own counter: a
-    // double-delivered final lands at 2, a lost delivery at 0.
+    // double-delivered final lands at 2, a lost delivery at 0. On red, the
+    // counters (plus the captured drainer warn below) self-report WHICH half
+    // of the pipeline stalled (#28).
     assert_eq!(
         snap.delivered_finals, 1,
-        "one delivered final must be accounted exactly once"
+        "one delivered final must be accounted exactly once: \
+         delivered={} failed={} pending={}",
+        snap.delivered_finals,
+        snap.failed_finals,
+        snap.finals_pending,
     );
-    assert_eq!(snap.failed_finals, 0);
+    assert_eq!(
+        snap.failed_finals, 0,
+        "drainer abandoned within the retry budget: \
+         delivered={} failed={} pending={}",
+        snap.delivered_finals,
+        snap.failed_finals,
+        snap.finals_pending,
+    );
     assert_eq!(snap.finals_pending, 0);
 }
 

--- a/src/tests/governor_gates_test.rs
+++ b/src/tests/governor_gates_test.rs
@@ -334,33 +334,67 @@ async fn drainer_wire_round(label: &str) {
     );
     assert_eq!(ts::snapshot(CHAT).unwrap().finals_pending, 1);
 
-    // Mock the passage of time until a token refills, polling in DRAIN_TICK
-    // steps; the spawned drainer lands the queued payload on the mock server.
-    // Everything runs on tokio's paused clock — no real sleeping anywhere.
-    let converge = async {
-        for _ in 0..60 {
-            ts::advance(600); // > 1/s refill AND > DRAIN_TICK (400ms)
-            tokio::time::sleep(Duration::from_millis(400)).await;
-            if ts::snapshot(CHAT)
-                .map(|s| s.delivered_finals == 1 && s.finals_pending == 0)
-                .unwrap_or(false)
-            {
-                break;
+    // Event-driven settle wait (#28 mode 4). `take_due_final` pops the final
+    // BEFORE the wire call, so `finals_pending` hits 0 while
+    // `delivered_finals` is still 0 — the old poll's exit condition
+    // (`delivered==1 && pending==0`) was unreachable mid-flight. Its 400ms
+    // sleep pump kept a virtual timer pending every iteration, so the
+    // paused runtime auto-advanced instead of real-parking on the reactor;
+    // the buffered mockito 200 never reached the drainer and the whole
+    // budget burned out in virtual milliseconds (receipt: run 33262674165,
+    // 0/0/0 at the exactly-once assert). Now `deliver_final` fires
+    // `ts::notify_settled()` on every verdict exit, and this loop parks on
+    // that notifier with NO tokio timer pending in this task — a real
+    // reactor park, so the in-flight response lands in real time and the
+    // drainer's verdict wakes the loop. The drainer's own DRAIN_TICK timer
+    // keeps auto-advance ticking until the wire call is in flight, then
+    // real time takes over. No real sleeping anywhere in the test itself.
+    //
+    // Watchdog: one real-clock thread per round. If the drainer is genuinely
+    // wedged (no verdict, no notify), the thread fires after 30s and the
+    // self-reporting panic below trips — the backstop the deleted 120s
+    // virtual timeout used to be (with the sleep pump gone that timeout
+    // would be the ONLY pending virtual timer and auto-advance to zero,
+    // panicking every run).
+    let watchdog = std::sync::Arc::new(tokio::sync::Notify::new());
+    let armed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+    {
+        let watchdog = std::sync::Arc::clone(&watchdog);
+        let armed = std::sync::Arc::clone(&armed);
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(30));
+            if armed.load(std::sync::atomic::Ordering::SeqCst) {
+                watchdog.notify_one();
             }
+        });
+    }
+    let wedged = loop {
+        let settled = ts::snapshot(CHAT)
+            .map(|s| s.finals_pending == 0 && (s.delivered_finals + s.failed_finals) >= 1)
+            .unwrap_or(false);
+        if settled {
+            break false;
+        }
+        tokio::select! {
+            _ = ts::settle_notifier().notified() => {
+                // A drainer exit happened; re-read the counters next pass.
+                // Keep advancing virtual time for refill / 429-wait
+                // bookkeeping while drainer timers are still pending.
+                ts::advance(600); // > 1/s refill AND > DRAIN_TICK (400ms)
+            }
+            _ = watchdog.notified() => break true,
         }
     };
-    match tokio::time::timeout(Duration::from_secs(120), converge).await {
-        Ok(()) => {}
-        Err(_) => {
-            // Self-reporting failure (#28): the counters say WHICH half of
-            // the drainer stalled — wire verdict vs bookkeeping.
-            match ts::snapshot(CHAT) {
-                Some(s) => panic!(
-                    "queued final never drained ({label}): delivered={} failed={} pending={}",
-                    s.delivered_finals, s.failed_finals, s.finals_pending
-                ),
-                None => panic!("queued final never drained: peer snapshot vanished"),
-            }
+    armed.store(false, std::sync::atomic::Ordering::SeqCst); // disarm
+    if wedged {
+        // Self-reporting failure (#28): the counters say WHICH half of
+        // the drainer stalled — wire verdict vs bookkeeping.
+        match ts::snapshot(CHAT) {
+            Some(s) => panic!(
+                "queued final never drained ({label}): delivered={} failed={} pending={}",
+                s.delivered_finals, s.failed_finals, s.finals_pending
+            ),
+            None => panic!("queued final never drained: peer snapshot vanished"),
         }
     }
 

--- a/src/tests/governor_gates_test.rs
+++ b/src/tests/governor_gates_test.rs
@@ -269,7 +269,18 @@ async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
         .with_body(
             r#"{"ok":true,"result":{"message_id":11,"date":1756166400,"chat":{"id":-100333,"title":"gates","type":"supergroup"},"text":"settled"}}"#,
         )
-        .expect(1)
+        // Retry-budget tolerance (#28, mode 2): a transient Err on the FIRST
+        // attempt — the wire hit counted, the 200 served, yet reqwest
+        // surfaced an error under paused-clock skew — makes the drainer
+        // requeue and retry, as designed. `.expect(1)` stopped the mock
+        // matching after one hit (mockito's is_missing_hits gate), so every
+        // retry got an unmatched 501 and the test died in a retry storm:
+        // one wire hit, delivered_finals stuck at 0, twice red on 39857b16.
+        // Serve the real response for the drainer's full retry budget
+        // instead; exactly-once is enforced where it lives — the
+        // delivered_finals counter asserted below.
+        .expect_at_least(1)
+        .expect_at_most(8) // governor's FINAL_MAX_ATTEMPTS
         .create_async()
         .await;
 
@@ -311,13 +322,29 @@ async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
             }
         }
     };
-    tokio::time::timeout(Duration::from_secs(120), converge)
-        .await
-        .expect("queued final never drained");
+    match tokio::time::timeout(Duration::from_secs(120), converge).await {
+        Ok(()) => {}
+        Err(_) => {
+            // Self-reporting failure (#28): the counters say WHICH half of
+            // the drainer stalled — wire verdict vs bookkeeping.
+            match ts::snapshot(CHAT) {
+                Some(s) => panic!(
+                    "queued final never drained: delivered={} failed={} pending={}",
+                    s.delivered_finals, s.failed_finals, s.finals_pending
+                ),
+                None => panic!("queued final never drained: peer snapshot vanished"),
+            }
+        }
+    }
 
-    delivered.assert(); // exactly one wire hit, body matched above
+    delivered.assert(); // wire hits within the retry budget, body matched above
     let snap = ts::snapshot(CHAT).unwrap();
-    assert_eq!(snap.delivered_finals, 1);
+    // The exactly-once invariant lives in the governor's own counter: a
+    // double-delivered final lands at 2, a lost delivery at 0.
+    assert_eq!(
+        snap.delivered_finals, 1,
+        "one delivered final must be accounted exactly once"
+    );
     assert_eq!(snap.failed_finals, 0);
     assert_eq!(snap.finals_pending, 0);
 }

--- a/src/tests/governor_gates_test.rs
+++ b/src/tests/governor_gates_test.rs
@@ -253,9 +253,14 @@ fn ensure_tracing_capture() {
     });
 }
 
-#[tokio::test(start_paused = true)]
-async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
-    ensure_tracing_capture();
+/// One full drainer round: fresh registry + virtual clock, fresh mock server
+/// and bot, one final queued through the starved edits bucket, then the
+/// spawned drainer settles it on the wire. Each round is an independent draw
+/// of the paused-clock schedule lottery; the stress variant below runs six
+/// draws so a rare wire race cannot hide behind a green run.
+///
+/// `label` names the round in every race-relevant failure message.
+async fn drainer_wire_round(label: &str) {
     let _guard = ts::registry_guard().await;
     ts::reset(5_000);
     rl_config!(
@@ -351,7 +356,7 @@ async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
             // the drainer stalled — wire verdict vs bookkeeping.
             match ts::snapshot(CHAT) {
                 Some(s) => panic!(
-                    "queued final never drained: delivered={} failed={} pending={}",
+                    "queued final never drained ({label}): delivered={} failed={} pending={}",
                     s.delivered_finals, s.failed_finals, s.finals_pending
                 ),
                 None => panic!("queued final never drained: peer snapshot vanished"),
@@ -367,7 +372,7 @@ async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
     // of the pipeline stalled (#28).
     assert_eq!(
         snap.delivered_finals, 1,
-        "one delivered final must be accounted exactly once: \
+        "one delivered final must be accounted exactly once ({label}): \
          delivered={} failed={} pending={}",
         snap.delivered_finals,
         snap.failed_finals,
@@ -375,13 +380,27 @@ async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
     );
     assert_eq!(
         snap.failed_finals, 0,
-        "drainer abandoned within the retry budget: \
+        "drainer abandoned within the retry budget ({label}): \
          delivered={} failed={} pending={}",
         snap.delivered_finals,
         snap.failed_finals,
         snap.finals_pending,
     );
     assert_eq!(snap.finals_pending, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn queued_final_drains_over_the_wire_through_mock_bot_api() {
+    ensure_tracing_capture();
+    drainer_wire_round("single").await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn queued_final_drains_over_the_wire_through_mock_bot_api_stress_6x() {
+    ensure_tracing_capture();
+    for round in 0..6 {
+        drainer_wire_round(&format!("stress-{round}")).await;
+    }
 }
 
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## What

Hardens the Telegram flood-governor drainer wire-tests so all four observed flake modes are structurally impossible, not just rare.

## Why

The drainer tests in `src/tests/governor_gates_test.rs` exercised a real tokio timing path: the drainer's settle-wait raced the mock server's response handling. Four distinct flake modes were reproduced and each is killed by a dedicated change below.

## How (5 commits)

- `436a6ba7` — timeout-free drainer client in tests: the client no longer carries a request timeout that could fire mid-test
- `adbf0843` — mock server grants the full retry budget (PascalCase `EditMessageText` + full `Message` body), so budget-exhaustion can never be a mock artifact
- `00ca9d6d` — self-reporting drainer instrument: the test reads the drainer's own state transitions instead of inferring them
- `30101911` — stress: 6x drainer draws per assertion pass
- `b6759367` — event-driven settle-wait: the test waits on a notify from the drainer itself (paused tokio + injectable clock; no real sleeps) instead of a fixed sleep racing the server

## Test evidence

- Mock telegram server + injectable clock seam; zero real sleeps in the test path.
- Gate (fmt + clippy `--locked --lib --bins --tests --all-features -D warnings` + `cargo test --locked --profile ci --all-features`, flags verbatim from ci.yml): GREEN — https://github.com/leshchenko1979/opencrabs/actions/runs/33283806285
- Shipped on the fork's production box (sha 781ecd80), smoke-passed, 0 real 429s/panics.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/28 (leshchenko1979/opencrabs#28)
