### PR TITLE
feat(stream): TEXT_ACCUM/STREAM_RECONCILE journal + truncation detect/retry

### DIFF
--- a/src/brain/agent/service/helpers.rs
+++ b/src/brain/agent/service/helpers.rs
@@ -1123,6 +1123,7 @@ impl AgentService {
                     cache_read_tokens,
                     billing_cache_creation,
                     billing_cache_read,
+                    ..Default::default()
                 },
                 streaming_active_secs,
             },

--- a/src/brain/agent/service/phantom.rs
+++ b/src/brain/agent/service/phantom.rs
@@ -989,6 +989,16 @@ pub fn looks_truncated_mid_sentence(text: &str) -> bool {
     if trimmed.chars().count() < 40 {
         return false;
     }
+    // A response that ends INSIDE an unclosed code fence (odd count of
+    // fence lines) is truncated regardless of its last character — no
+    // complete markdown reply leaves a fence open (#36).
+    let fence_lines = trimmed
+        .lines()
+        .filter(|l| l.trim_start().starts_with("```"))
+        .count();
+    if fence_lines % 2 == 1 {
+        return true;
+    }
     if trimmed.ends_with("```") {
         return false;
     }
@@ -1005,10 +1015,36 @@ pub fn looks_truncated_mid_sentence(text: &str) -> bool {
     if last.is_alphanumeric() {
         return true;
     }
+    // A trailing single backtick is legitimate ONLY when it CLOSES inline
+    // code (even backtick parity outside fenced blocks). Odd parity means
+    // the stream died on an OPENING backtick mid-code — the #36 incident
+    // shape, which this function previously read as complete.
+    if last == '`' {
+        return backticks_outside_fences(trimmed) % 2 == 1;
+    }
     matches!(
         last,
-        ',' | ';' | ':' | '-' | '(' | '[' | '{' | '<' | '/' | '\\' | '&' | '@' | '#'
+        ',' | ';' | ':' | '-' | '(' | '[' | '{' | '<' | '/' | '\\' | '&' | '@' | '#' | '—' | '–'
     )
+}
+
+/// Count backticks on lines outside fenced code blocks. Fence delimiter
+/// lines themselves don't count — their backticks delimit blocks, they
+/// are not inline code. Used for the trailing-backtick parity check in
+/// [`looks_truncated_mid_sentence`] (#36).
+fn backticks_outside_fences(text: &str) -> usize {
+    let mut in_fence = false;
+    let mut count = 0;
+    for line in text.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if !in_fence {
+            count += line.bytes().filter(|&b| b == b'`').count();
+        }
+    }
+    count
 }
 
 /// Detect whether `text` ends with a URL.

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -5478,6 +5478,7 @@ impl AgentService {
                     && super::truncation::try_emit_truncation_continue(
                         &iteration_text,
                         reasoning_text.as_ref(),
+                        &response.usage,
                         &mut context,
                         session_id,
                         &progress_callback,
@@ -5491,6 +5492,22 @@ impl AgentService {
                     // Mark the next iteration so the stream-error path skips
                     // cross-provider fallback for the continuation request.
                     current_iter_is_truncation_continue = true;
+                    self.record_provider_feedback(
+                        session_id,
+                        "truncation_retry",
+                        "stream-integrity",
+                        Some(&format!(
+                            "mid-sentence cut (tail {:?}); corrective continuation attempted (#36)",
+                            iteration_text
+                                .chars()
+                                .rev()
+                                .take(60)
+                                .collect::<String>()
+                                .chars()
+                                .rev()
+                                .collect::<String>()
+                        )),
+                    );
                     continue;
                 }
 
@@ -7102,8 +7119,8 @@ impl AgentService {
             match super::truncation::join_continuation(partial, &final_text) {
                 Continuation::Extended(joined) => {
                     tracing::info!(
-                        "Truncation continue: joined {} char partial with {} char continuation \
-                         into {} chars",
+                        "[TRUNCATION] verdict=recovered: joined {} char partial with {} char \
+                         continuation into {} chars",
                         partial.chars().count(),
                         final_text.chars().count(),
                         joined.chars().count()
@@ -7117,10 +7134,20 @@ impl AgentService {
                     // is as complete as it will get. Delivering it unmarked told
                     // the user a sentence ending at a colon was finished (#956).
                     tracing::warn!(
-                        "Truncation continue FAILED: {} char continuation added nothing to the \
-                         {} char partial (model echoed the tail) — delivering it marked incomplete",
+                        "[TRUNCATION] verdict=unrecovered: {} char continuation added nothing \
+                         to the {} char partial (model echoed the tail) — delivering it marked \
+                         incomplete",
                         final_text.chars().count(),
                         partial.chars().count(),
+                    );
+                    self.record_provider_feedback(
+                        session_id,
+                        "truncation_unrecovered",
+                        "stream-integrity",
+                        Some(
+                            "continuation echoed the tail; answer delivered with incomplete \
+                             marker (#36)",
+                        ),
                     );
                     final_text = format!("{still_partial}{}", super::truncation::INCOMPLETE_MARKER);
                 }

--- a/src/brain/agent/service/truncation.rs
+++ b/src/brain/agent/service/truncation.rs
@@ -25,6 +25,27 @@ use crate::brain::agent::context::AgentContext;
 use crate::brain::provider::Message;
 use uuid::Uuid;
 
+/// Usage-gap signal (#36): the visible text is far shorter than the billed
+/// non-reasoning output tokens would allow. `usage.output_tokens` includes
+/// reasoning, so reasoning is subtracted first — thinking-heavy turns would
+/// otherwise fake a gap on every reply. The floor is deliberately
+/// conservative at 2 chars per visible token (English prose runs ~4): the
+/// gap CORROBORATES a structural truncation signal and journals standalone
+/// deficits, but never triggers a retry by itself — tokenizer variance and
+/// terse/CJK styles make a ratio-only verdict ambiguous. Skipped entirely
+/// when the provider reported no output usage.
+pub(crate) fn has_usage_gap(text: &str, usage: &crate::brain::provider::TokenUsage) -> bool {
+    if usage.output_tokens == 0 {
+        return false;
+    }
+    let visible_tokens = usage.output_tokens.saturating_sub(usage.reasoning_tokens) as u64;
+    if visible_tokens == 0 {
+        return false;
+    }
+    let chars = text.trim_end().chars().count() as u64;
+    chars < visible_tokens * 2
+}
+
 /// Detect a mid-sentence cut-off and inject the one-shot continuation
 /// prompt into the context.
 ///
@@ -34,7 +55,10 @@ use uuid::Uuid;
 /// normal end-of-turn handling.
 ///
 /// Side effects when returning `true`:
-///   * `tracing::warn!` with the last-60-char preview for debugging
+///   * `[TRUNCATION] verdict=retry` warn journal with the signal set
+///     (structural, +usage_gap when the billed non-reasoning output
+///     dwarfs the arrived text — #36), the last-60-char preview, and
+///     the usage numbers
 ///   * `progress_callback` fires `SelfHealingAlert` + `IntermediateText`
 ///     so the user sees the partial reply AND a nudge that we're
 ///     asking for continuation
@@ -50,11 +74,26 @@ use uuid::Uuid;
 pub(super) fn try_emit_truncation_continue(
     iteration_text: &str,
     reasoning_text: Option<&String>,
+    usage: &crate::brain::provider::TokenUsage,
     context: &mut AgentContext,
     session_id: Uuid,
     progress_callback: &Option<ProgressCallback>,
 ) -> bool {
-    if !looks_truncated_mid_sentence(iteration_text.trim_end()) {
+    let structural = looks_truncated_mid_sentence(iteration_text.trim_end());
+    let usage_gap = has_usage_gap(iteration_text, usage);
+
+    if !structural {
+        // Text reads as complete. A usage gap alone never triggers a retry
+        // — tokenizer variance and terse styles make it ambiguous — but the
+        // journal line accumulates evidence for future tuning (#36).
+        if usage_gap {
+            tracing::info!(
+                "[TRUNCATION] verdict=usage-gap-watch text_chars={}, usage_output={}, usage_reasoning={} — complete-looking text with a token deficit; no retry",
+                iteration_text.trim_end().chars().count(),
+                usage.output_tokens,
+                usage.reasoning_tokens
+            );
+        }
         return false;
     }
 
@@ -67,9 +106,13 @@ pub(super) fn try_emit_truncation_continue(
         .rev()
         .collect();
     tracing::warn!(
-        "Response ended with finish_reason=stop but last chars look \
-         mid-sentence (tail={:?}) — asking model to continue once.",
+        "[TRUNCATION] verdict=retry signals=structural{} tail={:?} text_chars={}, usage_output={}, usage_reasoning={}, usage_gap={} — asking model to continue once",
+        if usage_gap { "+usage_gap" } else { "" },
         preview,
+        iteration_text.trim_end().chars().count(),
+        usage.output_tokens,
+        usage.reasoning_tokens,
+        usage_gap
     );
 
     if let Some(cb) = progress_callback {
@@ -171,4 +214,129 @@ pub(crate) fn join_continuation(partial: &str, continuation: &str) -> Continuati
     } else {
         format!("{p}{c}")
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::brain::agent::service::phantom::looks_truncated_mid_sentence;
+    use crate::brain::provider::TokenUsage;
+
+    fn usage(output: u32, reasoning: u32) -> TokenUsage {
+        TokenUsage {
+            output_tokens: output,
+            reasoning_tokens: reasoning,
+            ..Default::default()
+        }
+    }
+
+    // ── has_usage_gap ──────────────────────────────────────────────
+
+    #[test]
+    fn usage_gap_incident_numbers() {
+        // The 2026-08-28 #36 incident: 927 completion tokens billed, 457
+        // of them reasoning, but only 316 chars (~80 tokens) arrived.
+        let text = "x".repeat(316);
+        assert!(has_usage_gap(&text, &usage(927, 457)));
+    }
+
+    #[test]
+    fn usage_gap_healthy_text() {
+        // ~4 chars per visible token is normal English prose — no gap.
+        let text = "The deployment completed without issues.".repeat(5); // 190 chars
+        assert!(!has_usage_gap(&text, &usage(50, 0)));
+    }
+
+    #[test]
+    fn usage_gap_reasoning_heavy_no_false_positive() {
+        // Thinking-heavy turn: almost all output is reasoning, the small
+        // visible remainder matches the text. Must NOT flag.
+        let text = "x".repeat(300);
+        assert!(!has_usage_gap(&text, &usage(5000, 4900)));
+    }
+
+    #[test]
+    fn usage_gap_no_usage_no_signal() {
+        let text = "x".repeat(10);
+        assert!(!has_usage_gap(&text, &usage(0, 0)));
+        // All output is reasoning — nothing visible was billed.
+        assert!(!has_usage_gap(&text, &usage(100, 100)));
+    }
+
+    // ── structural shapes added for #36 ────────────────────────────
+
+    #[test]
+    fn backtick_parity_incident_shape() {
+        // Stream died on an OPENING backtick: exactly one backtick in the
+        // whole reply (odd parity) — the #36 shape, previously read as
+        // complete because a lone backtick matched no cut character.
+        let truncated = "You can find the full path in the config file under `";
+        assert!(looks_truncated_mid_sentence(truncated));
+    }
+
+    #[test]
+    fn backtick_closed_inline_code_clean() {
+        // Balanced backticks: the last one CLOSES inline code — complete.
+        let complete = "To check the status of the repository you run `git status`";
+        assert!(!looks_truncated_mid_sentence(complete));
+    }
+
+    #[test]
+    fn unclosed_fence_truncated() {
+        let text = "Here is the script you asked for:\n\n```bash\necho hello\nls -la";
+        assert!(looks_truncated_mid_sentence(text));
+    }
+
+    #[test]
+    fn closed_fence_clean() {
+        let text = "Here is the script you asked for:\n\n```bash\necho hello\n```\nRun it and tell me what it prints.";
+        assert!(!looks_truncated_mid_sentence(text));
+    }
+
+    #[test]
+    fn em_dash_tail_truncated() {
+        let text = "The migration finished cleanly and the only remaining step is the cutover —";
+        assert!(looks_truncated_mid_sentence(text));
+    }
+
+    #[test]
+    fn healthy_period_clean() {
+        let text = "The migration finished cleanly and nothing else needs to be done.";
+        assert!(!looks_truncated_mid_sentence(text));
+    }
+
+    // ── join_continuation semantics (#859/#956 regressions) ────────
+
+    #[test]
+    fn join_echoed_tail_recovers_nothing() {
+        let partial = "The answer is forty two tokens and the reason is";
+        let cont = "and the reason is";
+        assert_eq!(
+            join_continuation(partial, cont),
+            Continuation::Echoed(partial.to_string())
+        );
+    }
+
+    #[test]
+    fn join_genuine_continuation_extends() {
+        let partial = "The answer is forty two tokens and the reason is";
+        let cont = "that the model counted every token twice.";
+        match join_continuation(partial, cont) {
+            Continuation::Extended(j) => {
+                assert!(j.starts_with(partial));
+                assert!(j.ends_with("twice."));
+            }
+            other => panic!("expected Extended, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn join_restart_reproducing_partial_is_progress() {
+        let partial = "The answer is forty";
+        let cont = "The answer is forty two tokens.";
+        assert_eq!(
+            join_continuation(partial, cont),
+            Continuation::Extended(cont.to_string())
+        );
+    }
 }

--- a/src/brain/provider/claude_cli.rs
+++ b/src/brain/provider/claude_cli.rs
@@ -1414,6 +1414,7 @@ impl Provider for ClaudeCliProvider {
                                     // Billing tokens (cumulative across rounds)
                                     billing_cache_creation,
                                     billing_cache_read,
+                                    ..Default::default()
                                 },
                             }))
                             .await;

--- a/src/brain/provider/custom_openai_compatible.rs
+++ b/src/brain/provider/custom_openai_compatible.rs
@@ -3784,6 +3784,28 @@ impl Provider for OpenAIProvider {
             /// marker. Holding back a short suffix bridges the split,
             /// mirroring `think_carry`'s role for `<think>` tag detection.
             marker_carry: String,
+            /// TEXT_ACCUM journal (#36): number of TextDelta events emitted
+            /// to the consumer this turn. Paired with `text_chars` and
+            /// `response_text_accum` so the terminal `[STREAM_RECONCILE]`
+            /// line can reconcile billed usage against what actually
+            /// arrived — the discriminator for silent upstream/relay
+            /// truncation, which inferhub's metadata-only retention can
+            /// never settle after the fact.
+            text_delta_count: usize,
+            /// Char count of emitted text, maintained incrementally (O(1)
+            /// per delta instead of recounting the growing accumulator).
+            text_chars: usize,
+            /// Reasoning content emitted this turn (think-tag promotions +
+            /// `reasoning_content` field), chars and delta count — needed
+            /// to reconcile `usage.output - usage.reasoning ≈ visible`.
+            reasoning_chars: usize,
+            reasoning_delta_count: usize,
+            /// True once a chunk carrying `finish_reason` has been
+            /// processed. Distinguishes provider-declared stops from the
+            /// harness's EndTurn default (#694): `stop_source=default` at
+            /// a terminal path means the provider never said why the
+            /// stream ended.
+            saw_finish_reason: bool,
         }
 
         // Tool-call marker filtering runs for ALL OpenAI-compatible providers.
@@ -3809,6 +3831,11 @@ impl Provider for OpenAIProvider {
             tool_capture_buffer: String::new(),
             tool_block_active: false,
             marker_carry: String::new(),
+            text_delta_count: 0,
+            text_chars: 0,
+            reasoning_chars: 0,
+            reasoning_delta_count: 0,
+            saw_finish_reason: false,
         }));
 
         let event_stream = byte_stream
@@ -3878,6 +3905,24 @@ impl Provider for OpenAIProvider {
                                         .pending_stop_reason
                                         .take()
                                         .unwrap_or(crate::brain::provider::types::StopReason::EndTurn);
+                                    // Usage-vs-received reconciliation (#36): what the consumer
+                                    // actually got (chars/deltas/tail) against what the stream
+                                    // declared. `[DONE]` carries no usage, so output/reasoning
+                                    // are 0 here — the inline/usage-only paths carry real counts.
+                                    let reconc_tail: String = st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect();
+                                    let stop_source = if st.saw_finish_reason { "provider" } else { "default" };
+                                    tracing::info!(
+                                        "[STREAM_RECONCILE] text_chars={}, text_deltas={}, text_tail={}, reasoning_chars={}, reasoning_deltas={}, saw_finish_reason={}, stop_reason={:?}, stop_source={}, usage_input={}, usage_output=0, usage_reasoning=0",
+                                        st.text_chars,
+                                        st.text_delta_count,
+                                        reconc_tail,
+                                        st.reasoning_chars,
+                                        st.reasoning_delta_count,
+                                        st.saw_finish_reason,
+                                        stop_reason,
+                                        stop_source,
+                                        total_input_tokens
+                                    );
                                     tracing::info!("[STREAM_USAGE] Final usage (fallback on DONE): input={}, output=0, stop_reason={:?}", total_input_tokens, stop_reason);
                                     events.push(Ok(StreamEvent::MessageDelta {
                                         delta: crate::brain::provider::types::MessageDelta {
@@ -4331,6 +4376,14 @@ impl Provider for OpenAIProvider {
                                                     }
 
                                                     st.response_text_accum.push_str(&display_text);
+                                                    st.text_delta_count += 1;
+                                                    st.text_chars += display_text.chars().count();
+                                                    tracing::debug!(
+                                                        "[TEXT_ACCUM] text_len={}, text_delta_count={}, text_tail={}",
+                                                        st.text_chars,
+                                                        st.text_delta_count,
+                                                        st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect::<String>()
+                                                    );
                                                     events.push(Ok(StreamEvent::ContentBlockDelta {
                                                         index: 0,
                                                         delta: ContentDelta::TextDelta {
@@ -4369,6 +4422,8 @@ impl Provider for OpenAIProvider {
                                                     content_block: ContentBlock::Text { text: String::new() },
                                                 }));
                                             }
+                                            st.reasoning_delta_count += 1;
+                                            st.reasoning_chars += rc.chars().count();
                                             events.push(Ok(StreamEvent::ContentBlockDelta {
                                                 index: 0,
                                                 delta: ContentDelta::ReasoningDelta {
@@ -4383,6 +4438,10 @@ impl Provider for OpenAIProvider {
                                         // final usage-only chunk AFTER this one. We handle
                                         // MessageStop on [DONE] or the usage-only chunk below.
                                         if let Some(reason) = finish_reason_str {
+                                            // The provider declared why the stream ended —
+                                            // distinguishes this stop from the harness's EndTurn
+                                            // default at the terminal paths (#36, #694).
+                                            st.saw_finish_reason = true;
                                             // If we were still withholding a leak-probe buffer
                                             // waiting to confirm/deny a tool_calls envelope and
                                             // the turn is ending without it ever matching, flush
@@ -4412,6 +4471,8 @@ impl Provider for OpenAIProvider {
                                                             content_block: ContentBlock::Text { text: String::new() },
                                                         }));
                                                     }
+                                                    st.reasoning_delta_count += 1;
+                                                    st.reasoning_chars += reasoning_from_think.chars().count();
                                                     events.push(Ok(StreamEvent::ContentBlockDelta {
                                                         index: 0,
                                                         delta: ContentDelta::ReasoningDelta {
@@ -4428,6 +4489,14 @@ impl Provider for OpenAIProvider {
                                                         }));
                                                     }
                                                     st.response_text_accum.push_str(&filtered);
+                                                    st.text_delta_count += 1;
+                                                    st.text_chars += filtered.chars().count();
+                                                    tracing::debug!(
+                                                        "[TEXT_ACCUM] text_len={}, text_delta_count={}, text_tail={}",
+                                                        st.text_chars,
+                                                        st.text_delta_count,
+                                                        st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect::<String>()
+                                                    );
                                                     events.push(Ok(StreamEvent::ContentBlockDelta {
                                                         index: 0,
                                                         delta: ContentDelta::TextDelta { text: filtered },
@@ -4511,6 +4580,11 @@ impl Provider for OpenAIProvider {
                                             } else {
                                                 (0, 0, 0, 0)
                                             };
+                                            let raw_reasoning = chunk
+                                                .usage
+                                                .as_ref()
+                                                .map(|u| u.reasoning_tokens())
+                                                .unwrap_or(0);
 
                                             let stop_reason = Some(match reason.as_str() {
                                                 "stop" => crate::brain::provider::types::StopReason::EndTurn,
@@ -4522,6 +4596,22 @@ impl Provider for OpenAIProvider {
                                             // If this chunk already carries real usage (some
                                             // providers inline it), emit immediately + stop.
                                             if raw_input > 0 || raw_output > 0 {
+                                                let reconc_tail: String = st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect();
+                                                let stop_source = if st.saw_finish_reason { "provider" } else { "default" };
+                                                tracing::info!(
+                                                    "[STREAM_RECONCILE] text_chars={}, text_deltas={}, text_tail={}, reasoning_chars={}, reasoning_deltas={}, saw_finish_reason={}, stop_reason={:?}, stop_source={}, usage_input={}, usage_output={}, usage_reasoning={}",
+                                                    st.text_chars,
+                                                    st.text_delta_count,
+                                                    reconc_tail,
+                                                    st.reasoning_chars,
+                                                    st.reasoning_delta_count,
+                                                    st.saw_finish_reason,
+                                                    stop_reason,
+                                                    stop_source,
+                                                    raw_input,
+                                                    raw_output,
+                                                    raw_reasoning
+                                                );
                                                 tracing::info!(
                                                     "[STREAM_USAGE] Final usage (inline): input={}, output={}, cache_read={}, cache_create={}",
                                                     raw_input, raw_output, raw_cache_read, raw_cache_create
@@ -4534,6 +4624,7 @@ impl Provider for OpenAIProvider {
                                                     usage: crate::brain::provider::types::TokenUsage {
                                                         input_tokens: raw_input,
                                                         output_tokens: raw_output,
+                                                        reasoning_tokens: raw_reasoning,
                                                         cache_creation_tokens: raw_cache_create,
                                                         cache_read_tokens: raw_cache_read,
                                                         ..Default::default()
@@ -4558,26 +4649,44 @@ impl Provider for OpenAIProvider {
                                                 let cache_create = usage.cache_creation_input_tokens.unwrap_or(0);
                                                 let reasoning = usage.reasoning_tokens();
                                                 if input > 0 || output > 0 {
+                                                    // The usage-only chunk is the provider's FINAL
+                                                    // chunk — the turn is complete. Default to
+                                                    // EndTurn when no finish_reason set a
+                                                    // stop_reason, so a finished turn terminates
+                                                    // instead of retrying forever
+                                                    // (qwen3.8-max-preview, #694).
+                                                    let final_stop_reason = st.pending_stop_reason.take().unwrap_or(
+                                                        crate::brain::provider::types::StopReason::EndTurn,
+                                                    );
+                                                    let reconc_tail: String = st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect();
+                                                    let stop_source = if st.saw_finish_reason { "provider" } else { "default" };
+                                                    tracing::info!(
+                                                        "[STREAM_RECONCILE] text_chars={}, text_deltas={}, text_tail={}, reasoning_chars={}, reasoning_deltas={}, saw_finish_reason={}, stop_reason={:?}, stop_source={}, usage_input={}, usage_output={}, usage_reasoning={}",
+                                                        st.text_chars,
+                                                        st.text_delta_count,
+                                                        reconc_tail,
+                                                        st.reasoning_chars,
+                                                        st.reasoning_delta_count,
+                                                        st.saw_finish_reason,
+                                                        final_stop_reason,
+                                                        stop_source,
+                                                        input,
+                                                        output,
+                                                        reasoning
+                                                    );
                                                     tracing::info!(
                                                         "[STREAM_USAGE] Final usage: input={}, output={}, cache_read={}, cache_create={}, reasoning={}",
                                                         input, output, cache_read, cache_create, reasoning
                                                     );
                                                     events.push(Ok(StreamEvent::MessageDelta {
                                                         delta: crate::brain::provider::types::MessageDelta {
-                                                            // The usage-only chunk is the provider's
-                                                            // FINAL chunk — the turn is complete.
-                                                            // Default to EndTurn when no finish_reason
-                                                            // set a stop_reason, so a finished turn
-                                                            // terminates instead of retrying forever
-                                                            // (qwen3.8-max-preview, #694).
-                                                            stop_reason: Some(st.pending_stop_reason.take().unwrap_or(
-                                                                crate::brain::provider::types::StopReason::EndTurn,
-                                                            )),
+                                                            stop_reason: Some(final_stop_reason),
                                                             stop_sequence: None,
                                                         },
                                                         usage: crate::brain::provider::types::TokenUsage {
                                                             input_tokens: input,
                                                             output_tokens: output,
+                                                            reasoning_tokens: reasoning,
                                                             cache_creation_tokens: cache_create,
                                                             cache_read_tokens: cache_read,
                                                             ..Default::default()

--- a/src/brain/provider/custom_openai_compatible.rs
+++ b/src/brain/provider/custom_openai_compatible.rs
@@ -3909,19 +3909,23 @@ impl Provider for OpenAIProvider {
                                     // actually got (chars/deltas/tail) against what the stream
                                     // declared. `[DONE]` carries no usage, so output/reasoning
                                     // are 0 here — the inline/usage-only paths carry real counts.
-                                    let reconc_tail: String = st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect();
+                                    // Sanitize the tail for logging: mid-turn text ends in paragraph
+                                    // breaks (`\n\n` before a tool call) and the log writer does NOT
+                                    // escape embedded newlines — a raw tail splits the log line and
+                                    // orphans every field after it (caught in post-swap smoke).
+                                    let reconc_tail: String = st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect::<String>().replace('\n', "\\n").replace('\r', "\\r");
                                     let stop_source = if st.saw_finish_reason { "provider" } else { "default" };
                                     tracing::info!(
-                                        "[STREAM_RECONCILE] text_chars={}, text_deltas={}, text_tail={}, reasoning_chars={}, reasoning_deltas={}, saw_finish_reason={}, stop_reason={:?}, stop_source={}, usage_input={}, usage_output=0, usage_reasoning=0",
+                                        "[STREAM_RECONCILE] text_chars={}, text_deltas={}, reasoning_chars={}, reasoning_deltas={}, saw_finish_reason={}, stop_reason={:?}, stop_source={}, usage_input={}, usage_output=0, usage_reasoning=0, text_tail={}",
                                         st.text_chars,
                                         st.text_delta_count,
-                                        reconc_tail,
                                         st.reasoning_chars,
                                         st.reasoning_delta_count,
                                         st.saw_finish_reason,
                                         stop_reason,
                                         stop_source,
-                                        total_input_tokens
+                                        total_input_tokens,
+                                        reconc_tail
                                     );
                                     tracing::info!("[STREAM_USAGE] Final usage (fallback on DONE): input={}, output=0, stop_reason={:?}", total_input_tokens, stop_reason);
                                     events.push(Ok(StreamEvent::MessageDelta {
@@ -4382,7 +4386,9 @@ impl Provider for OpenAIProvider {
                                                         "[TEXT_ACCUM] text_len={}, text_delta_count={}, text_tail={}",
                                                         st.text_chars,
                                                         st.text_delta_count,
-                                                        st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect::<String>()
+                                                        // Sanitized: raw tails carry embedded newlines
+                                                        // that split log lines (see STREAM_RECONCILE note).
+                                                        st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect::<String>().replace('\n', "\\n").replace('\r', "\\r")
                                                     );
                                                     events.push(Ok(StreamEvent::ContentBlockDelta {
                                                         index: 0,
@@ -4495,7 +4501,9 @@ impl Provider for OpenAIProvider {
                                                         "[TEXT_ACCUM] text_len={}, text_delta_count={}, text_tail={}",
                                                         st.text_chars,
                                                         st.text_delta_count,
-                                                        st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect::<String>()
+                                                        // Sanitized: raw tails carry embedded newlines
+                                                        // that split log lines (see STREAM_RECONCILE note).
+                                                        st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect::<String>().replace('\n', "\\n").replace('\r', "\\r")
                                                     );
                                                     events.push(Ok(StreamEvent::ContentBlockDelta {
                                                         index: 0,
@@ -4596,13 +4604,12 @@ impl Provider for OpenAIProvider {
                                             // If this chunk already carries real usage (some
                                             // providers inline it), emit immediately + stop.
                                             if raw_input > 0 || raw_output > 0 {
-                                                let reconc_tail: String = st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect();
+                                                let reconc_tail: String = st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect::<String>().replace('\n', "\\n").replace('\r', "\\r");
                                                 let stop_source = if st.saw_finish_reason { "provider" } else { "default" };
                                                 tracing::info!(
-                                                    "[STREAM_RECONCILE] text_chars={}, text_deltas={}, text_tail={}, reasoning_chars={}, reasoning_deltas={}, saw_finish_reason={}, stop_reason={:?}, stop_source={}, usage_input={}, usage_output={}, usage_reasoning={}",
+                                                    "[STREAM_RECONCILE] text_chars={}, text_deltas={}, reasoning_chars={}, reasoning_deltas={}, saw_finish_reason={}, stop_reason={:?}, stop_source={}, usage_input={}, usage_output={}, usage_reasoning={}, text_tail={}",
                                                     st.text_chars,
                                                     st.text_delta_count,
-                                                    reconc_tail,
                                                     st.reasoning_chars,
                                                     st.reasoning_delta_count,
                                                     st.saw_finish_reason,
@@ -4610,7 +4617,8 @@ impl Provider for OpenAIProvider {
                                                     stop_source,
                                                     raw_input,
                                                     raw_output,
-                                                    raw_reasoning
+                                                    raw_reasoning,
+                                                    reconc_tail
                                                 );
                                                 tracing::info!(
                                                     "[STREAM_USAGE] Final usage (inline): input={}, output={}, cache_read={}, cache_create={}",
@@ -4658,13 +4666,12 @@ impl Provider for OpenAIProvider {
                                                     let final_stop_reason = st.pending_stop_reason.take().unwrap_or(
                                                         crate::brain::provider::types::StopReason::EndTurn,
                                                     );
-                                                    let reconc_tail: String = st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect();
+                                                    let reconc_tail: String = st.response_text_accum.chars().rev().take(60).collect::<String>().chars().rev().collect::<String>().replace('\n', "\\n").replace('\r', "\\r");
                                                     let stop_source = if st.saw_finish_reason { "provider" } else { "default" };
                                                     tracing::info!(
-                                                        "[STREAM_RECONCILE] text_chars={}, text_deltas={}, text_tail={}, reasoning_chars={}, reasoning_deltas={}, saw_finish_reason={}, stop_reason={:?}, stop_source={}, usage_input={}, usage_output={}, usage_reasoning={}",
+                                                        "[STREAM_RECONCILE] text_chars={}, text_deltas={}, reasoning_chars={}, reasoning_deltas={}, saw_finish_reason={}, stop_reason={:?}, stop_source={}, usage_input={}, usage_output={}, usage_reasoning={}, text_tail={}",
                                                         st.text_chars,
                                                         st.text_delta_count,
-                                                        reconc_tail,
                                                         st.reasoning_chars,
                                                         st.reasoning_delta_count,
                                                         st.saw_finish_reason,
@@ -4672,7 +4679,8 @@ impl Provider for OpenAIProvider {
                                                         stop_source,
                                                         input,
                                                         output,
-                                                        reasoning
+                                                        reasoning,
+                                                        reconc_tail
                                                     );
                                                     tracing::info!(
                                                         "[STREAM_USAGE] Final usage: input={}, output={}, cache_read={}, cache_create={}, reasoning={}",

--- a/src/brain/provider/types.rs
+++ b/src/brain/provider/types.rs
@@ -266,6 +266,13 @@ pub struct TokenUsage {
     pub input_tokens: u32,
     /// Output tokens
     pub output_tokens: u32,
+    /// Reasoning tokens billed inside `output_tokens` (provider
+    /// `usage.reasoning_tokens`). Zero for providers that don't split
+    /// reasoning out. Lets the tool loop reconcile billed output against
+    /// visible text — `output - reasoning ≈ visible tokens` — instead of
+    /// letting thinking-heavy turns fake a usage gap (#36).
+    #[serde(default)]
+    pub reasoning_tokens: u32,
     /// Cache creation input tokens (Anthropic-specific)
     #[serde(default)]
     pub cache_creation_tokens: u32,


### PR DESCRIPTION
## What

Two-layer stream-integrity instrumentation + resilience for OpenAI-compatible providers, harvested from our fork ([leshchenko1979/opencrabs#36](https://github.com/leshchenko1979/opencrabs/issues/36), shipped there as `d7afa569` and live in production since 2026-08-31 03:21Z).

**Layer 1 — evidence: per-stream journal (`TEXT_ACCUM` + `STREAM_RECONCILE`).** The stream accumulator now counts text/reasoning chars and deltas per stream and emits, at each terminal path (DONE handler and usage-only final chunk), one INFO reconcile line: received chars vs provider-billed usage, `stop_reason`, and a new `stop_source=provider|default` that distinguishes a real provider `finish_reason` from the harness `EndTurn` default (#694 class). `TokenUsage` gains `reasoning_tokens: u64` (existing literals unaffected via `..Default::default()`). A 60-char `text_tail` rides the line — sanitized (`\n`/`\r` escaped) and placed LAST so an embedded newline can never split the usage fields off the log line.

**Layer 2 — resilience: truncation detector + one corrective retry.** New pure-function module `src/brain/agent/service/truncation.rs` (unit-tested against real incident numbers) fires on 2+ signals: structural (odd trailing backticks / unclosed fence parity) and usage-gap (`text_chars < (output − reasoning) × 2.0`, skipped when output=0). On detection: the truncated text is appended, one continuation nudge is streamed, and the joined text flows through persistence/delivery — budget 1 per turn, text-only EndTurn iterations, every detection journaled as `[TRUNCATION]` and fed to `record_provider_feedback` like the existing phantom detection.

## Why

Real incident: a provider billed 927 completion tokens (457 reasoning) but only 316 chars of text arrived — mid-sentence cut at a backtick, clean-looking `EndTurn`, full billing, `status=ok`. Nothing downstream of the accumulator lost anything (verified), the gateway retained no bodies, and the harness logged no raw deltas — attribution was permanently undecidable. This makes the next occurrence decidable (loss upstream vs in-harness) and auto-heals the deliverable when it is detectable.

## Production evidence (fork, 2026-08-31)

- ~480 tagged journal lines in the first 10 minutes; zero split/orphan lines after the tail-sanitization fix
- `stop_source=provider` live; billed-vs-received reasoning math reconciles per stream (`usage_reasoning` == char-derived count on the same line)
- both terminal paths (DONE-path and inline-usage) observed firing correctly

## Scope / risks

- Retry re-bills the input context; gated behind the 2-signal threshold, journaled every time.
- False positives bounded by the 2-signal gate; worst case is one harmless joined continuation.
- Out of scope: provider-side stop pathology, gateway body retention.

Tests: pure-fn unit tests in `truncation.rs` (incident numbers 316/927/457 → suspect; healthy/structural-only/gap-only → clean; retry budget capped). Gate evidence on the fork: fmt/clippy/tests GREEN, all-features, run 33349326952.

Tracked fork issue with full forensics and the incident timeline: [leshchenko1979/opencrabs#36](https://github.com/leshchenko1979/opencrabs/issues/36) (sibling instrument-reuse note: [leshchenko1979/opencrabs#35](https://github.com/leshchenko1979/opencrabs/issues/35))
