### PR TITLE
fix(plan): align archive writer/reader on one stem so completion cards post again

### DIFF
--- a/src/tests/plan_files_test.rs
+++ b/src/tests/plan_files_test.rs
@@ -344,3 +344,55 @@ async fn plan_autonomy_is_a_durable_session_policy() {
     })
     .await;
 }
+
+#[tokio::test]
+async fn archive_roundtrip_latest_archived_plan_finds_writer_output() {
+    // #16 round 2 regression: `archive_plan_files` trims the leading dot
+    // off `.opencrabs_plan_<sid>` when renaming into `archive/`, and
+    // `latest_archived_plan_from_path` must prefix-match exactly those
+    // dot-less names via the shared `plan_archive_stem`. Between c57de25c
+    // and this fix the reader computed its own prefix WITH the dot,
+    // matched nothing on disk, and every completed-plan card finalize hit
+    // its no-doc branch — zero completion cards posted.
+    in_temp_home(async {
+        let sid = Uuid::new_v4();
+        let mut plan = PlanDocument::new(sid, "Round trip".to_string());
+        plan.add_task(task(1, "t1"));
+        save_plan(&plan).await.unwrap();
+
+        // The live file is dotted…
+        let live = plan_json_path(sid).await;
+        assert!(
+            live.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with('.')),
+            "live plan file must be dotted, got {}",
+            live.display()
+        );
+
+        // …the archive name is dot-less…
+        crate::utils::plan_files::archive_plan(sid).await.unwrap();
+        let names: Vec<String> = std::fs::read_dir(archive_dir(sid).await)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            names
+                .iter()
+                .any(|n| n.starts_with("opencrabs_plan_") && n.ends_with(".json")),
+            "archive writer must produce dot-less names, got {names:?}"
+        );
+
+        // …and the reader finds it again — the round trip itself.
+        let doc = crate::utils::plan_files::latest_archived_plan(sid)
+            .await
+            .expect(
+                "latest_archived_plan must match the writer's dot-less \
+                 archive names (#16 round 2)",
+            );
+        assert_eq!(doc.title, "Round trip");
+        assert_eq!(doc.tasks.len(), 1);
+    })
+    .await;
+}

--- a/src/utils/plan_files.rs
+++ b/src/utils/plan_files.rs
@@ -559,6 +559,25 @@ pub async fn recent_archived_plan(session_id: Uuid, max_age: std::time::Duration
     recent_archive_in_dir(&dir, max_age)
 }
 
+/// Canonical archive stem for the plan living at `json_path` (#16 round 2).
+///
+/// `archive_plan_files` renames into `{stem}-{ts}.json` and
+/// `latest_archived_plan_from_path` filters archive names by this same stem
+/// prefix — BOTH must go through this one helper. The 2026-08-29 incident:
+/// the writer trimmed the leading dot off `.opencrabs_plan_<sid>` while the
+/// reader kept it, so the reader's `starts_with` prefix never matched any
+/// archive on disk, every completed-plan finalize hit its no-doc branch, and
+/// no completion card was ever posted again (zero successful finalizes
+/// between c57de25c and this fix). One stem, one place, no drift.
+fn plan_archive_stem(json_path: &Path) -> String {
+    json_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("plan")
+        .trim_start_matches('.')
+        .to_string()
+}
+
 fn archive_plan_files(json_path: &Path) -> std::io::Result<()> {
     // Archive next to wherever the plan actually lives (resolved or legacy
     // dir), so this stays sync and path-based for the loader's terminal-status
@@ -569,12 +588,7 @@ fn archive_plan_files(json_path: &Path) -> std::io::Result<()> {
         .unwrap_or_else(|| PathBuf::from("archive"));
     std::fs::create_dir_all(&dir)?;
     let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
-    let stem = json_path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("plan")
-        .trim_start_matches('.')
-        .to_string();
+    let stem = plan_archive_stem(json_path);
     if json_path.exists() {
         std::fs::rename(json_path, dir.join(format!("{stem}-{ts}.json")))?;
     }
@@ -616,15 +630,13 @@ fn archive_plan_files(json_path: &Path) -> std::io::Result<()> {
 pub fn latest_archived_plan_from_path(json_path: &Path) -> Option<PlanDocument> {
     let dir = json_path.parent()?.join("archive");
     // Only this session's own archives qualify (#1239). archive_plan_files
-    // renames into `{live-stem}-{ts}.json`, so the live file's stem prefixes
-    // precisely its session's entries no matter which layout dir holds them.
-    let prefix = format!(
-        "{}-",
-        json_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("plan")
-    );
+    // renames into `{stem}-{ts}.json`, and the stem comes from the SAME
+    // `plan_archive_stem` helper the writer uses — the live file's stem
+    // prefixes precisely its session's entries no matter which layout dir
+    // holds them. (#16 round 2: computing this stem separately at the two
+    // sites let a leading-dot trim drift between them — writer trimmed,
+    // reader kept the dot, `starts_with` never matched again.)
+    let prefix = format!("{}-", plan_archive_stem(json_path));
     let newest = std::fs::read_dir(dir)
         .ok()?
         .filter_map(|e| e.ok())


### PR DESCRIPTION
## Symptom

Completion cards stopped posting after every plan finalize. The plan's live file is a dotfile (`.opencrabs_plan_<sid>.json`). The #1239 archive-scoping rework (`c57de25c`) introduced the `archive/` layout; since then the writer's rename to `{stem}-{ts}.json` trimmed the leading dot from the stem while the reader's prefix kept it, so `latest_archived_plan_from_path`'s `starts_with` never matched anything on disk. Every completed-plan finalize hit its no-doc branch — zero completion cards posted.

## Root cause

Two sites computed the archive stem independently:

- `archive_plan_files` — `file_stem().trim_start_matches('.')` (dot trimmed)
- `latest_archived_plan_from_path` — raw `file_stem()` (dot kept)

The drift is inherent to duplicated logic; neither side is wrong on its own, they just disagree.

## Fix

One shared `plan_archive_stem()` helper; both the writer rename and the reader's prefix now go through it. No behavior change other than the reader finally matching the writer's output.

## Test

Round-trip regression test (`save -> archive -> find`) asserting the live file is dotted, the archive name is dot-less, and `latest_archived_plan` returns the title and tasks.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/40