### PR TITLE
feat(notify): redirect delivery to the new occupant when a session's channel is claimed (leshchenko1979/opencrabs#19)

### DIFF
--- a/src/brain/agent/service/background_tasks.rs
+++ b/src/brain/agent/service/background_tasks.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 
 use uuid::Uuid;
 
-use super::types::{MessageEnqueueCallback, PushOrigin, QueuedUserMessage};
+use super::types::{PushOrigin, QueuedUserMessage};
 
 /// Result of a finished background command.
 #[derive(Debug, Clone)]
@@ -33,7 +33,6 @@ pub struct RunningTask {
 
 /// Manages background commands and resumes their sessions on completion.
 pub struct BackgroundTaskManager {
-    enqueue: MessageEnqueueCallback,
     /// In-flight background tasks per session.
     ///
     /// Holds the label and start time, not just a count, because a surface has
@@ -46,9 +45,8 @@ pub struct BackgroundTaskManager {
 use super::detached_status::{self, DetachedFinish};
 
 impl BackgroundTaskManager {
-    pub fn new(enqueue: MessageEnqueueCallback) -> Self {
+    pub fn new() -> Self {
         Self {
-            enqueue,
             running: Mutex::new(HashMap::new()),
         }
     }
@@ -191,12 +189,54 @@ impl BackgroundTaskManager {
             // Only touches the in-memory map, so moving it earlier cannot
             // affect what gets delivered.
             this.mark_finished(session_id, &label);
-            // Deliver to the surface that OWNS the session, not to whichever
-            // one executed the command. A channel session driven from the TUI
-            // runs on the TUI's service, so `this.enqueue` would answer into
-            // the TUI and leave the channel that asked for the work waiting on
-            // a reply that never comes (#940).
-            super::session_routes::resolve_route(session_id, &this.enqueue)(session_id, msg);
+            // Deliver through the ONE gated route (fork #19): the same
+            // `deliver_to_session` that sub-agent completions and the
+            // session_notify tool use, so channel-ownership, mid-turn and
+            // redirect decisions live in exactly one place instead of being
+            // re-derived per surface. Resolves the owner by SESSION, never by
+            // whichever service executed the command — a channel session
+            // driven from the TUI runs on the TUI's service, and the old
+            // direct-resolve would answer into the TUI and leave the channel
+            // that asked for the work waiting on a reply that never comes
+            // (#940). interrupt=true: a completion is the origin's own
+            // awaited work, exactly like a sub-agent's; it must reach it even
+            // mid-turn (fork #13).
+            let outcome = super::session_routes::deliver_to_session(session_id, msg, true);
+            match outcome {
+                super::session_routes::Delivery::Redirected { to } => {
+                    tracing::info!(
+                        target: "background_task",
+                        "Background task '{label}' completion for session {session_id} was \
+                         redirected to session {to}, which now owns its channel"
+                    );
+                }
+                super::session_routes::Delivery::Parked => {
+                    tracing::info!(
+                        target: "background_task",
+                        "Background task '{label}' completion for session {session_id} is \
+                         parked until its channel claims the session"
+                    );
+                }
+                super::session_routes::Delivery::NoRoute => {
+                    tracing::warn!(
+                        target: "background_task",
+                        "Background task '{label}' completion for session {session_id} had \
+                         nowhere to go; the session will not hear about it"
+                    );
+                }
+                super::session_routes::Delivery::RefusedInFlight { .. } => {
+                    // Unreachable by construction: interrupt=true is passed
+                    // above, so the fork #13 gate cannot refuse. Kept explicit
+                    // so a future change to the flag cannot drop the outcome
+                    // silently (port seam: upstream's match has no catch-all).
+                    tracing::warn!(
+                        target: "background_task",
+                        "Background task '{label}' completion for session {session_id} was \
+                         refused by the mid-turn gate despite interrupt=true"
+                    );
+                }
+                super::session_routes::Delivery::Delivered => {}
+            }
         });
     }
 }

--- a/src/brain/agent/service/builder.rs
+++ b/src/brain/agent/service/builder.rs
@@ -769,11 +769,13 @@ impl AgentService {
         mut self,
         callback: Option<super::types::MessageEnqueueCallback>,
     ) -> Self {
-        // Spin up the background-task manager from the same producer so bash can
-        // resume the session when a long command finishes (#722).
+        // Spin up the background-task manager (fork #19: it no longer carries
+        // its own enqueue route — delivery goes through the one gated route,
+        // `deliver_to_session`, which resolves the session's registered route;
+        // this callback is still kept on self for #940 claiming).
         self.background_manager = callback
             .clone()
-            .map(|cb| std::sync::Arc::new(super::background_tasks::BackgroundTaskManager::new(cb)));
+            .map(|_cb| std::sync::Arc::new(super::background_tasks::BackgroundTaskManager::new()));
         self.message_enqueue_callback = callback;
         self
     }

--- a/src/brain/agent/service/session_routes.rs
+++ b/src/brain/agent/service/session_routes.rs
@@ -61,7 +61,10 @@ pub fn register_session_route(session_id: Uuid, enqueue: MessageEnqueueCallback)
 /// session, falling back to `executing` when nothing did.
 ///
 /// The whole fix in one line — pick by session, never by who ran the command —
-/// so it is a pure function and directly testable.
+/// so it is a pure function and directly testable. Test-only since fork #19:
+/// production delivery now flows through [`deliver_to_session`], but the
+/// pre-#19 routing suites still exercise these semantics directly (#22).
+#[cfg(test)]
 pub fn resolve_route(
     session_id: Uuid,
     executing: &MessageEnqueueCallback,
@@ -222,14 +225,17 @@ pub enum Delivery {
     NoRoute,
     /// The target is mid-turn and the caller did not ask to interrupt
     /// (fork #13). Nothing was delivered; the sender retries when the
-    /// target goes idle, or resends with `interrupt` set.
-    RefusedInFlight,
+    /// target goes idle, or resends with `interrupt` set. When the
+    /// refusal follows a redirect (fork #19), `redirected_to` names the
+    /// occupant that is mid-turn — the message WOULD have gone there, and
+    /// will once it goes idle or `interrupt` is set.
+    RefusedInFlight { redirected_to: Option<Uuid> },
     /// The target no longer owns its channel — a different session now
-    /// occupies the chat/topic it was bound to (fork #17). `interrupt`
-    /// does NOT override this gate: a replaced session must never be
-    /// woken into its successor's conversation. The refusal names the
-    /// `occupant` so the sender can redirect the message.
-    RefusedChannelOccupied { occupant: Uuid },
+    /// occupies the chat/topic it was bound to (fork #17). Instead of
+    /// refusing, the message was REDIRECTED to the occupant `to`, with a
+    /// provenance frame so the successor does not adopt a dead session's
+    /// task as its own (fork #19).
+    Redirected { to: Uuid },
 }
 
 /// Deliver `msg` to whoever owns `session_id`, falling back to the booting
@@ -246,33 +252,89 @@ pub enum Delivery {
 /// the conversation, not the target's turn state, so `interrupt` does not
 /// override it. Unknown ownership (no probe, or no binding recorded) fails
 /// open, same posture as the turn gate.
+///
+/// Occupied no longer REFUSES (fork #19): the replaced session's message is
+/// nobody's fault, and retrying a session that no longer owns its channel
+/// never fixes it. Instead the message is REDIRECTED to the occupant — the
+/// session that owns the channel now — with a provenance frame prefixed to
+/// its context text so the successor does not mistake it for its own task.
+/// The redirect follows the occupant chain up to a hop cap (cycle insurance:
+/// an occupant can itself be replaced mid-flight) and parks past the cap —
+/// held, never dropped. The original `interrupt` flag is then honored
+/// against the FINAL target: a redirect landing on a mid-turn occupant is
+/// still gated by the sender's original intent.
 pub fn deliver_to_session(session_id: Uuid, msg: QueuedUserMessage, interrupt: bool) -> Delivery {
-    if let Some(probe) = channel_owner_probe(session_id)
-        && let ChannelOwnership::Occupied { occupant } = probe()
-    {
+    // Channel-ownership gate, outermost (fork #17). Occupied → redirect to
+    // the occupant (fork #19), with provenance framing once per chain and a
+    // hop cap so a replacing chain (A replaced B replaced C…) cannot loop.
+    const REDIRECT_HOP_CAP: usize = 3;
+    let mut target = session_id;
+    let mut hops: usize = 0;
+    let mut msg = msg;
+    loop {
+        if let Some(probe) = channel_owner_probe(target)
+            && let ChannelOwnership::Occupied { occupant } = probe()
+        {
+            if hops >= REDIRECT_HOP_CAP {
+                // Cycle insurance exhausted: park rather than loop. The
+                // message is safe and leaves when a channel claims it.
+                tracing::warn!(
+                    target: "background_task",
+                    "Redirect cap hit for session {session_id}: its channel-owner chain \
+                     (ending at session {occupant}) did not stabilise after {hops} hops; \
+                     parking instead of delivering"
+                );
+                super::restart_recovery::parking_route()(target, msg);
+                return Delivery::Parked;
+            }
+            hops += 1;
+            tracing::info!(
+                target: "background_task",
+                "Redirecting delivery for session {target}: its channel is occupied by \
+                 session {occupant} (hop {hops}); delivering to the new owner"
+            );
+            if hops == 1 {
+                // Provenance framing (#19): the successor must know this
+                // message was written for the session that lost the
+                // channel, not for itself. Framed once, against the ORIGINAL
+                // target, so a multi-hop chain does not stack frames.
+                msg.context_text = format!(
+                    "[redirected — originally for session {session_id}, which no longer \
+                     owns this channel] {}",
+                    msg.context_text
+                );
+            }
+            target = occupant;
+            continue;
+        }
+        break;
+    }
+    // Mid-turn gate (fork #13), honored against the FINAL target: a redirect
+    // can land on an occupant that is mid-turn, and the sender's original
+    // `interrupt` flag travels with the message. Refuse with the redirect
+    // context attached so the sender hears where the message WOULD have gone.
+    if !interrupt && turn_probe(target).is_some_and(|probe| probe()) {
         tracing::info!(
             target: "background_task",
-            "Refusing delivery to session {session_id}: its channel is occupied by session \
-             {occupant}"
+            "Refusing delivery to session {target}: mid-turn and interrupt not set"
         );
-        return Delivery::RefusedChannelOccupied { occupant };
+        return Delivery::RefusedInFlight {
+            redirected_to: (hops > 0).then_some(target),
+        };
     }
-    if !interrupt && turn_probe(session_id).is_some_and(|probe| probe()) {
-        tracing::info!(
-            target: "background_task",
-            "Refusing delivery to session {session_id}: mid-turn and interrupt not set"
-        );
-        return Delivery::RefusedInFlight;
-    }
-    if let Some(route) = session_route(session_id) {
-        route(session_id, msg);
-        return Delivery::Delivered;
+    if let Some(route) = session_route(target) {
+        route(target, msg);
+        return if hops > 0 {
+            Delivery::Redirected { to: target }
+        } else {
+            Delivery::Delivered
+        };
     }
     // Same reasoning as `resolve_route`: an unclaimed session that recovery
     // knows came from a channel must wait for that channel, not be handed to
     // whatever this process booted on (#1206).
-    if super::restart_recovery::awaits_channel_route(session_id) {
-        super::restart_recovery::parking_route()(session_id, msg);
+    if super::restart_recovery::awaits_channel_route(target) {
+        super::restart_recovery::parking_route()(target, msg);
         return Delivery::Parked;
     }
     let local = match LOCAL_ROUTE.lock() {
@@ -280,20 +342,24 @@ pub fn deliver_to_session(session_id: Uuid, msg: QueuedUserMessage, interrupt: b
         Err(e) => {
             tracing::error!(
                 target: "background_task",
-                "Could not read the local delivery route for session {session_id}: {e}"
+                "Could not read the local delivery route for session {target}: {e}"
             );
             None
         }
     };
     match local {
         Some(route) => {
-            route(session_id, msg);
-            Delivery::Delivered
+            route(target, msg);
+            if hops > 0 {
+                Delivery::Redirected { to: target }
+            } else {
+                Delivery::Delivered
+            }
         }
         None => {
             tracing::error!(
                 target: "background_task",
-                "Nothing can receive a message for session {session_id}; it is dropped: {}",
+                "Nothing can receive a message for session {target}; it is dropped: {}",
                 msg.display_text
             );
             Delivery::NoRoute

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -21,16 +21,16 @@ fn short_id(id: uuid::Uuid) -> String {
     id.simple().to_string()[..8].to_string()
 }
 
-/// Refusal text for a delivery blocked by the channel-ownership gate (fork
-/// #17). Pure so tests can pin the remedy wording: the sender must be able to
-/// redirect to the occupant without a second discovery round.
-fn channel_occupied_message(target: uuid::Uuid, occupant: uuid::Uuid) -> String {
+/// Redirect-acknowledgement text for a delivery steered to the channel's
+/// current owner (fork #19). Pure so tests can pin the wording: the sender
+/// must hear WHERE the message went without a second discovery round.
+fn redirect_message(target: uuid::Uuid, occupant: uuid::Uuid) -> String {
     format!(
-        "Refused: session {target} no longer owns its channel — the chat/topic it was bound \
-         to is now occupied by session {occupant} (a newer session replaced it, e.g. an \
-         idle-timeout reset took over the topic). Waking it would post into {occupant}'s \
-         conversation. Notify {occupant} instead if your message belongs to that channel, \
-         or pick another target."
+        "Redirected: session {target} no longer owns its channel — the chat/topic it was \
+         bound to is now occupied by session {occupant} (a newer session replaced it, e.g. \
+         an idle-timeout reset took over the topic). The message was delivered to {occupant} \
+         instead, with provenance framing so the new owner can tell it apart from its own \
+         work."
     )
 }
 
@@ -43,10 +43,11 @@ impl Tool for SessionNotifyTool {
     fn description(&self) -> &str {
         "Push a message to another session's queue in this process. The target \
          drains it at its next tool-loop boundary, or wakes immediately if idle. \
-Refuses while the target is mid-turn unless interrupt=true — do not \
-         derail a working session by default. Also refuses when the target no \
-         longer owns its channel (a newer session replaced it on its \
-         chat/topic) — the refusal names the occupying session, and \
+         Refuses while the target is mid-turn unless interrupt=true — do not \
+         derail a working session by default. When the target no longer \
+         owns its channel (a newer session replaced it on its \
+         chat/topic), the message is REDIRECTED to the occupying session \
+         with provenance framing, and delivery reports the redirect; \
          interrupt does NOT override that gate. Every delivery carries a \
          mechanical header [session-notify from=<sender session id>]; to reply, \
          call session_notify with target_session set to that id. Discover \
@@ -132,22 +133,30 @@ Refuses while the target is mid-turn unless interrupt=true — do not \
                  restart, so it will be delivered as soon as that channel next binds the \
                  session."
             ))),
-            Delivery::RefusedInFlight => Ok(ToolResult::error(format!(
-                "Refused: session {target} is mid-turn (a turn is streaming) and interrupt \
-                 was not set — delivering now would derail its current task. Retry when the \
-                 session goes idle, or resend with interrupt=true to queue the message for \
-                 its in-flight turn's next tool-loop boundary."
-            ))),
+            Delivery::RefusedInFlight { redirected_to } => {
+                let who = match redirected_to {
+                    Some(to) => format!(
+                        "{to} (mid-turn — the message was redirected there because \
+                         {target} no longer owns its channel)"
+                    ),
+                    None => target.to_string(),
+                };
+                Ok(ToolResult::error(format!(
+                    "Refused: session {who} is mid-turn (a turn is streaming) and interrupt \
+                     was not set — delivering now would derail its current task. Retry when \
+                     the session goes idle, or resend with interrupt=true to queue the \
+                     message for its in-flight turn's next tool-loop boundary."
+                )))
+            }
             Delivery::NoRoute => Ok(ToolResult::error(format!(
                 "No live route for session {target} in this process — it has not messaged \
                  since boot, or belongs to another instance/profile. Use a2a_send for \
                  cross-instance targets."
             ))),
-            // The target was replaced on its channel (fork #17): name the
-            // occupant so the sender can redirect instead of guessing.
-            Delivery::RefusedChannelOccupied { occupant } => Ok(ToolResult::error(
-                channel_occupied_message(target, occupant),
-            )),
+            // The target no longer owns its channel (fork #17): the message
+            // was redirected to the session that owns it NOW (fork #19) — a
+            // success, not a refusal, and the reply names where it went.
+            Delivery::Redirected { to } => Ok(ToolResult::success(redirect_message(target, to))),
         }
     }
 }

--- a/src/brain/tools/subagent/spawn.rs
+++ b/src/brain/tools/subagent/spawn.rs
@@ -111,24 +111,24 @@ pub(crate) fn push_result(
                  {parent_session_id}; the parent will not hear about it"
             );
         }
-        Delivery::RefusedInFlight => {
+        Delivery::RefusedInFlight { redirected_to } => {
             // Unreachable by construction: interrupt=true is passed above and
             // the fork #13 gate refuses only when interrupt is unset. Arm kept
             // explicit so a future call-site change cannot drop the outcome
             // silently (port seam: upstream's match has no catch-all).
             tracing::warn!(
                 "Sub-agent {agent_id}'s result was refused by the interrupt gate \
-                 for session {parent_session_id}; the parent will not hear about it"
+                 for session {parent_session_id} (redirected to {redirected_to:?}); the \
+                 parent will not hear about it"
             );
         }
-        Delivery::RefusedChannelOccupied { occupant } => {
+        Delivery::Redirected { to } => {
             // The parent was replaced on its channel while the sub-agent ran
-            // (fork #17). interrupt=true does not override that gate, so say
-            // out loud where the outcome went instead of dropping it quietly.
-            tracing::warn!(
-                "Sub-agent {agent_id}'s result was refused for session {parent_session_id}: \
-                 its channel is occupied by session {occupant}; the parent will not hear \
-                 about it"
+            // (fork #17), so the result was REDIRECTED to the session that
+            // owns the channel now (fork #19) — delivered, not dropped.
+            tracing::info!(
+                "Sub-agent {agent_id}'s result was redirected from session \
+                 {parent_session_id} to session {to}, which now owns its channel"
             );
         }
     }

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -35,27 +35,6 @@ pub(crate) fn build_enqueue_callback(
                 tracing::warn!("[bg-resume] telegram: no chat for session {session_id}; dropping");
                 return;
             };
-            // Channel-ownership guard (fork #17): this callback is ALSO
-            // reached by paths that bypass deliver_to_session's gate —
-            // background-task completions resolve their route directly
-            // (background_tasks.rs) — so the choke point checks too. A
-            // session replaced on its chat/topic must never be woken into
-            // the successor's conversation; refuse the wake. (Port seam:
-            // the fork parks the message here; upstream has no channel
-            // park primitive in this callback, so the completion is dropped
-            // with a loud warn — the gate's contract is refusing the wake,
-            // not preserving the message.)
-            if let crate::brain::agent::service::session_routes::ChannelOwnership::Occupied {
-                occupant,
-            } = state.channel_ownership_of(session_id)
-            {
-                tracing::warn!(
-                    "[bg-resume] telegram: session {session_id} no longer owns chat {chat_id} — \
-                     occupied by session {occupant}; refusing to wake it into the successor's \
-                     conversation"
-                );
-                return;
-            }
             let Some(bot) = state.bot().await else {
                 tracing::warn!("[bg-resume] telegram: bot not available; dropping resume");
                 return;

--- a/src/tests/background_tasks_test.rs
+++ b/src/tests/background_tasks_test.rs
@@ -6,6 +6,8 @@ use crate::brain::agent::service::QueuedUserMessage;
 use crate::brain::agent::service::background_tasks::{
     BackgroundTaskManager, CmdResult, completion_message, short_label, tail_lines,
 };
+use crate::brain::agent::service::restart_recovery;
+use crate::brain::agent::service::session_routes;
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
@@ -57,7 +59,14 @@ fn short_label_takes_the_command_after_cd() {
 }
 
 #[tokio::test]
+// The test_guard serializes suites touching the process-global parked-queue
+// state; holding it across the polling `.await`s below is the entire point —
+// same shape as the session_notify suite (#22).
+#[allow(clippy::await_holding_lock)]
 async fn spawn_command_enqueues_on_completion() {
+    // register_session_route → claim_session touches the process-global
+    // parked-queue state, so serialize against other suites that do too.
+    let _guard = restart_recovery::test_guard();
     #[allow(clippy::type_complexity)]
     let recorded: Arc<Mutex<Vec<(Uuid, QueuedUserMessage)>>> = Arc::new(Mutex::new(Vec::new()));
     let rec = recorded.clone();
@@ -65,8 +74,13 @@ async fn spawn_command_enqueues_on_completion() {
         rec.lock().unwrap().push((sid, msg));
     });
 
-    let mgr = Arc::new(BackgroundTaskManager::new(enqueue));
+    let mgr = Arc::new(BackgroundTaskManager::new());
     let sid = Uuid::new_v4();
+    // The manager no longer carries its own route (fork #19 — delivery goes
+    // through the one gated route, which resolves the session's registered
+    // route), so claim the session the way a channel would: register the
+    // recording callback as its route.
+    session_routes::register_session_route(sid, enqueue);
     let cwd = std::env::temp_dir();
 
     mgr.clone().spawn_command(

--- a/src/tests/session_notify_test.rs
+++ b/src/tests/session_notify_test.rs
@@ -309,9 +309,8 @@ async fn test_tool_reports_redirect_to_occupant() {
         .await;
     let result = outcome.expect("tool executes");
     assert!(result.success, "#19: a redirect is delivery, not failure");
-    let message = result
-        .message
-        .expect("#19: the outcome names where it went");
+    let message = result.output;
+    assert!(!message.is_empty(), "#19: the outcome names where it went");
     assert!(
         message.contains(&occupant.to_string()),
         "#19: must name the session that owns the channel now: {message}"

--- a/src/tests/session_notify_test.rs
+++ b/src/tests/session_notify_test.rs
@@ -11,7 +11,7 @@ use crate::brain::agent::QueuedUserMessage;
 use crate::brain::agent::service::restart_recovery::{expect_channel_route, test_guard};
 use crate::brain::agent::service::session_routes::{
     ChannelOwnership, Delivery, deliver_to_session, register_channel_owner_probe,
-    register_turn_probe,
+    register_session_route, register_turn_probe,
 };
 use crate::brain::tools::subagent::SessionNotifyTool;
 use crate::brain::tools::r#trait::Tool;
@@ -108,7 +108,7 @@ fn test_an_unroutable_session_is_reported_as_such() {
     );
 }
 
-// ── Channel-ownership gate (fork #17) ────────────────────────────────────
+// ── Channel-ownership gate (fork #17) + redirect (fork #19) ─────────────
 //
 // A session REPLACED on its chat/topic (idle-timeout reset creates a
 // successor) keeps its delivery route — routes are UUID-keyed and never
@@ -116,25 +116,54 @@ fn test_an_unroutable_session_is_reported_as_such() {
 // successor's conversation. The gate is the OUTERMOST check: it guards who
 // owns the channel, not the target's turn state, so `interrupt` does not
 // override it. Unknown ownership fails open, same posture as the turn gate.
+//
+// Occupied no longer REFUSES (#19): the message is REDIRECTED to the
+// occupant — the session that owns the channel now — with a provenance
+// frame on its context text, up to a 3-hop cap (cycle insurance), then
+// parked. The original `interrupt` flag is honored against the FINAL
+// target after redirecting.
 
 #[test]
-fn test_occupied_channel_refuses_delivery() {
+fn test_occupied_channel_redirects_delivery_to_occupant() {
     let _guard = test_guard();
     let session = Uuid::new_v4();
     let occupant = Uuid::new_v4();
+    let captured: std::sync::Arc<std::sync::Mutex<Option<QueuedUserMessage>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(None));
+    let sink = captured.clone();
     register_channel_owner_probe(
         session,
         std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant }),
     );
+    register_session_route(
+        occupant,
+        std::sync::Arc::new(move |_id, queued| {
+            *sink.lock().unwrap() = Some(queued);
+        }),
+    );
+    let outcome = deliver_to_session(session, msg(), false);
     assert_eq!(
-        deliver_to_session(session, msg(), false),
-        Delivery::RefusedChannelOccupied { occupant },
-        "#17: a replaced session must not be woken into its successor's channel"
+        outcome,
+        Delivery::Redirected { to: occupant },
+        "#19: an occupied channel redirects to the occupant — delivered, never refused"
+    );
+    let queued = captured
+        .lock()
+        .unwrap()
+        .take()
+        .expect("occupant got the message");
+    let frame = format!(
+        "[redirected — originally for session {session}, which no longer owns this channel]"
+    );
+    assert!(
+        queued.context_text.starts_with(&frame),
+        "#19: the successor must see the provenance frame: {}",
+        queued.context_text
     );
 }
 
 #[test]
-fn test_occupied_channel_refuses_even_with_interrupt() {
+fn test_occupied_channel_redirects_even_with_interrupt() {
     let _guard = test_guard();
     let session = Uuid::new_v4();
     let occupant = Uuid::new_v4();
@@ -142,10 +171,12 @@ fn test_occupied_channel_refuses_even_with_interrupt() {
         session,
         std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant }),
     );
+    register_session_route(occupant, std::sync::Arc::new(|_id, _queued| {}));
     assert_eq!(
         deliver_to_session(session, msg(), true),
-        Delivery::RefusedChannelOccupied { occupant },
-        "#17: interrupt overrides the TURN gate only — never channel ownership"
+        Delivery::Redirected { to: occupant },
+        "#19: interrupt overrides the TURN gate only — never channel ownership; \
+         the redirect still happens"
     );
 }
 
@@ -159,12 +190,74 @@ fn test_ownership_gate_outranks_turn_gate() {
         session,
         std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant }),
     );
-    // Mid-turn AND replaced: the refusal must name the occupant, not the
-    // turn state — redirecting to the occupant is the actionable remedy.
+    register_session_route(occupant, std::sync::Arc::new(|_id, _queued| {}));
+    // Mid-turn AND replaced: the redirect wins — the message goes to the
+    // occupant, whose own turn state (not the dead session's) gates it.
     assert_eq!(
         deliver_to_session(session, msg(), false),
-        Delivery::RefusedChannelOccupied { occupant },
-        "#17: the ownership gate runs outside the turn gate"
+        Delivery::Redirected { to: occupant },
+        "#19: the ownership gate runs outside the turn gate"
+    );
+}
+
+#[test]
+fn test_redirect_honors_interrupt_against_occupant() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    let occupant = Uuid::new_v4();
+    register_channel_owner_probe(
+        session,
+        std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant }),
+    );
+    // The FINAL target (the occupant) is mid-turn: the sender's original
+    // `interrupt` flag gates IT, not the replaced session.
+    register_turn_probe(occupant, std::sync::Arc::new(|| true));
+    register_session_route(occupant, std::sync::Arc::new(|_id, _queued| {}));
+    assert_eq!(
+        deliver_to_session(session, msg(), false),
+        Delivery::RefusedInFlight {
+            redirected_to: Some(occupant)
+        },
+        "#19: a redirect landing on a mid-turn occupant is refused with the \
+         redirect context — the sender hears where the message WOULD have gone"
+    );
+    assert_eq!(
+        deliver_to_session(session, msg(), true),
+        Delivery::Redirected { to: occupant },
+        "#19: interrupt=true still delivers through the redirect"
+    );
+}
+
+#[test]
+fn test_redirect_hop_cap_parks_beyond_three() {
+    let _guard = test_guard();
+    let session = Uuid::new_v4();
+    let occ1 = Uuid::new_v4();
+    let occ2 = Uuid::new_v4();
+    let occ3 = Uuid::new_v4();
+    let occ4 = Uuid::new_v4();
+    // A replacing chain: each session's channel is occupied by the next.
+    register_channel_owner_probe(
+        session,
+        std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant: occ1 }),
+    );
+    register_channel_owner_probe(
+        occ1,
+        std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant: occ2 }),
+    );
+    register_channel_owner_probe(
+        occ2,
+        std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant: occ3 }),
+    );
+    register_channel_owner_probe(
+        occ3,
+        std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant: occ4 }),
+    );
+    assert_eq!(
+        deliver_to_session(session, msg(), false),
+        Delivery::Parked,
+        "#19: hop cap 3 is cycle insurance — past it the message is parked, \
+         never looped and never dropped"
     );
 }
 
@@ -197,7 +290,7 @@ fn test_unknown_ownership_fails_open() {
 
 #[tokio::test]
 #[expect(clippy::await_holding_lock)]
-async fn test_tool_reports_channel_occupied_with_occupant() {
+async fn test_tool_reports_redirect_to_occupant() {
     let _guard = test_guard();
     let session = Uuid::new_v4();
     let occupant = Uuid::new_v4();
@@ -205,6 +298,7 @@ async fn test_tool_reports_channel_occupied_with_occupant() {
         session,
         std::sync::Arc::new(move || ChannelOwnership::Occupied { occupant }),
     );
+    register_session_route(occupant, std::sync::Arc::new(|_id, _queued| {}));
 
     let context = crate::brain::tools::r#trait::ToolExecutionContext::new(Uuid::new_v4());
     let outcome = SessionNotifyTool
@@ -214,19 +308,17 @@ async fn test_tool_reports_channel_occupied_with_occupant() {
         )
         .await;
     let result = outcome.expect("tool executes");
+    assert!(result.success, "#19: a redirect is delivery, not failure");
+    let message = result
+        .message
+        .expect("#19: the outcome names where it went");
     assert!(
-        !result.success,
-        "#17: refusal must read as failure to the sender"
-    );
-    let error = result.error.expect("#17: refusal carries an explanation");
-    assert!(
-        error.contains(&occupant.to_string()),
-        "#17: the refusal must name the occupying session so the sender can \
-         redirect without a discovery round: {error}"
+        message.contains(&occupant.to_string()),
+        "#19: must name the session that owns the channel now: {message}"
     );
     assert!(
-        error.contains("no longer owns its channel"),
-        "#17: the refusal must say WHY: {error}"
+        message.contains("Redirected"),
+        "#19: must say it was redirected: {message}"
     );
 }
 


### PR DESCRIPTION
## What

Closes the gap left by the refusal-only ownership gate: when a session's channel (DM or forum topic) has been claimed by a newer session, `session_notify` delivery no longer bounces with an error — it is **redirected to the current occupant**, with provenance framing so the occupier's conversation knows where the message came from.

- **Redirect loop with hop cap**: delivery to an occupied session re-routes to the occupant; if the occupant's channel is *also* occupied, the chase continues, capped at 3 hops — on cap the message is parked (logged loudly) instead of looping.
- **Provenance framing**: redirected messages carry a header naming the original target, so the receiving session can contextualize the content.
- **`Delivery::Redirected`** replaces the fork's `RefusedChannelOccupied` shape: both `session_notify` tool and background-task completion callers report the redirect as a success outcome with the new occupant named.
- **DRY reroute**: the background-task completion path (which previously resolved its enqueue route directly, bypassing `deliver_to_session`'s ownership gate) now flows through the single `deliver_to_session` route. One route, one semantics — the duplicate channel-ownership choke in the Telegram `resume.rs` enqueue callback is removed (its only reason to exist was that bypass).
- Folds in the four clippy findings from the follow-up cleanup (collapsed nested-if → let-chain, import cleanup) so the feature lands lint-clean.

## Tests

`session_notify_test.rs` carries the fork suite ported to the upstream tree: mirror keys DM and general buckets separately, mirror tracks channel replacement, redirect reports the new occupant, hop cap parks on multi-hop chains, tool reports redirects as success. The pre-existing refusal tests were converted to their redirect counterparts. Full suite: 14 tests in the file, gate run below.

## Port seams (fork → upstream)

- Fork's `park_undeliverable` / `wait_ready` machinery in `resume.rs` is **not** ported (fork-only lineage, separate concerns); the choke removal here keeps upstream's plain bot fetch.
- Fork's `BgTaskMeta` plumbing does not exist upstream; the DRY reroute passes the plain 3-field `QueuedUserMessage`.
- Upstream `ToolResult` exposes `.output`, so redirect assertions assert on `.output`.

## CI

Fork gate run on this exact head (`ab25391b`, proven in job title): https://github.com/leshchenko1979/opencrabs/actions/runs/33352364236 — GREEN (fmt, clippy, tests).

**Note for reviewers**: this branch is stacked on #1267 (`fix(notify): refuse delivery…`), whose commits are not yet on `main` — the file-level diff below therefore shows #1267 + this PR combined. The reviewable delta for *this* PR is the two commits on top of `af2998218792552bf79563e41854e866949ba5ff`. Merge order: this PR after #1267.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/19
