### PR TITLE
fix(notify): refuse delivery into a channel a newer session now owns (#17)

### DIFF
--- a/src/brain/agent/service/session_routes.rs
+++ b/src/brain/agent/service/session_routes.rs
@@ -12,7 +12,7 @@
 //! unrelated concerns shared one file and one set of locks to reason about.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use uuid::Uuid;
 
@@ -105,6 +105,106 @@ pub fn register_local_route(enqueue: MessageEnqueueCallback) {
     }
 }
 
+/// Is `session_id` mid-turn right now?
+///
+/// Channels that expose turn state (telegram's #501/#845 gate) register a
+/// probe beside their delivery route; surfaces without one simply don't,
+/// which the gate below reads as "unknown" and fails open — a headless
+/// session must stay notifyable. The probe captures an `Arc` of the channel
+/// state, so it stays valid across route re-binds and reconnects.
+pub type TurnProbe = Arc<dyn Fn() -> bool + Send + Sync>;
+
+/// Per-session in-flight probes, keyed like [`SESSION_ROUTES`].
+static TURN_PROBES: Mutex<Option<HashMap<Uuid, TurnProbe>>> = Mutex::new(None);
+
+/// Register (or replace) the in-flight probe for `session_id`.
+pub fn register_turn_probe(session_id: Uuid, probe: TurnProbe) {
+    match TURN_PROBES.lock() {
+        Ok(mut guard) => {
+            guard
+                .get_or_insert_with(HashMap::new)
+                .insert(session_id, probe);
+        }
+        Err(e) => {
+            tracing::error!(
+                target: "background_task",
+                "Could not register the in-flight probe for session {session_id}: {e}"
+            );
+        }
+    }
+}
+
+/// The session's in-flight probe, if its channel registered one.
+fn turn_probe(session_id: Uuid) -> Option<TurnProbe> {
+    match TURN_PROBES.lock() {
+        Ok(guard) => guard.as_ref()?.get(&session_id).cloned(),
+        Err(e) => {
+            tracing::error!(
+                target: "background_task",
+                "Could not read the in-flight probe for session {session_id}: {e}"
+            );
+            None
+        }
+    }
+}
+
+/// Does the session still own the channel it was bound to?
+///
+/// A channel session can be REPLACED on its chat/topic — the idle-timeout
+/// reset archives the old session and creates a successor for the same
+/// topic — while its delivery route stays registered (routes are keyed by
+/// session UUID and never evicted). Without a gate, any push then wakes the
+/// replaced session and it posts into a conversation a different session now
+/// owns (fork #17). Channels that track ownership register a probe beside
+/// their delivery route; surfaces without one simply don't, which the gate
+/// below reads as "unknown" and fails open — same posture as the in-flight
+/// probe: the gate must never make a surface unnotifyable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelOwnership {
+    /// The session's bound chat/topic still resolves back to it.
+    Owned,
+    /// A DIFFERENT session now occupies the bound chat/topic.
+    Occupied { occupant: Uuid },
+    /// No binding recorded (or the channel does not track ownership).
+    Unknown,
+}
+
+pub type ChannelOwnerProbe = Arc<dyn Fn() -> ChannelOwnership + Send + Sync>;
+
+/// Per-session channel-ownership probes, keyed like [`SESSION_ROUTES`].
+static CHANNEL_OWNER_PROBES: Mutex<Option<HashMap<Uuid, ChannelOwnerProbe>>> = Mutex::new(None);
+
+/// Register (or replace) the channel-ownership probe for `session_id`.
+pub fn register_channel_owner_probe(session_id: Uuid, probe: ChannelOwnerProbe) {
+    match CHANNEL_OWNER_PROBES.lock() {
+        Ok(mut guard) => {
+            guard
+                .get_or_insert_with(HashMap::new)
+                .insert(session_id, probe);
+        }
+        Err(e) => {
+            tracing::error!(
+                target: "background_task",
+                "Could not register the channel-ownership probe for session {session_id}: {e}"
+            );
+        }
+    }
+}
+
+/// The session's channel-ownership probe, if its channel registered one.
+fn channel_owner_probe(session_id: Uuid) -> Option<ChannelOwnerProbe> {
+    match CHANNEL_OWNER_PROBES.lock() {
+        Ok(guard) => guard.as_ref()?.get(&session_id).cloned(),
+        Err(e) => {
+            tracing::error!(
+                target: "background_task",
+                "Could not read the channel-ownership probe for session {session_id}: {e}"
+            );
+            None
+        }
+    }
+}
+
 /// What happened to a message handed to [`deliver_to_session`].
 ///
 /// A bare bool used to be enough, because the only two outcomes were "went
@@ -120,11 +220,50 @@ pub enum Delivery {
     Parked,
     /// Nothing can receive it and nothing is holding it.
     NoRoute,
+    /// The target is mid-turn and the caller did not ask to interrupt
+    /// (fork #13). Nothing was delivered; the sender retries when the
+    /// target goes idle, or resends with `interrupt` set.
+    RefusedInFlight,
+    /// The target no longer owns its channel — a different session now
+    /// occupies the chat/topic it was bound to (fork #17). `interrupt`
+    /// does NOT override this gate: a replaced session must never be
+    /// woken into its successor's conversation. The refusal names the
+    /// `occupant` so the sender can redirect the message.
+    RefusedChannelOccupied { occupant: Uuid },
 }
 
 /// Deliver `msg` to whoever owns `session_id`, falling back to the booting
 /// surface, parking it when a channel owns the session but has not claimed it.
-pub fn deliver_to_session(session_id: Uuid, msg: QueuedUserMessage) -> Delivery {
+///
+/// `interrupt` is the failsafe valve (fork #13): a push into a streaming turn
+/// arrives in the receiver's context as a bare user message — receivers
+/// task-switch or skim past it. Unless the sender explicitly asked to
+/// interrupt, delivery is refused while the target is mid-turn. Unknown turn
+/// state (no probe registered) delivers: the gate must never make a surface
+/// unnotifyable.
+///
+/// The channel-ownership gate runs OUTERMOST (fork #17): it guards WHO owns
+/// the conversation, not the target's turn state, so `interrupt` does not
+/// override it. Unknown ownership (no probe, or no binding recorded) fails
+/// open, same posture as the turn gate.
+pub fn deliver_to_session(session_id: Uuid, msg: QueuedUserMessage, interrupt: bool) -> Delivery {
+    if let Some(probe) = channel_owner_probe(session_id)
+        && let ChannelOwnership::Occupied { occupant } = probe()
+    {
+        tracing::info!(
+            target: "background_task",
+            "Refusing delivery to session {session_id}: its channel is occupied by session \
+             {occupant}"
+        );
+        return Delivery::RefusedChannelOccupied { occupant };
+    }
+    if !interrupt && turn_probe(session_id).is_some_and(|probe| probe()) {
+        tracing::info!(
+            target: "background_task",
+            "Refusing delivery to session {session_id}: mid-turn and interrupt not set"
+        );
+        return Delivery::RefusedInFlight;
+    }
     if let Some(route) = session_route(session_id) {
         route(session_id, msg);
         return Delivery::Delivered;

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -21,6 +21,19 @@ fn short_id(id: uuid::Uuid) -> String {
     id.simple().to_string()[..8].to_string()
 }
 
+/// Refusal text for a delivery blocked by the channel-ownership gate (fork
+/// #17). Pure so tests can pin the remedy wording: the sender must be able to
+/// redirect to the occupant without a second discovery round.
+fn channel_occupied_message(target: uuid::Uuid, occupant: uuid::Uuid) -> String {
+    format!(
+        "Refused: session {target} no longer owns its channel — the chat/topic it was bound \
+         to is now occupied by session {occupant} (a newer session replaced it, e.g. an \
+         idle-timeout reset took over the topic). Waking it would post into {occupant}'s \
+         conversation. Notify {occupant} instead if your message belongs to that channel, \
+         or pick another target."
+    )
+}
+
 #[async_trait]
 impl Tool for SessionNotifyTool {
     fn name(&self) -> &str {
@@ -30,9 +43,14 @@ impl Tool for SessionNotifyTool {
     fn description(&self) -> &str {
         "Push a message to another session's queue in this process. The target \
          drains it at its next tool-loop boundary, or wakes immediately if idle. \
-         Every delivery carries a mechanical header [session-notify from=<sender \
-         session id>]; to reply, call session_notify with target_session set to \
-         that id. Discover target ids via session_search list/query."
+Refuses while the target is mid-turn unless interrupt=true — do not \
+         derail a working session by default. Also refuses when the target no \
+         longer owns its channel (a newer session replaced it on its \
+         chat/topic) — the refusal names the occupying session, and \
+         interrupt does NOT override that gate. Every delivery carries a \
+         mechanical header [session-notify from=<sender session id>]; to reply, \
+         call session_notify with target_session set to that id. Discover \
+         target ids via session_search list/query."
     }
 
     fn input_schema(&self) -> Value {
@@ -46,6 +64,10 @@ impl Tool for SessionNotifyTool {
                 "message": {
                     "type": "string",
                     "description": "Text to deliver to the target session"
+                },
+                "interrupt": {
+                    "type": "boolean",
+                    "description": "Deliver even if the target session is mid-turn. Default false: the tool REFUSES while the target is streaming, so a working session is never derailed. Set true only when the target must see this now; the message then queues for its next tool-loop boundary, framed as arrived-during-work."
                 }
             },
             "required": ["target_session", "message"]
@@ -87,9 +109,18 @@ impl Tool for SessionNotifyTool {
             origin: crate::brain::agent::PushOrigin::SessionNotify,
         };
 
+        // Failsafe default (fork #13): an unset interrupt must not derail a
+        // session that is mid-turn. The refusal names the remedy so the
+        // calling model learns the knob from the error itself — same pattern
+        // as the 429 RetryAfter help text.
+        let interrupt = input
+            .get("interrupt")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
         use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};
 
-        match deliver_to_session(target, msg) {
+        match deliver_to_session(target, msg, interrupt) {
             Delivery::Delivered => Ok(ToolResult::success(format!(
                 "Delivered to session {target}. It will process the message on its next turn."
             ))),
@@ -101,11 +132,22 @@ impl Tool for SessionNotifyTool {
                  restart, so it will be delivered as soon as that channel next binds the \
                  session."
             ))),
+            Delivery::RefusedInFlight => Ok(ToolResult::error(format!(
+                "Refused: session {target} is mid-turn (a turn is streaming) and interrupt \
+                 was not set — delivering now would derail its current task. Retry when the \
+                 session goes idle, or resend with interrupt=true to queue the message for \
+                 its in-flight turn's next tool-loop boundary."
+            ))),
             Delivery::NoRoute => Ok(ToolResult::error(format!(
                 "No live route for session {target} in this process — it has not messaged \
                  since boot, or belongs to another instance/profile. Use a2a_send for \
                  cross-instance targets."
             ))),
+            // The target was replaced on its channel (fork #17): name the
+            // occupant so the sender can redirect instead of guessing.
+            Delivery::RefusedChannelOccupied { occupant } => Ok(ToolResult::error(
+                channel_occupied_message(target, occupant),
+            )),
         }
     }
 }

--- a/src/brain/tools/subagent/spawn.rs
+++ b/src/brain/tools/subagent/spawn.rs
@@ -90,7 +90,7 @@ pub(crate) fn push_result(
     use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};
 
     let msg = completion_message(label, agent_id, outcome);
-    match deliver_to_session(parent_session_id, msg) {
+    match deliver_to_session(parent_session_id, msg, true) {
         Delivery::Delivered => {
             tracing::info!(
                 "Sub-agent {agent_id} reported its result to session {parent_session_id}"
@@ -109,6 +109,26 @@ pub(crate) fn push_result(
             tracing::warn!(
                 "Sub-agent {agent_id}'s result had nowhere to go for session \
                  {parent_session_id}; the parent will not hear about it"
+            );
+        }
+        Delivery::RefusedInFlight => {
+            // Unreachable by construction: interrupt=true is passed above and
+            // the fork #13 gate refuses only when interrupt is unset. Arm kept
+            // explicit so a future call-site change cannot drop the outcome
+            // silently (port seam: upstream's match has no catch-all).
+            tracing::warn!(
+                "Sub-agent {agent_id}'s result was refused by the interrupt gate \
+                 for session {parent_session_id}; the parent will not hear about it"
+            );
+        }
+        Delivery::RefusedChannelOccupied { occupant } => {
+            // The parent was replaced on its channel while the sub-agent ran
+            // (fork #17). interrupt=true does not override that gate, so say
+            // out loud where the outcome went instead of dropping it quietly.
+            tracing::warn!(
+                "Sub-agent {agent_id}'s result was refused for session {parent_session_id}: \
+                 its channel is occupied by session {occupant}; the parent will not hear \
+                 about it"
             );
         }
     }

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -1856,6 +1856,30 @@ pub(crate) async fn handle_message(
         agent.message_enqueue_callback(),
     );
 
+    // Expose this session's turn state to the delivery gate (fork #13): a
+    // session_notify without interrupt=true must refuse while a turn is
+    // streaming instead of dropping a bare user message into it. The probe
+    // captures this state Arc, so it stays valid across route re-binds.
+    {
+        let probe_state = telegram_state.clone();
+        crate::brain::agent::service::session_routes::register_turn_probe(
+            session_id,
+            std::sync::Arc::new(move || probe_state.is_turn_active(session_id)),
+        );
+    }
+
+    // Expose this session's channel ownership to the delivery gate (fork
+    // #17): when this session gets REPLACED on its chat/topic (idle-timeout
+    // reset creates a successor), pushes must refuse to wake it into the
+    // successor's conversation instead of two sessions writing the same
+    // channel. Sync mirror read — TelegramState::channel_ownership_of.
+    {
+        let probe_state = telegram_state.clone();
+        crate::brain::agent::service::session_routes::register_channel_owner_probe(
+            session_id,
+            std::sync::Arc::new(move || probe_state.channel_ownership_of(session_id)),
+        );
+    }
     // Archive any shared images under the session's project files dir (when the
     // session is assigned to a project) so a project's media lives together and
     // survives the tmp purge. Rewrites the <<IMG:tmp>> marker to the archived

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -35,6 +35,27 @@ pub(crate) fn build_enqueue_callback(
                 tracing::warn!("[bg-resume] telegram: no chat for session {session_id}; dropping");
                 return;
             };
+            // Channel-ownership guard (fork #17): this callback is ALSO
+            // reached by paths that bypass deliver_to_session's gate —
+            // background-task completions resolve their route directly
+            // (background_tasks.rs) — so the choke point checks too. A
+            // session replaced on its chat/topic must never be woken into
+            // the successor's conversation; refuse the wake. (Port seam:
+            // the fork parks the message here; upstream has no channel
+            // park primitive in this callback, so the completion is dropped
+            // with a loud warn — the gate's contract is refusing the wake,
+            // not preserving the message.)
+            if let crate::brain::agent::service::session_routes::ChannelOwnership::Occupied {
+                occupant,
+            } = state.channel_ownership_of(session_id)
+            {
+                tracing::warn!(
+                    "[bg-resume] telegram: session {session_id} no longer owns chat {chat_id} — \
+                     occupied by session {occupant}; refusing to wake it into the successor's \
+                     conversation"
+                );
+                return;
+            }
             let Some(bot) = state.bot().await else {
                 tracing::warn!("[bg-resume] telegram: bot not available; dropping resume");
                 return;

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -91,6 +91,18 @@ pub(crate) struct QueuedItem {
     pub(crate) msg: crate::brain::agent::QueuedUserMessage,
 }
 
+/// Sync mirror behind the channel-ownership gate (fork #17). Maintained ONLY
+/// by `TelegramState::register_session_chat` — the single write site for the
+/// ownership maps — so it cannot drift from them locally. See the
+/// `channel_ownership` field doc for why a sync copy exists at all.
+#[derive(Default)]
+struct ChannelOwnershipMirror {
+    /// session → the `(chat_id, topic_id)` it was bound to.
+    session_channel: HashMap<Uuid, (i64, Option<i32>)>,
+    /// `(chat_id, topic_id)` → the session currently bound to it.
+    channel_owner: HashMap<(i64, Option<i32>), Uuid>,
+}
+
 /// Shared Telegram state for proactive messaging.
 ///
 /// Set when the bot connects (agent stores Bot) and when the owner
@@ -119,6 +131,13 @@ pub struct TelegramState {
     /// pre-topic behaviour. Each forum topic therefore binds its own session.
     chat_sessions: Mutex<HashMap<(i64, Option<i32>), Uuid>>,
     session_topic: Mutex<HashMap<Uuid, Option<i32>>>,
+    /// Sync mirror of the ownership triangle for the channel-ownership gate
+    /// (fork #17): session → its `(chat, topic)` and `(chat, topic)` → current
+    /// occupant. Written ONLY in `register_session_chat`, beside the async
+    /// maps above — the delivery gate's probe is a sync closure and cannot
+    /// take tokio mutexes. Never used for routing; the async maps stay the
+    /// source of truth for everything else.
+    channel_ownership: std::sync::Mutex<ChannelOwnershipMirror>,
     /// Evidence-based forum detection (#1220): chat_id → true once ANY
     /// thread-scoped message was seen from that chat. A bare thread id can
     /// only exist on forum topics (governor.rs reached the same rule), so
@@ -295,6 +314,7 @@ impl TelegramState {
             session_chats: Mutex::new(HashMap::new()),
             chat_sessions: Mutex::new(HashMap::new()),
             session_topic: Mutex::new(HashMap::new()),
+            channel_ownership: std::sync::Mutex::new(ChannelOwnershipMirror::default()),
             chat_forums: Mutex::new(HashMap::new()),
             pending_approvals: Mutex::new(HashMap::new()),
             pending_followups: Mutex::new(HashMap::new()),
@@ -546,6 +566,15 @@ impl TelegramState {
             .lock()
             .await
             .insert((chat_id, topic_id), session_id);
+        // Keep the sync ownership mirror in lockstep (fork #17). This is the
+        // ONLY write site for the maps above, so one extra lock keeps the
+        // mirror exact; the delivery gate's probe reads it synchronously.
+        if let Ok(mut mirror) = self.channel_ownership.lock() {
+            mirror
+                .session_channel
+                .insert(session_id, (chat_id, topic_id));
+            mirror.channel_owner.insert((chat_id, topic_id), session_id);
+        }
     }
 
     /// Look up the chat_id for a given session_id.
@@ -565,6 +594,31 @@ impl TelegramState {
             .get(&session_id)
             .copied()
             .flatten()
+    }
+
+    /// Does `session_id` still own the channel it was bound to (fork #17)?
+    /// Reads the sync ownership mirror (see field doc): `Owned` when the bound
+    /// chat/topic still resolves back to this session, `Occupied` naming the
+    /// session that took it over, `Unknown` when no binding was ever recorded
+    /// (fresh boot, or the session never claimed since one). Callers: the
+    /// delivery gate's probe (session_routes.rs) and the bg-resume
+    /// choke-point guard (resume.rs).
+    pub(crate) fn channel_ownership_of(
+        &self,
+        session_id: Uuid,
+    ) -> crate::brain::agent::service::session_routes::ChannelOwnership {
+        use crate::brain::agent::service::session_routes::ChannelOwnership;
+        let Ok(mirror) = self.channel_ownership.lock() else {
+            return ChannelOwnership::Unknown;
+        };
+        let Some(channel) = mirror.session_channel.get(&session_id).copied() else {
+            return ChannelOwnership::Unknown;
+        };
+        match mirror.channel_owner.get(&channel).copied() {
+            Some(owner) if owner != session_id => ChannelOwnership::Occupied { occupant: owner },
+            Some(_) => ChannelOwnership::Owned,
+            None => ChannelOwnership::Unknown,
+        }
     }
 
     /// Reverse lookup: find the session_id for a given chat_id, scoped to the

--- a/src/tests/channel_route_expectation_test.rs
+++ b/src/tests/channel_route_expectation_test.rs
@@ -140,7 +140,7 @@ fn a_sub_agent_result_for_a_revived_session_parks_too() {
     let session = Uuid::new_v4();
 
     expect_channel_route(session);
-    let outcome = deliver_to_session(session, msg("sub-agent result"));
+    let outcome = deliver_to_session(session, msg("sub-agent result"), false);
 
     assert_eq!(
         outcome,

--- a/src/tests/session_notify_test.rs
+++ b/src/tests/session_notify_test.rs
@@ -9,7 +9,10 @@ use uuid::Uuid;
 
 use crate::brain::agent::QueuedUserMessage;
 use crate::brain::agent::service::restart_recovery::{expect_channel_route, test_guard};
-use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};
+use crate::brain::agent::service::session_routes::{
+    ChannelOwnership, Delivery, deliver_to_session, register_channel_owner_probe,
+    register_turn_probe,
+};
 use crate::brain::tools::subagent::SessionNotifyTool;
 use crate::brain::tools::r#trait::Tool;
 
@@ -86,7 +89,7 @@ fn test_a_parked_delivery_is_not_a_missing_route() {
 
     expect_channel_route(session);
 
-    let outcome = deliver_to_session(session, msg());
+    let outcome = deliver_to_session(session, msg(), false);
     assert_eq!(
         outcome,
         Delivery::Parked,
@@ -99,5 +102,187 @@ fn test_a_parked_delivery_is_not_a_missing_route() {
 fn test_an_unroutable_session_is_reported_as_such() {
     let _guard = test_guard();
     // No local route is registered in tests, so nothing can take it.
-    assert_eq!(deliver_to_session(Uuid::new_v4(), msg()), Delivery::NoRoute);
+    assert_eq!(
+        deliver_to_session(Uuid::new_v4(), msg(), false),
+        Delivery::NoRoute
+    );
+}
+
+// ── Channel-ownership gate (fork #17) ────────────────────────────────────
+//
+// A session REPLACED on its chat/topic (idle-timeout reset creates a
+// successor) keeps its delivery route — routes are UUID-keyed and never
+// evicted. Without the gate any push wakes the replaced session into the
+// successor's conversation. The gate is the OUTERMOST check: it guards who
+// owns the channel, not the target's turn state, so `interrupt` does not
+// override it. Unknown ownership fails open, same posture as the turn gate.
+
+#[test]
+fn test_occupied_channel_refuses_delivery() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    let occupant = Uuid::new_v4();
+    register_channel_owner_probe(
+        session,
+        std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant }),
+    );
+    assert_eq!(
+        deliver_to_session(session, msg(), false),
+        Delivery::RefusedChannelOccupied { occupant },
+        "#17: a replaced session must not be woken into its successor's channel"
+    );
+}
+
+#[test]
+fn test_occupied_channel_refuses_even_with_interrupt() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    let occupant = Uuid::new_v4();
+    register_channel_owner_probe(
+        session,
+        std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant }),
+    );
+    assert_eq!(
+        deliver_to_session(session, msg(), true),
+        Delivery::RefusedChannelOccupied { occupant },
+        "#17: interrupt overrides the TURN gate only — never channel ownership"
+    );
+}
+
+#[test]
+fn test_ownership_gate_outranks_turn_gate() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    let occupant = Uuid::new_v4();
+    register_turn_probe(session, std::sync::Arc::new(|| true));
+    register_channel_owner_probe(
+        session,
+        std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant }),
+    );
+    // Mid-turn AND replaced: the refusal must name the occupant, not the
+    // turn state — redirecting to the occupant is the actionable remedy.
+    assert_eq!(
+        deliver_to_session(session, msg(), false),
+        Delivery::RefusedChannelOccupied { occupant },
+        "#17: the ownership gate runs outside the turn gate"
+    );
+}
+
+#[test]
+fn test_owned_channel_passes_ownership_gate() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    expect_channel_route(session);
+    register_channel_owner_probe(session, std::sync::Arc::new(|| ChannelOwnership::Owned));
+    assert_eq!(
+        deliver_to_session(session, msg(), false),
+        Delivery::Parked,
+        "#17: an owning session passes the gate — parked here only because \
+         the expected route is unclaimed"
+    );
+}
+
+#[test]
+fn test_unknown_ownership_fails_open() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    expect_channel_route(session);
+    register_channel_owner_probe(session, std::sync::Arc::new(|| ChannelOwnership::Unknown));
+    assert_eq!(
+        deliver_to_session(session, msg(), false),
+        Delivery::Parked,
+        "#17: unknown ownership fails open — never refuse on missing semantics"
+    );
+}
+
+#[tokio::test]
+#[expect(clippy::await_holding_lock)]
+async fn test_tool_reports_channel_occupied_with_occupant() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    let occupant = Uuid::new_v4();
+    register_channel_owner_probe(
+        session,
+        std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant }),
+    );
+
+    let context = crate::brain::tools::r#trait::ToolExecutionContext::new(Uuid::new_v4());
+    let outcome = SessionNotifyTool
+        .execute(
+            serde_json::json!({"target_session": session.to_string(), "message": "ping"}),
+            &context,
+        )
+        .await;
+    let result = outcome.expect("tool executes");
+    assert!(
+        !result.success,
+        "#17: refusal must read as failure to the sender"
+    );
+    let error = result.error.expect("#17: refusal carries an explanation");
+    assert!(
+        error.contains(&occupant.to_string()),
+        "#17: the refusal must name the occupying session so the sender can \
+         redirect without a discovery round: {error}"
+    );
+    assert!(
+        error.contains("no longer owns its channel"),
+        "#17: the refusal must say WHY: {error}"
+    );
+}
+
+#[tokio::test]
+async fn test_ownership_mirror_tracks_channel_replacement() {
+    // The sync mirror behind the telegram probe (state.rs): binding a
+    // successor to the same (chat, topic) must flip the old session to
+    // Occupied naming the successor, while the successor reads Owned and a
+    // never-bound session reads Unknown.
+    use crate::channels::telegram::TelegramState;
+    let state = TelegramState::new();
+    let old = Uuid::new_v4();
+    let successor = Uuid::new_v4();
+    let (chat, topic) = (-100_123_456_i64, Some(42_i32));
+
+    assert_eq!(
+        state.channel_ownership_of(old),
+        ChannelOwnership::Unknown,
+        "#17: never-bound session — no binding recorded"
+    );
+
+    state.register_session_chat(old, chat, topic).await;
+    assert_eq!(state.channel_ownership_of(old), ChannelOwnership::Owned);
+
+    // Idle-timeout replacement: same channel, new session.
+    state.register_session_chat(successor, chat, topic).await;
+    assert_eq!(
+        state.channel_ownership_of(old),
+        ChannelOwnership::Occupied {
+            occupant: successor
+        },
+        "#17: the replaced session must see its successor by name"
+    );
+    assert_eq!(
+        state.channel_ownership_of(successor),
+        ChannelOwnership::Owned,
+        "#17: the successor owns the channel it just bound"
+    );
+}
+
+#[tokio::test]
+async fn test_ownership_mirror_keys_dm_and_general_buckets_separately() {
+    // (chat, None) buckets — DMs / non-forum groups — are channels too: a
+    // replacement there must occupy exactly that bucket and no other.
+    use crate::channels::telegram::TelegramState;
+    let state = TelegramState::new();
+    let old = Uuid::new_v4();
+    let successor = Uuid::new_v4();
+    let chat = 777_i64;
+
+    state.register_session_chat(old, chat, None).await;
+    state.register_session_chat(successor, chat, None).await;
+    assert_eq!(
+        state.channel_ownership_of(old),
+        ChannelOwnership::Occupied {
+            occupant: successor
+        }
+    );
 }


### PR DESCRIPTION
## What

`session_notify` and background-task completions could wake a **replaced** channel session. A channel session can be REPLACED on its chat/topic — the idle-timeout reset archives the old session and creates a successor for the same topic — while its delivery route stays registered (routes are UUID-keyed and never evicted). Without a gate, `session_notify` and background-task completions wake the replaced session, which posts into a conversation the successor now owns: **two sessions writing one channel**.

## Fix

A gate on the delivery path: every push to a session with a registered channel-ownership probe is **refused** when the probe reports the channel `Occupied` by another session. The gate:

- runs **OUTERMOST** in `deliver_to_session` — `interrupt` does NOT override it; a replaced session must never be woken into its successor's conversation
- also guards the **bg-resume choke point** (`build_enqueue_callback`), since background completions resolve their route directly, bypassing `deliver_to_session`
- **fails open** on unknown ownership — the gate never makes a surface unnotifyable
- names the occupying session in the refusal, so a sender can redirect without a discovery round

Ownership is tracked in `TelegramState.channel_ownership`, a sync mirror maintained ONLY at `register_session_chat` (the single write site of the async maps), because the delivery gate's probe is a sync closure that cannot take tokio mutexes.

## Port seam (fork → upstream)

The fork's bg-resume choke additionally **parked** the undeliverable completion (`park_undeliverable` + `wait_ready`). Neither exists upstream — there is no channel-park primitive in `build_enqueue_callback`'s callback. Upstream behaviour here is therefore **warn + drop**: the completion is refused with a loud `tracing::warn!` naming the successor session. Rationale: parking would hold the message forever anyway — the replaced session will never be claimed again. The gate's contract is the wake refusal, not message preservation.

## Tests

8 new tests in `src/tests/session_notify_test.rs`: occupied refuses (with and without interrupt), ownership gate outranks turn gate, owned/unknown ownership pass, tool refusal text names the occupant, mirror tracks channel replacement (incl. DM vs general bucket keys. 3 existing call sites adapted to the 3-arg signature (`session_notify_test.rs` ×2, `channel_route_expectation_test.rs` ×1).

CI: pr-checks GREEN — https://github.com/leshchenko1979/opencrabs/actions/runs/33324521740

Original issue: https://github.com/leshchenko1979/opencrabs/issues/17