### PR TITLE
fix(telegram): reclaim post-halt sign-off as trailer after option-surface buttons (leshchenko1979/opencrabs#31)

### DIFF
--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -1409,6 +1409,12 @@ impl AgentService {
         // fallback to a different provider rather than giving up.
         let mut phantom_retries_used: u32 = 0;
         const MAX_PHANTOM_RETRIES: u32 = 5;
+        // #31: set when a suggest_options surface halts the turn (#1178 M1).
+        // The NEXT text-only iteration is then the model's sign-off, not a
+        // phantom threat — the ack-skip path keeps it, and this flag only
+        // tags that exemption surgically in the log (the skip itself fires
+        // 70+ times/day for ordinary acks and must not be disturbed).
+        let mut option_surface_halt_seen = false;
         // Consecutive identical tool rounds (#1030). Observes only; the
         // repeated call still runs and its result still reaches the model.
         // Reset on a provider swap below, because a fallback replays the
@@ -4697,14 +4703,31 @@ impl AgentService {
                     );
                 }
                 if !phantom_eligible && tool_calls_completed_this_turn > 0 {
-                    tracing::info!(
-                        target: "phantom",
-                        tools_completed = tool_calls_completed_this_turn,
-                        text_len = iteration_text.len(),
-                        "phantom detection skipped: turn already produced successful tool calls \
-                         and the text-only iteration is a pure completion acknowledgement \
-                         (no forward-looking intent phrase)"
-                    );
+                    if option_surface_halt_seen {
+                        // #31: this text-only iteration follows a suggest_options
+                        // halt — it is the model's sign-off, not a phantom threat.
+                        // The ack-skip keeps its text as a trailing Text entry in
+                        // the flow (AFTER the option-surface Tool entry), where the
+                        // options-pending reclaim lifts it as the trailer. The text
+                        // preview closes the ~50-char truncation gap in forensics.
+                        tracing::info!(
+                            target: "phantom",
+                            tools_completed = tool_calls_completed_this_turn,
+                            text_len = iteration_text.len(),
+                            trailer_preview = %iteration_text.chars().take(160).collect::<String>(),
+                            "phantom ack classification exempted: text-only iteration follows an \
+                             option-surface halt — kept as trailing trailer entry (#31)"
+                        );
+                    } else {
+                        tracing::info!(
+                            target: "phantom",
+                            tools_completed = tool_calls_completed_this_turn,
+                            text_len = iteration_text.len(),
+                            "phantom detection skipped: turn already produced successful tool calls \
+                             and the text-only iteration is a pure completion acknowledgement \
+                             (no forward-looking intent phrase)"
+                        );
+                    }
                 }
                 let stuck_loop_now =
                     phantom_eligible && super::phantom::is_stuck_in_intent_loop(&iteration_text);
@@ -6459,6 +6482,9 @@ impl AgentService {
                                     tracing::info!(
                                         "🛑 Turn halted by option-surface tool (suggest_options)"
                                     );
+                                    // #31: the following text-only iteration is the
+                                    // sign-off — tag it for the phantom-gate exemption.
+                                    option_surface_halt_seen = true;
                                     break;
                                 }
 
@@ -6746,6 +6772,9 @@ impl AgentService {
                 // Policy routes through ToolRegistry::halts_turn (Tool::halts_turn).
                 if halt_turn_requested {
                     tracing::info!("🛑 Turn halted by option-surface tool (suggest_options)");
+                    // #31: the following text-only iteration is the sign-off —
+                    // tag it for the phantom-gate exemption.
+                    option_surface_halt_seen = true;
                     break;
                 }
             }

--- a/src/channels/telegram/delivery.rs
+++ b/src/channels/telegram/delivery.rs
@@ -6,7 +6,8 @@
 use super::TelegramState;
 use super::flow::{
     DisplayItem, StreamingState, append_intermediate_to_flow, append_system_to_flow,
-    append_tool_group, folded_duplicates_final, last_folded_text, take_folded_final,
+    append_tool_group, folded_duplicates_final, last_folded_text, settle_options_reclaim,
+    take_folded_final,
 };
 use super::handler::{fire_reaction, map_to_allowed_reaction};
 use super::intermediates::send_html_or_plain;
@@ -36,6 +37,19 @@ use uuid::Uuid;
 /// content channel holds, so it is not a parameter here.
 pub(crate) fn is_react_only(text_after_directive: &str) -> bool {
     text_after_directive.trim().is_empty()
+}
+
+/// Whether the turn ends on a suggest_options surface (#1226 K): the
+/// progress handler stashes the options mid-turn (progress.rs), so by
+/// delivery time a Some here means an option surface is armed and the
+/// flow block ends on the suggest_options Tool entry — the reclaim calls
+/// below must then look BEFORE that trailing tool for the answer.
+fn options_pending(streaming: &Arc<std::sync::Mutex<StreamingState>>) -> bool {
+    streaming
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .pending_suggestions
+        .is_some()
 }
 
 /// True when a rich-send failure means Telegram could not fetch the embedded
@@ -213,19 +227,45 @@ pub(crate) async fn deliver_final_response(
             // that predicate deliberately only matches prefix overlap. So
             // when suppression happened, strip the folded copy from the
             // block silently — it is already delivered.
+            //
+            // #31: tracks whether THIS block already reclaimed the answer, so
+            // the main reclaim below can tell "nothing left to reclaim" from
+            // "the reclaim found nothing that was ever there" in its K warn.
+            let mut pre_reclaimed = false;
             let text_only = if text_only.trim().is_empty() {
                 if suppressed_final {
-                    if let Some(discarded) = take_folded_final(bot, chat_id, streaming).await {
+                    let (discarded, discarded_trailer) =
+                        take_folded_final(bot, chat_id, streaming, options_pending(streaming))
+                            .await;
+                    if discarded.is_some() || discarded_trailer.is_some() {
                         tracing::info!(
-                            "Telegram: final suppressed by dedup — dropping {} folded \
+                            "Telegram: final suppressed by dedup — dropping {}(+{}) folded \
                              chars already delivered as intermediates (#1152)",
-                            discarded.len()
+                            discarded.as_ref().map(|t| t.len()).unwrap_or(0),
+                            discarded_trailer.as_ref().map(|t| t.len()).unwrap_or(0),
                         );
                     }
                     text_only
                 } else {
-                    match take_folded_final(bot, chat_id, streaming).await {
+                    let (reclaimed, trailer) =
+                        take_folded_final(bot, chat_id, streaming, options_pending(streaming))
+                            .await;
+                    if let Some(t) = trailer {
+                        // #31: the post-halt sign-off rides AFTER the buttons —
+                        // stash it for render_suggestions (keep-never-discard).
+                        streaming
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .pending_trailer = Some(t);
+                        tracing::info!(
+                            "Telegram: stashed {} trailer chars reclaimed before the react \
+                             decision (#31)",
+                            t.len()
+                        );
+                    }
+                    match reclaimed {
                         Some(reclaimed) => {
+                            pre_reclaimed = true;
                             tracing::info!(
                                 "Telegram: reclaimed folded final ({} chars) before react \
                                  decision (#478)",
@@ -533,59 +573,71 @@ pub(crate) async fn deliver_final_response(
             // reclaim it. For other providers (or CLI turns where the answer stayed
             // in content), if the same text ended up both folded and in the final
             // response, remove the folded copy to avoid showing it twice.
-            let text_only = if text_only.trim().is_empty() {
+            //
+            // #31: with options pending the reclaim returns BOTH runs — the
+            // answer as host, the post-halt sign-off run as trailer — and
+            // `settle_options_reclaim` arbitrates. The options arm runs FIRST:
+            // the stock trailing-duplicate strip used to pop the trailer run
+            // and drop the host with it (the smoke-v4 abandonment).
+            let (text_only, reclaimed_trailer) = if text_only.trim().is_empty() {
                 // CLI provider case: no separate answer, reclaim the folded final
-                take_folded_final(bot, chat_id, streaming)
-                    .await
-                    .unwrap_or(text_only)
+                let (host, trailer) =
+                    take_folded_final(bot, chat_id, streaming, options_pending(streaming)).await;
+                settle_options_reclaim(text_only, host, trailer)
+            } else if options_pending(streaming) {
+                // #1226 flow-fold (K) + #31 trailer: the turn halted on the
+                // suggest_options surface — the substantive pre-options answer
+                // is the Text run BEFORE the Tool entry, the sign-off ack the
+                // run AFTER it. Reclaim both; the answer becomes the final
+                // bubble, the ack rides after the buttons.
+                let (host, trailer) = take_folded_final(bot, chat_id, streaming, true).await;
+                if host.is_none() && trailer.is_none() && !pre_reclaimed {
+                    tracing::warn!(
+                        "Telegram: options pending but flow reclaim returned nothing — \
+                         answer stuck in flow block (#1226 K)"
+                    );
+                }
+                let (text, trailer) = settle_options_reclaim(text_only, host, trailer);
+                if let Some(t) = &trailer {
+                    tracing::info!(
+                        "Telegram: options reclaim settled — {} trailer chars ride after \
+                         the buttons (#31)",
+                        t.len()
+                    );
+                }
+                (text, trailer)
             } else {
                 // Non-CLI case: check if the trailing folded text matches the final
                 // answer and remove it to prevent duplication
-                let mut final_text = text_only;
                 let trailing_matches = {
                     let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
                     // Past any chrome appended after the answer (#1253): a
                     // provider switch landing late must not hide the folded
                     // copy and let it render twice.
                     match last_folded_text(&s.flow_entries) {
-                        Some(folded) => folded_duplicates_final(folded, &final_text),
+                        Some(folded) => folded_duplicates_final(folded, &text_only),
                         None => false,
                     }
                 };
                 if trailing_matches {
                     // Remove the duplicate from the block
-                    take_folded_final(bot, chat_id, streaming).await;
-                    final_text
+                    take_folded_final(bot, chat_id, streaming, options_pending(streaming)).await;
+                    (text_only, None)
                 } else {
-                    // #1226 flow-fold: a turn ending at the suggest_options
-                    // surface halts with its substantive pre-options answer
-                    // folded inside the flow block (thin narration folds, #582;
-                    // sent_intermediates stays empty, so dedup never sees it)
-                    // while response.content carries a short closing pointer.
-                    // When suggestions are pending, promote any REMAINING
-                    // trailing folded run into the final bubble — otherwise the
-                    // answer lives only inside the collapsed processing log and
-                    // the buttons merge onto the thin pointer. Trailing Text
-                    // after the last tool IS the final answer (flow.rs
-                    // invariant), so interstitial narration cannot be promoted.
-                    // Norm-equal / prefix duplicates were already popped above.
-                    let options_pending = {
-                        let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-                        s.pending_suggestions.is_some()
-                    };
-                    if options_pending
-                        && let Some(folded) = take_folded_final(bot, chat_id, streaming).await
-                    {
-                        tracing::info!(
-                            "Telegram: promote {} folded chars into final bubble \
-                                 (suggestions pending, #1226)",
-                            folded.len()
-                        );
-                        final_text = format!("{folded}\n\n{final_text}");
-                    }
-                    final_text
+                    (text_only, None)
                 }
             };
+
+            // #31: hand the trailer to render_suggestions — rich merges it as
+            // a paragraph after the in-body button rows, classic delivers it
+            // as its own bubble. Stashed here so both render sites (handler
+            // turn end + resume) pick it up identically.
+            if let Some(trailer) = reclaimed_trailer {
+                streaming
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .pending_trailer = Some(trailer);
+            }
 
             // #690: re-expand any table the model collapsed onto one line so it
             // renders (native rich or <pre> grid) instead of raw pipes. Applied

--- a/src/channels/telegram/delivery.rs
+++ b/src/channels/telegram/delivery.rs
@@ -251,6 +251,7 @@ pub(crate) async fn deliver_final_response(
                         take_folded_final(bot, chat_id, streaming, options_pending(streaming))
                             .await;
                     if let Some(t) = trailer {
+                        let trailer_len = t.len();
                         // #31: the post-halt sign-off rides AFTER the buttons —
                         // stash it for render_suggestions (keep-never-discard).
                         streaming
@@ -260,7 +261,7 @@ pub(crate) async fn deliver_final_response(
                         tracing::info!(
                             "Telegram: stashed {} trailer chars reclaimed before the react \
                              decision (#31)",
-                            t.len()
+                            trailer_len
                         );
                     }
                     match reclaimed {

--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -76,6 +76,13 @@ pub(crate) struct StreamingState {
     /// the options here and render them once, after the final delivery. Only the
     /// latest set is kept if the tool fires more than once.
     pub(crate) pending_suggestions: Option<Vec<String>>,
+    /// Trailing text reclaimed from the flow AFTER the option-surface Tool
+    /// entry (#31): the model's post-halt sign-off iteration. Stashed by the
+    /// options-pending reclaim in `deliver_final_response`, rendered by
+    /// `render_suggestions` — rich: paragraph after the in-body button rows;
+    /// classic: its own bubble. Keep-never-discard: the ack must neither leak
+    /// into the answer bubble nor vanish with the flow block.
+    pub(crate) pending_trailer: Option<String>,
     /// Response/thinking message (always at bottom)
     pub(crate) msg_id: Option<MessageId>,
     /// Reasoning/thinking text — streamed live, cleared before tool calls or response
@@ -1688,26 +1695,58 @@ pub(crate) async fn restick_flow_if_buried(
 /// without it (header-only when it empties), and returns the text.
 /// Returns `None` when the flow ended on a tool call — then the answer is in
 /// `response.content` and the normal delivery path handles it.
+///
+/// `options_pending`: the turn ends on a `suggest_options` surface (#1226 K).
+/// The substantive answer then sits in the Text run BEFORE the trailing Tool
+/// entry — the halted turn never moves it into `response.content`, so the
+/// stock "flow ended on a tool -> answer is in content" invariant breaks.
+/// The popper lifts the trailing Tool run aside, reclaims that Text run, and
+/// restores the Tool run on top: only the answer text leaves the block, the
+/// tool history stays.
+///
+/// #31: a text-only iteration AFTER the halt leaves its sign-off run as a
+/// Text entry past the Tool — the popper returns BOTH runs as
+/// `(host, trailer)` and nothing is discarded. The host is the answer, the
+/// trailer rides after the buttons; when both are `None` the entries are
+/// untouched.
 pub(crate) async fn take_folded_final(
     bot: &Bot,
     chat: ChatId,
     streaming: &Arc<std::sync::Mutex<StreamingState>>,
-) -> Option<String> {
-    let text = {
+    options_pending: bool,
+) -> (Option<String>, Option<String>) {
+    let (host, trailer, none_kind): (Option<String>, Option<String>, Option<&'static str>) = {
         let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-        pop_trailing_folded_texts(&mut s.flow_entries)
+        let (host, trailer) = pop_trailing_folded_texts(&mut s.flow_entries, options_pending);
+        // #1226: a None here used to be silent, which made the K failure mode
+        // (answer stranded in the collapsed flow) undiagnosable from logs.
+        // Name what the flow ended on.
+        let kind = (host.is_none() && trailer.is_none()).then(|| match s.flow_entries.last() {
+            Some(FlowEntry::Tool(_)) => "Tool",
+            Some(FlowEntry::Text(_)) => "Text",
+            Some(FlowEntry::System(_)) => "System",
+            None => "empty",
+        });
+        (host, trailer, kind)
     };
-    text.as_ref()?;
-    // Re-render the block without the promoted answer. An emptied block is
-    // NOT deleted anymore: the flow message is the turn's chrome surface
-    // (header, sections, ctx) and settles header-only at turn end, same as a
-    // no-tool long turn.
-    refresh_flow(bot, chat, streaming, super::governor::EditClass::Final).await;
-    text
+    if let Some(kind) = none_kind {
+        tracing::info!(
+            "Telegram: take_folded_final reclaimed nothing (flow ended on {kind}, \
+             options_pending={options_pending}) (#1226)"
+        );
+    }
+    if host.is_some() || trailer.is_some() {
+        // Re-render the block without the promoted runs. An emptied block is
+        // NOT deleted anymore: the flow message is the turn's chrome surface
+        // (header, sections, ctx) and settles header-only at turn end, same as a
+        // no-tool long turn.
+        refresh_flow(bot, chat, streaming, super::governor::EditClass::Final).await;
+    }
+    (host, trailer)
 }
 
-/// Pop the trailing run of folded model `Text` entries and join them
-/// (#478). Mid-turn narration is always followed by more tool calls, so
+/// Pop the trailing folded `Text` runs, split into host and trailer runs
+/// (#478, #31). Mid-turn narration is always followed by more tool calls, so
 /// the trailing text run after the last tool IS the final answer — and
 /// since #475 keeps ONE block across queued follow-ups, that answer can
 /// be multi-part. Popping only the last entry left earlier parts
@@ -1720,25 +1759,95 @@ pub(crate) async fn take_folded_final(
 /// behind a provider switch produced: the banner became the answer, and
 /// because the answer then read as non-empty, the react-only path never
 /// ran and the reaction was never sent either.
-pub(crate) fn pop_trailing_folded_texts(entries: &mut Vec<FlowEntry>) -> Option<String> {
-    // The candidate run is everything after the last tool call.
-    let run_start = entries
-        .iter()
-        .rposition(|e| matches!(e, FlowEntry::Tool(_)))
-        .map_or(0, |i| i + 1);
-    let mut parts: Vec<String> = Vec::new();
-    let mut chrome: Vec<FlowEntry> = Vec::new();
-    for entry in entries.drain(run_start..) {
-        match entry {
-            FlowEntry::Text(t) => parts.push(t),
-            other => chrome.push(other),
+///
+/// `options_pending` (#1226 K): the turn halted on a `suggest_options`
+/// call, so a Tool entry sits LAST and the answer is the Text run
+/// immediately BEFORE it. Lift the trailing Tool run aside, pop that Text
+/// run, then restore the Tool run in its original order — the block keeps
+/// its tool history; only the answer text is reclaimed. When no Text run
+/// precedes the tools nothing is popped and the entries are untouched.
+///
+/// #31: when the model's text-only iteration FOLLOWED the halt, its
+/// sign-off run sits AFTER the Tool entry as the trailer. That run is
+/// popped FIRST, then the K lift runs — the return is `(host, trailer)`
+/// and nothing is discarded. `trailer` is always `None` without
+/// `options_pending` (the stock pop never looks past a Tool entry).
+pub(crate) fn pop_trailing_folded_texts(
+    entries: &mut Vec<FlowEntry>,
+    options_pending: bool,
+) -> (Option<String>, Option<String>) {
+    if !options_pending {
+        // The candidate run is everything after the last tool call.
+        let run_start = entries
+            .iter()
+            .rposition(|e| matches!(e, FlowEntry::Tool(_)))
+            .map_or(0, |i| i + 1);
+        let mut parts: Vec<String> = Vec::new();
+        let mut chrome: Vec<FlowEntry> = Vec::new();
+        for entry in entries.drain(run_start..) {
+            match entry {
+                FlowEntry::Text(t) => parts.push(t),
+                other => chrome.push(other),
+            }
+        }
+        entries.extend(chrome);
+        if parts.is_empty() {
+            return (None, None);
+        }
+        return (Some(parts.join("\n\n")), None);
+    }
+
+    // #31: the post-halt trailer run sits AFTER the trailing Tool entry —
+    // pop it first, then run the K lift for the host run.
+    let join = |mut parts: Vec<String>| {
+        parts.reverse();
+        parts.join("\n\n")
+    };
+    let mut trailer_parts: Vec<String> = Vec::new();
+    while matches!(entries.last(), Some(FlowEntry::Text(_))) {
+        match entries.pop() {
+            Some(FlowEntry::Text(t)) => trailer_parts.push(t),
+            other => {
+                if let Some(e) = other {
+                    entries.push(e);
+                }
+                break;
+            }
         }
     }
-    entries.extend(chrome);
-    if parts.is_empty() {
-        return None;
+    let mut aside: Vec<FlowEntry> = Vec::new();
+    while matches!(entries.last(), Some(FlowEntry::Tool(_))) {
+        if let Some(e) = entries.pop() {
+            aside.push(e);
+        }
     }
-    Some(parts.join("\n\n"))
+    let mut host_parts: Vec<String> = Vec::new();
+    while matches!(entries.last(), Some(FlowEntry::Text(_))) {
+        match entries.pop() {
+            Some(FlowEntry::Text(t)) => host_parts.push(t),
+            other => {
+                if let Some(e) = other {
+                    entries.push(e);
+                }
+                break;
+            }
+        }
+    }
+    let had_trailing_tools = !aside.is_empty();
+    while let Some(e) = aside.pop() {
+        entries.push(e);
+    }
+
+    if !had_trailing_tools {
+        // No Tool entry trailed the run — the gate's precondition (flow ends
+        // on the suggest Tool) does not hold, so the popped run is just the
+        // stock trailing answer. Return it as the host, never as a trailer.
+        let host = (!trailer_parts.is_empty()).then(|| join(trailer_parts));
+        return (host, None);
+    }
+    let host = (!host_parts.is_empty()).then(|| join(host_parts));
+    let trailer = (!trailer_parts.is_empty()).then(|| join(trailer_parts));
+    (host, trailer)
 }
 
 /// The last model-authored folded text, looking past any system chrome
@@ -1784,4 +1893,43 @@ pub(crate) fn folded_duplicates_final(folded: &str, final_text: &str) -> bool {
     }
     let overlap = norm_folded.len().min(norm_final.len());
     overlap >= 20 && (norm_final.starts_with(&norm_folded) || norm_folded.starts_with(&norm_final))
+}
+
+/// Settle the options-pending reclaim into `(final text, trailer)` (#31).
+///
+/// `content` is the response.content text — with an option-surface halt the
+/// trailing text-only iteration usually leaks its sign-off ack here. `host`
+/// is the reclaimed answer run (before the trailing Tool), `trailer` the
+/// reclaimed post-halt run (after it). Pure so the #31 arbitration is unit-
+/// testable without a Bot or a session.
+///
+/// Rules, per the owner-approved design:
+/// - The host WINS the content slot. The old prepend (`host\n\ncontent`)
+///   shipped the ack inside the answer bubble; the answer must not stay
+///   imprisoned in the flow block and the ack must not ride inside it.
+/// - The trailer survives unless it duplicates the final text (provider
+///   double-copy observed inferhub-side in smoke v4/S4) — no double-send.
+/// - Keep-never-discard: when the popper found no trailer run but content
+///   carries a non-duplicate leftover (the ack never folded into the flow),
+///   the content text BECOMES the trailer instead of vanishing.
+pub(crate) fn settle_options_reclaim(
+    content: String,
+    host: Option<String>,
+    trailer: Option<String>,
+) -> (String, Option<String>) {
+    let text = match &host {
+        Some(h) => h.clone(),
+        None => content.clone(),
+    };
+    let trailer = match trailer {
+        Some(t) if folded_duplicates_final(&t, &text) => None,
+        Some(t) => Some(t),
+        None => match host {
+            Some(_) if !content.trim().is_empty() && !folded_duplicates_final(&content, &text) => {
+                Some(content)
+            }
+            _ => None,
+        },
+    };
+    (text, trailer)
 }

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2394,6 +2394,7 @@ pub(crate) async fn handle_message(
     let streaming = Arc::new(std::sync::Mutex::new(StreamingState {
         is_dm,
         pending_suggestions: None,
+        pending_trailer: None,
         msg_id: None,
         thinking: String::new(),
         tool_msgs: Vec::new(),
@@ -2868,10 +2869,11 @@ pub(crate) async fn handle_message(
     if let Some(options) = suggestions {
         // Merge candidate (#tg-suggest-merge): the bubble the final response
         // landed in, captured by deliver_final_response. Attaching the
-        // keyboard THERE kills the separate "Suggested next" bubble.
-        let merge_host = {
+        // keyboard THERE kills the separate "Suggested next" bubble. The
+        // #31 sign-off trailer rides along — it renders after the buttons.
+        let (merge_host, trailer) = {
             let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-            s.final_bubble.take()
+            (s.final_bubble.take(), s.pending_trailer.take())
         };
         super::suggest_options::render_suggestions(
             &bot,
@@ -2881,6 +2883,7 @@ pub(crate) async fn handle_message(
             thread_id,
             options,
             merge_host,
+            trailer,
         )
         .await;
     }

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -312,6 +312,7 @@ pub(crate) async fn resume_session_inner(
         // Telegram: positive chat id = private/DM, negative = group (#677).
         is_dm: chat_id.0 > 0,
         pending_suggestions: None,
+        pending_trailer: None,
         msg_id: None,
         thinking: String::new(),
         tool_msgs: Vec::new(),
@@ -663,9 +664,11 @@ pub(crate) async fn resume_session_inner(
         .pending_suggestions
         .take();
     if let Some(options) = suggestions {
-        let merge_host = {
+        // #31: the sign-off trailer rides to render_suggestions with the
+        // merge host — same last-out-of-the-flow ordering as handle_message.
+        let (merge_host, trailer) = {
             let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-            s.final_bubble.take()
+            (s.final_bubble.take(), s.pending_trailer.take())
         };
         super::suggest_options::render_suggestions(
             &bot,
@@ -675,6 +678,7 @@ pub(crate) async fn resume_session_inner(
             thread_id,
             options,
             merge_host,
+            trailer,
         )
         .await;
     }

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -655,6 +655,20 @@ impl TelegramState {
         }
     }
 
+    /// Peek at the merged host WITHOUT consuming the stash (#31): the
+    /// trailer-send decision in render_suggestions needs to know whether the
+    /// RICH merge actually landed (the embedded trailer shipped with it) or
+    /// the placement fell back to standalone (no embed ever hit the wire).
+    /// `attach_followup_host` fires only on merge success, so Some(host) ==
+    /// "the merge path landed".
+    pub(crate) async fn peek_followup_host(&self, token: &str) -> Option<MergedHost> {
+        self.pending_followups
+            .lock()
+            .await
+            .get(token)
+            .and_then(|e| e.host.clone())
+    }
+
     /// Forget an unused registration (buttons never landed).
     pub(crate) async fn drop_pending_followup(&self, token: &str) {
         self.pending_followups.lock().await.remove(token);

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 
 use teloxide::payloads::{EditMessageTextSetters, SendMessageSetters};
+use teloxide::prelude::Requester;
 use teloxide::types::{ChatId, InlineKeyboardButton, InlineKeyboardMarkup, ParseMode, ThreadId};
 use uuid::Uuid;
 

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -173,6 +173,7 @@ pub(crate) fn suggestion_rows_rich_html(options: &[String], token: &str) -> Stri
     }
 }
 
+#[allow(clippy::too_many_arguments)] // #31: trailer rides the existing arg set
 pub(crate) async fn render_suggestions(
     bot: &teloxide::Bot,
     state: &Arc<TelegramState>,
@@ -331,10 +332,8 @@ pub(crate) async fn render_suggestions(
                     .await
                     .map(|h| h.rich && trailer.is_some())
                     .unwrap_or(false);
-                if !embedded {
-                    if let Some(t) = &trailer {
-                        send_trailer_bubble(bot, chat_id, thread_id, t).await;
-                    }
+                if !embedded && let Some(t) = &trailer {
+                    send_trailer_bubble(bot, chat_id, thread_id, t).await;
                 }
             }
             Err(e) => {

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -185,10 +185,22 @@ pub(crate) async fn render_suggestions(
     // instead of two, no "Suggested next" header. None or failed edit =
     // standalone fallback below.
     merge_host: Option<super::state::MergeBubble>,
+    // #31: the post-halt sign-off run reclaimed from the flow (after the
+    // suggest_options Tool entry). Rich merge: embedded as a paragraph AFTER
+    // the in-body button rows (one message, never removed). Every other
+    // shape: its own bubble after placement — content, not chrome, so it
+    // ships even when the buttons die.
+    trailer: Option<String>,
 ) {
     use teloxide::prelude::Requester;
 
     if options.is_empty() {
+        // Stash cleared between delivery and render (mid-turn tap, newer
+        // turn) — the trailer still ships (#31); there is nothing to
+        // register and no keyboard to place.
+        if let Some(t) = &trailer {
+            send_trailer_bubble(bot, chat_id, thread_id, t).await;
+        }
         return;
     }
 
@@ -265,6 +277,12 @@ pub(crate) async fn render_suggestions(
         if rich {
             new_html.push('\n');
             new_html.push_str(&suggestion_rows_rich_html(&options, &token));
+            // #31: the sign-off paragraph rides AFTER the button rows — one
+            // message carries answer + controls + trailer, in that order.
+            if let Some(t) = &trailer {
+                new_html.push('\n');
+                new_html.push_str(&super::rich::markdown_to_html_p(t));
+            }
         }
         let outcome: Result<(), String> = if rich {
             super::rich::api::edit_rich_html(
@@ -301,6 +319,22 @@ pub(crate) async fn render_suggestions(
                         },
                     )
                     .await;
+                // #31: did the trailer actually ride inside the merged panel?
+                // Only when the RICH merge landed — the standalone body never
+                // carries the embed. The followup host is attached ONLY on
+                // merge success, so it doubles as the landed-path probe; no
+                // host = standalone landed = the trailer still owes its
+                // bubble.
+                let embedded = state
+                    .peek_followup_host(&token)
+                    .await
+                    .map(|h| h.rich && trailer.is_some())
+                    .unwrap_or(false);
+                if !embedded {
+                    if let Some(t) = &trailer {
+                        send_trailer_bubble(bot, chat_id, thread_id, t).await;
+                    }
+                }
             }
             Err(e) => {
                 tracing::warn!(
@@ -330,6 +364,54 @@ pub(crate) async fn render_suggestions(
             // The buttons never landed — drop the stash so a stale entry can't
             // swallow an unrelated future tap.
             state.drop_pending_followup(&token).await;
+        }
+        // #31: the standalone body never carries the embed — whether the
+        // buttons landed or died, the sign-off ships as its own bubble.
+        if let Some(t) = &trailer {
+            send_trailer_bubble(bot, chat_id, thread_id, t).await;
+        }
+    }
+}
+
+/// The #31 sign-off trailer as its own bubble: Markdown rendered with the
+/// same HTML wire as every other telegram bubble, thread-routed, with a
+/// plain-text retry when the parse-mode send is rejected — a malformed
+/// markdown construct must degrade the sign-off, never discard it
+/// (keep-never-discard is the whole point of #31).
+async fn send_trailer_bubble(
+    bot: &teloxide::Bot,
+    chat_id: ChatId,
+    thread_id: Option<ThreadId>,
+    trailer: &str,
+) {
+    use teloxide::prelude::Requester;
+
+    let html = super::markdown::markdown_to_telegram_html(trailer);
+    let mut req = bot.send_message(chat_id, html).parse_mode(ParseMode::Html);
+    if let Some(tid) = thread_id {
+        req = req.message_thread_id(tid);
+    }
+    match req.await {
+        Ok(msg) => {
+            tracing::info!("Telegram: #31 trailer bubble delivered as msg {}", msg.id);
+        }
+        Err(e) => {
+            tracing::warn!("Telegram: #31 trailer bubble HTML send failed ({e}) — retrying plain");
+            let mut plain = bot.send_message(chat_id, trailer);
+            if let Some(tid) = thread_id {
+                plain = plain.message_thread_id(tid);
+            }
+            match plain.await {
+                Ok(msg) => {
+                    tracing::info!(
+                        "Telegram: #31 trailer bubble delivered plain as msg {}",
+                        msg.id
+                    );
+                }
+                Err(e2) => {
+                    tracing::warn!("Telegram: #31 trailer bubble dropped after plain retry: {e2}");
+                }
+            }
         }
     }
 }

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -10,7 +10,6 @@
 use std::sync::Arc;
 
 use teloxide::payloads::{EditMessageTextSetters, SendMessageSetters};
-use teloxide::prelude::Requester;
 use teloxide::types::{ChatId, InlineKeyboardButton, InlineKeyboardMarkup, ParseMode, ThreadId};
 use uuid::Uuid;
 

--- a/src/tests/telegram_folded_reclaim_suppression_test.rs
+++ b/src/tests/telegram_folded_reclaim_suppression_test.rs
@@ -52,8 +52,9 @@ fn pop_joins_whole_trailing_text_run() {
         FlowEntry::Text("part one".to_string()),
         FlowEntry::Text("part two".to_string()),
     ];
-    let joined = pop_trailing_folded_texts(&mut entries).expect("trailing run exists");
-    assert_eq!(joined, "part one\n\npart two");
+    let (joined, trailer) = pop_trailing_folded_texts(&mut entries, false);
+    assert_eq!(joined.as_deref(), Some("part one\n\npart two"));
+    assert_eq!(trailer, None, "stock pop never produces a trailer");
     assert_eq!(entries.len(), 1, "the Tool entry must survive");
 }
 
@@ -66,8 +67,8 @@ fn pop_stops_at_tool_entry() {
         FlowEntry::Tool(1),
         FlowEntry::Text("tail".to_string()),
     ];
-    let joined = pop_trailing_folded_texts(&mut entries).expect("tail run exists");
-    assert_eq!(joined, "tail");
+    let (joined, _) = pop_trailing_folded_texts(&mut entries, false);
+    assert_eq!(joined.as_deref(), Some("tail"));
     assert_eq!(entries.len(), 2, "narration + tool stay in the block");
 }
 
@@ -76,5 +77,5 @@ fn pop_on_tool_ended_flow_returns_none() {
     // Flow ended on a tool call -> nothing folded to strip; delivery falls
     // through to response.content handling as before.
     let mut entries: Vec<FlowEntry> = vec![FlowEntry::Tool(3)];
-    assert_eq!(pop_trailing_folded_texts(&mut entries), None);
+    assert_eq!(pop_trailing_folded_texts(&mut entries, false), (None, None));
 }

--- a/src/tests/telegram_options_reclaim_test.rs
+++ b/src/tests/telegram_options_reclaim_test.rs
@@ -1,0 +1,245 @@
+//! Tests for the #1226 K fix and the #31 trailer reclaim.
+//!
+//! #1226 incident (smoke v3, 2026-08-28): the model delivered its final
+//! answer mid-turn, then called suggest_options; the turn halted with
+//! `options_pending`, the promote branch asked for the folded final, got
+//! None silently, and the answer stayed imprisoned (badly formatted) in
+//! the flow block while the buttons landed standalone.
+//!
+//! The fix gives `pop_trailing_folded_texts` an options-aware gate: when
+//! options are pending it lifts the trailing Tool run aside, pops the Text
+//! run immediately before it, and RESTORES the Tool run on top — only the
+//! answer text leaves the block, the tool history stays. The gate never
+//! fires on turns that did not halt on an option surface.
+//!
+//! #31 extension (smoke v4 abandonment): after the halt, the model's
+//! text-only sign-off iteration folds ANOTHER Text run into the flow —
+//! AFTER the suggest_options Tool entry. The gate now returns BOTH runs:
+//! `(host, trailer)` — the answer before the Tool, the sign-off after it.
+//! Nothing is discarded; `settle_options_reclaim` arbitrates against
+//! `response.content` (host wins the content slot, duplicates die,
+//! an unfolded content leftover is promoted to the trailer).
+
+use crate::channels::telegram::flow::{
+    FlowEntry, pop_trailing_folded_texts, settle_options_reclaim,
+};
+
+#[test]
+fn options_pending_reclaims_answer_before_trailing_tool() {
+    // The K shape: answer folded, then suggest_options appends a Tool
+    // entry LAST. The gate must reach past the tool and pop the answer.
+    let mut entries = vec![
+        FlowEntry::Text("the substantive answer".into()),
+        FlowEntry::Tool(4),
+    ];
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, true);
+    assert_eq!(host.as_deref(), Some("the substantive answer"));
+    assert_eq!(trailer, None, "no post-halt run folded");
+    // The Tool entry is RESTORED — the flow block keeps its tool history.
+    assert_eq!(entries.len(), 1, "tool entry restored after reclaim");
+    assert!(matches!(entries[0], FlowEntry::Tool(4)));
+}
+
+#[test]
+fn options_pending_pops_whole_run_before_tool() {
+    // Multi-part answer (#478 run semantics carry across the gate): both
+    // parts come out, joined in order; earlier narration behind an older
+    // tool stays in the block.
+    let mut entries = vec![
+        FlowEntry::Text("mid-turn narration".into()),
+        FlowEntry::Tool(2),
+        FlowEntry::Text("answer part one".into()),
+        FlowEntry::Text("answer part two".into()),
+        FlowEntry::Tool(5),
+    ];
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, true);
+    assert_eq!(host.as_deref(), Some("answer part one\n\nanswer part two"));
+    assert_eq!(trailer, None);
+    assert_eq!(entries.len(), 3, "narration + old tool + suggest tool stay");
+    assert!(matches!(entries[0], FlowEntry::Text(_)));
+    assert!(matches!(entries[1], FlowEntry::Tool(2)));
+    assert!(matches!(entries[2], FlowEntry::Tool(5)));
+}
+
+#[test]
+fn options_pending_restores_multiple_trailing_tools_in_order() {
+    let mut entries = vec![
+        FlowEntry::Text("answer".into()),
+        FlowEntry::Tool(1),
+        FlowEntry::Tool(2),
+    ];
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, true);
+    assert_eq!(host.as_deref(), Some("answer"));
+    assert_eq!(trailer, None);
+    assert_eq!(entries.len(), 2, "both tools restored");
+    assert!(matches!(entries[0], FlowEntry::Tool(1)));
+    assert!(matches!(entries[1], FlowEntry::Tool(2)));
+}
+
+#[test]
+fn options_pending_without_preceding_text_changes_nothing() {
+    // No Text run before the trailing tools: nothing to reclaim, and the
+    // entries must come back untouched (no mutation on None).
+    let mut entries = vec![FlowEntry::Tool(3), FlowEntry::Tool(4)];
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, true);
+    assert_eq!(host, None);
+    assert_eq!(trailer, None);
+    assert_eq!(entries.len(), 2);
+    assert!(matches!(entries[0], FlowEntry::Tool(3)));
+    assert!(matches!(entries[1], FlowEntry::Tool(4)));
+}
+
+#[test]
+fn options_pending_pops_host_and_trailer_around_tool() {
+    // #31 both-runs shape: the sign-off folds AFTER the suggest_options
+    // Tool entry. The gate returns host AND trailer; the Tool entry is
+    // restored so the flow block keeps its tool history.
+    let mut entries = vec![
+        FlowEntry::Text("mid-turn narration".into()),
+        FlowEntry::Tool(2),
+        FlowEntry::Text("the substantive answer".into()),
+        FlowEntry::Tool(4),
+        FlowEntry::Text("trailer line one".into()),
+        FlowEntry::Text("trailer line two".into()),
+    ];
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, true);
+    assert_eq!(host.as_deref(), Some("the substantive answer"));
+    assert_eq!(
+        trailer.as_deref(),
+        Some("trailer line one\n\ntrailer line two"),
+        "post-halt run joins in order"
+    );
+    assert_eq!(entries.len(), 3, "narration + old tool + suggest tool stay");
+    assert!(matches!(entries[0], FlowEntry::Text(_)));
+    assert!(matches!(entries[1], FlowEntry::Tool(2)));
+    assert!(matches!(entries[2], FlowEntry::Tool(4)));
+}
+
+#[test]
+fn options_pending_trailer_only_when_no_host_text() {
+    // The answer arrived in response.content (never folded), but the
+    // sign-off still folded after the Tool entry: trailer comes back
+    // alone, host None, tool history intact.
+    let mut entries = vec![
+        FlowEntry::Tool(4),
+        FlowEntry::Text("all set — sign-off".into()),
+    ];
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, true);
+    assert_eq!(host, None);
+    assert_eq!(trailer.as_deref(), Some("all set — sign-off"));
+    assert_eq!(entries.len(), 1);
+    assert!(matches!(entries[0], FlowEntry::Tool(4)));
+}
+
+#[test]
+fn options_pending_trailing_text_without_tool_is_host() {
+    // Tolerance: no Tool entry trailed the run — the gate's precondition
+    // (flow ends on the suggest Tool) does not hold, so the popped run is
+    // the stock trailing answer, NEVER a trailer.
+    let mut entries = vec![FlowEntry::Text("plain trailing answer".into())];
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, true);
+    assert_eq!(host.as_deref(), Some("plain trailing answer"));
+    assert_eq!(trailer, None);
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn gate_closed_keeps_tool_last_invariant() {
+    // options_pending = false: a tool-ended flow still reclaims nothing —
+    // the stock invariant (answer is in response.content) is untouched
+    // for every turn that did not halt on an option surface.
+    let mut entries = vec![
+        FlowEntry::Text("the substantive answer".into()),
+        FlowEntry::Tool(4),
+    ];
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, false);
+    assert_eq!(host, None);
+    assert_eq!(trailer, None);
+    assert_eq!(entries.len(), 2, "nothing consumed");
+}
+
+#[test]
+fn gate_closed_on_trailing_text_unchanged() {
+    // Regression guard: the gate's plumbing must not disturb the stock
+    // trailing-run pop when the flow ends on Text.
+    let mut entries = vec![
+        FlowEntry::Tool(0),
+        FlowEntry::Text("plain final answer".into()),
+    ];
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, false);
+    assert_eq!(host.as_deref(), Some("plain final answer"));
+    assert_eq!(trailer, None);
+    assert_eq!(entries.len(), 1);
+}
+
+#[test]
+fn settle_host_wins_content_slot() {
+    // The old prepend shipped the ack inside the answer bubble (#31
+    // abandonment): host takes the content slot, the ack rides AFTER the
+    // buttons as the trailer.
+    let (text, trailer) = settle_options_reclaim(
+        "all set, pushed".into(),
+        Some("the substantive answer".into()),
+        Some("sign-off paragraph".into()),
+    );
+    assert_eq!(text, "the substantive answer");
+    assert_eq!(trailer.as_deref(), Some("sign-off paragraph"));
+}
+
+#[test]
+fn settle_drops_trailer_duplicate_of_host() {
+    // Provider double-copy (inferhub, smoke v4/S4): the sign-off run IS
+    // the final text — no double-send.
+    let (text, trailer) = settle_options_reclaim(
+        "ack".into(),
+        Some("the substantive answer".into()),
+        Some("the substantive answer".into()),
+    );
+    assert_eq!(text, "the substantive answer");
+    assert_eq!(trailer, None);
+}
+
+#[test]
+fn settle_content_becomes_trailer_when_no_run_folded() {
+    // Keep-never-discard: the popper found no trailer run (the ack never
+    // folded into the flow) but content carries a non-duplicate leftover —
+    // it BECOMES the trailer instead of vanishing.
+    let (text, trailer) = settle_options_reclaim(
+        "unfolded sign-off ack".into(),
+        Some("the substantive answer".into()),
+        None,
+    );
+    assert_eq!(text, "the substantive answer");
+    assert_eq!(trailer.as_deref(), Some("unfolded sign-off ack"));
+}
+
+#[test]
+fn settle_content_duplicate_of_host_not_promoted() {
+    // The content leftover is a duplicate of the host (prefix overlap) —
+    // promoting it would double-send the answer.
+    let (text, trailer) = settle_options_reclaim(
+        "the substantive answer".into(),
+        Some("the substantive answer delivered in full".into()),
+        None,
+    );
+    assert_eq!(text, "the substantive answer delivered in full");
+    assert_eq!(trailer, None);
+}
+
+#[test]
+fn settle_no_host_uses_content() {
+    // Nothing folded before the Tool: content IS the final text, trailer
+    // rides unchanged.
+    let (text, trailer) =
+        settle_options_reclaim("the whole answer".into(), None, Some("sign-off".into()));
+    assert_eq!(text, "the whole answer");
+    assert_eq!(trailer.as_deref(), Some("sign-off"));
+}
+
+#[test]
+fn settle_no_host_no_trailer_is_stock() {
+    // Plain shape: content only, no runs — the stock reclaim result.
+    let (text, trailer) = settle_options_reclaim("the whole answer".into(), None, None);
+    assert_eq!(text, "the whole answer");
+    assert_eq!(trailer, None);
+}

--- a/src/tests/telegram_stream_loop_resume_test.rs
+++ b/src/tests/telegram_stream_loop_resume_test.rs
@@ -157,6 +157,7 @@ async fn resume_shape_loop_edits_tools_in_place_and_never_reacts() {
     let streaming = Arc::new(std::sync::Mutex::new(StreamingState {
         is_dm: true,
         pending_suggestions: None,
+        pending_trailer: None,
         msg_id: None,
         thinking: String::new(),
         tool_msgs: vec![ToolMsg {

--- a/src/tests/telegram_system_chrome_reclaim_test.rs
+++ b/src/tests/telegram_system_chrome_reclaim_test.rs
@@ -28,8 +28,11 @@ fn a_banner_alone_is_never_reclaimed_as_the_answer() {
         "🔧 Switched to fallback/model — primary Rate limit exceeded".to_string(),
     )];
 
+    // Port union: the fork's pop takes options_pending (#1226/#31); `false`
+    // selects the stock pop these #1253 tests pin.
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, false);
     assert!(
-        pop_trailing_folded_texts(&mut entries).is_none(),
+        host.is_none() && trailer.is_none(),
         "a react-only turn must keep its empty final empty"
     );
     assert_eq!(entries.len(), 1, "the banner stays in the block");
@@ -44,10 +47,9 @@ fn chrome_landing_after_the_answer_stays_behind() {
         FlowEntry::System("🔄 Now using fallback/model".to_string()),
     ];
 
-    assert_eq!(
-        pop_trailing_folded_texts(&mut entries).as_deref(),
-        Some("the real answer")
-    );
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, false);
+    assert_eq!(host.as_deref(), Some("the real answer"));
+    assert!(trailer.is_none(), "stock pop returns no trailer");
     assert!(matches!(entries[0], FlowEntry::Tool(0)));
     assert!(
         matches!(&entries[1], FlowEntry::System(t) if t.contains("Now using")),
@@ -64,10 +66,9 @@ fn chrome_before_the_answer_does_not_block_the_reclaim() {
         FlowEntry::Text("answer written after the switch".to_string()),
     ];
 
-    assert_eq!(
-        pop_trailing_folded_texts(&mut entries).as_deref(),
-        Some("answer written after the switch")
-    );
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, false);
+    assert_eq!(host.as_deref(), Some("answer written after the switch"));
+    assert!(trailer.is_none(), "stock pop returns no trailer");
     assert_eq!(entries.len(), 1);
     assert!(matches!(entries[0], FlowEntry::System(_)));
 }
@@ -81,10 +82,9 @@ fn a_multipart_model_answer_is_still_joined_and_popped_whole() {
         FlowEntry::Text("part two".to_string()),
     ];
 
-    assert_eq!(
-        pop_trailing_folded_texts(&mut entries).as_deref(),
-        Some("part one\n\npart two")
-    );
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, false);
+    assert_eq!(host.as_deref(), Some("part one\n\npart two"));
+    assert!(trailer.is_none(), "stock pop returns no trailer");
     assert_eq!(entries.len(), 1, "only the tool row remains");
 }
 
@@ -98,10 +98,9 @@ fn the_reclaim_still_stops_at_the_last_tool_call() {
         FlowEntry::Text("closing answer".to_string()),
     ];
 
-    assert_eq!(
-        pop_trailing_folded_texts(&mut entries).as_deref(),
-        Some("closing answer")
-    );
+    let (host, trailer) = pop_trailing_folded_texts(&mut entries, false);
+    assert_eq!(host.as_deref(), Some("closing answer"));
+    assert!(trailer.is_none(), "stock pop returns no trailer");
     assert_eq!(
         entries.len(),
         3,

--- a/src/tests/telegram_tool_group_test.rs
+++ b/src/tests/telegram_tool_group_test.rs
@@ -913,11 +913,12 @@ fn trailing_text_run_pops_joined_in_order() {
         FlowEntry::Text("first part of the answer".into()),
         FlowEntry::Text("Already factored in. Standing by.".into()),
     ];
-    let reclaimed = pop_trailing_folded_texts(&mut entries).expect("reclaims");
+    let (reclaimed, trailer) = pop_trailing_folded_texts(&mut entries, false);
     assert_eq!(
-        reclaimed,
-        "first part of the answer\n\nAlready factored in. Standing by."
+        reclaimed.as_deref(),
+        Some("first part of the answer\n\nAlready factored in. Standing by.")
     );
+    assert_eq!(trailer, None);
     assert_eq!(entries.len(), 1, "tool entry stays");
     assert!(matches!(entries[0], FlowEntry::Tool(0)));
 }
@@ -928,8 +929,13 @@ fn text_only_flow_pops_everything() {
         FlowEntry::Text("the whole answer".into()),
         FlowEntry::Text("plus a follow-up".into()),
     ];
-    let reclaimed = pop_trailing_folded_texts(&mut entries).expect("reclaims");
-    assert!(reclaimed.starts_with("the whole answer"));
+    let (reclaimed, _) = pop_trailing_folded_texts(&mut entries, false);
+    assert!(
+        reclaimed
+            .as_deref()
+            .unwrap_or_default()
+            .starts_with("the whole answer")
+    );
     assert!(entries.is_empty());
 }
 
@@ -937,7 +943,7 @@ fn text_only_flow_pops_everything() {
 fn tool_last_flow_reclaims_nothing() {
     // Trailing tool call = the answer is in response.content, not folded.
     let mut entries = vec![FlowEntry::Text("narration".into()), FlowEntry::Tool(0)];
-    assert!(pop_trailing_folded_texts(&mut entries).is_none());
+    assert_eq!(pop_trailing_folded_texts(&mut entries, false), (None, None));
     assert_eq!(entries.len(), 2, "nothing consumed");
 }
 


### PR DESCRIPTION
## Summary

When a tool-run halts and follow-up option buttons (suggestions surface) are shown, the model's post-halt sign-off text was previously folded away or mislabelled as the host answer. This changes the reclaim path so the sign-off rides along as a dedicated **trailer**:

- `render_suggestions` gains a `trailer: Option<String>` parameter. When the suggestions merge into the host answer (rich mode), the trailer is embedded as a trailing paragraph; when placement fails or no merge candidate exists, it ships as its own Markdown-rendered bubble (`send_trailer_bubble`, thread-routed, plain-text retry when the parse-mode send is rejected).
- `flow.rs`: `pop_trailing_folded_texts` now returns `(Option<String>, Option<String>)` (host, trailer) and takes an `options_pending` flag (`false` selects the stock pop the #1253 chrome-reclaim tests pin); adds `settle_options_reclaim` and `last_folded_text` helpers; captures `had_trailing_tools` before the aside drain so a trailing tool run doesn't degenerate the K lift into a plain pop.
- `state.rs`: `attach_followup_host` / `peek_followup_host` — the followup host doubles as the landed-path probe (embedded = rich merge landed).
- Tests: `telegram_system_chrome_reclaim_test` ported to the tuple API, `telegram_options_reclaim_test` restored, tool-group and folded-reclaim-suppression tests updated.

## Verification

Gate run on the fork (fmt + clippy -D warnings + tests, all-features): GREEN — https://github.com/leshchenko1979/opencrabs/actions/runs/33317044766

Tracked issue on the fork: https://github.com/leshchenko1979/opencrabs/issues/31