### PR TITLE
fix(telegram): boot-time wake of recently-active sessions, log-only

### DIFF
--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -868,54 +868,32 @@ fn short_session_id(uuid: Uuid) -> String {
     uuid.simple().to_string()[..8].to_owned()
 }
 
-/// How recently (seconds) a Telegram-bound session must have been active for
-/// the boot-time wake pass (#1227) to ping it.
+/// How recently (seconds) a Telegram-bound session must have been active to
+/// appear in the boot-time wake log (#1227).
 ///
 /// Kept short on purpose: a back-to-back dev restart (the recurring case on
-/// the ops box, 10+/day) must not re-nudge every recently-active topic every
-/// time. Only sessions that touched their topic inside this window are told
-/// the platform survived.
+/// the ops box, 10+/day) must not flood the log with every recently-active
+/// session each time. Only sessions that touched their topic inside this
+/// window are recorded.
 pub const WAKE_RECENT_SECS: i64 = 600;
 
-/// Text for the boot-time "I'm back" nudge. Deliberately states nothing was
-/// lost and asks for a message only if something was truly in flight, so a
-/// plain stream of restarts reads as reassuring rather than alarming.
-fn wake_text() -> String {
-    "⚙️ <b>beep</b> — I just restarted and I'm back online.\n\
-     Everything from before the restart is safe. If you had anything in \
-     flight, send a message and I'll pick it up — otherwise I'm ready."
-        .to_string()
-}
-
-/// Wait (bounded) for the Telegram bot to authenticate at startup.
-async fn wait_for_bot(state: &Arc<TelegramState>) -> Option<teloxide::Bot> {
-    for _ in 0..30 {
-        if let Some(bot) = state.bot().await {
-            return Some(bot);
-        }
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    }
-    tracing::error!(target: "telegram", "Boot wake: bot not available after 30s");
-    None
-}
-
-/// Ping every Telegram-bound session that was active shortly before boot but
-/// is not currently being resumed, so its topic does not look dead (#1227).
+/// Log every Telegram-bound session that was active shortly before boot but
+/// is not currently being resumed, so the stranded set is auditable (#1227).
 ///
 /// The on-disk journal only rescues turns that were literally mid-loop at the
 /// kill instant; between-turn sessions have no row (#1224 re-registers their
 /// delivery routes, which drains parked reports, but that happens quietly).
-/// Nothing tells such a topic that the platform survived, so it looks dead
-/// until someone pokes it. This pass closes that with a single lightweight
-/// message to the topic each session belongs to — it runs no turn and
-/// re-executes nothing, it is purely informational.
+/// This pass names them in the log instead: it runs no turn, re-executes
+/// nothing, and sends no message — the former "I'm back" bubble was removed
+/// per #34 (owner direction 2026-08-29: remove the UX message, leave
+/// logging), because it promised resumption the feature does not yet deliver
+/// and was never persisted in `channel_messages`, so it could not be audited.
 ///
 /// Sessions whose ids are in `already_resumed` are skipped: those were roused
-/// by a full continuation prompt via `resume_session` already, and would
-/// otherwise get a redundant nudge. Returns how many nudges were scheduled.
+/// by a full continuation prompt via `resume_session` already. Returns how
+/// many sessions landed in the log.
 pub async fn wake_recently_active(
     pool: crate::db::Pool,
-    state: Arc<TelegramState>,
     already_resumed: &std::collections::HashSet<Uuid>,
 ) -> usize {
     let now = std::time::SystemTime::now()
@@ -929,54 +907,22 @@ pub async fn wake_recently_active(
         return 0;
     };
 
-    let mut scheduled = 0usize;
+    let mut stranded: Vec<String> = Vec::new();
     for b in bindings {
         let Ok(sid) = Uuid::parse_str(&b.session_id) else { continue };
         if already_resumed.contains(&sid) {
             continue;
         }
-        let Ok(chat_id) = b.chat_id.parse::<i64>() else { continue };
-        let thread_id = b
-            .thread_id
-            .map(|t| teloxide::types::ThreadId(teloxide::types::MessageId(t)));
-        let state = state.clone();
-        tokio::spawn(async move {
-            let Some(bot) = wait_for_bot(&state).await else { return };
-            // 429 discipline (#816): several wakes can land in the same chat
-            // at once right after a resume stream, so wait the window out and
-            // retry once with fresh content, matching delivery.rs / flow.rs.
-            let text = wake_text();
-            let send_now = |fresh: String| {
-                let mut req = bot
-                    .send_message(teloxide::types::ChatId(chat_id), fresh)
-                    .parse_mode(teloxide::types::ParseMode::Html);
-                if let Some(tid) = thread_id {
-                    req = req.message_thread_id(tid);
-                }
-                req
-            };
-            match send_now(text.clone()).await {
-                Ok(_) => {}
-                Err(teloxide::RequestError::RetryAfter(secs)) => {
-                    super::rate_limit::wait_out(
-                        "boot wake",
-                        secs.duration(),
-                        " on first delivery, retrying once",
-                    )
-                    .await;
-                    if let Err(e) = send_now(text).await {
-                        tracing::warn!(target: "telegram", "boot wake failed on 429 retry for session {sid}: {e}");
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!("boot wake failed for session {sid}: {e}");
-                }
-            }
-        });
-        scheduled += 1;
+        stranded.push(short_session_id(sid));
     }
 
+    let scheduled = stranded.len();
     if scheduled > 0 {
+        tracing::info!(
+            target: "telegram",
+            "Boot wake pass (log-only, #34): recently-active sessions not resumed: [{}]",
+            stranded.join(",")
+        );
         tracing::info!(
             target: "telegram",
             "Scheduled boot wake for {scheduled} recently-active session(s) (#1227)"

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -867,3 +867,120 @@ async fn sender_label(
 fn short_session_id(uuid: Uuid) -> String {
     uuid.simple().to_string()[..8].to_owned()
 }
+
+/// How recently (seconds) a Telegram-bound session must have been active for
+/// the boot-time wake pass (#1227) to ping it.
+///
+/// Kept short on purpose: a back-to-back dev restart (the recurring case on
+/// the ops box, 10+/day) must not re-nudge every recently-active topic every
+/// time. Only sessions that touched their topic inside this window are told
+/// the platform survived.
+pub const WAKE_RECENT_SECS: i64 = 600;
+
+/// Text for the boot-time "I'm back" nudge. Deliberately states nothing was
+/// lost and asks for a message only if something was truly in flight, so a
+/// plain stream of restarts reads as reassuring rather than alarming.
+fn wake_text() -> String {
+    "⚙️ <b>beep</b> — I just restarted and I'm back online.\n\
+     Everything from before the restart is safe. If you had anything in \
+     flight, send a message and I'll pick it up — otherwise I'm ready."
+        .to_string()
+}
+
+/// Wait (bounded) for the Telegram bot to authenticate at startup.
+async fn wait_for_bot(state: &Arc<TelegramState>) -> Option<teloxide::Bot> {
+    for _ in 0..30 {
+        if let Some(bot) = state.bot().await {
+            return Some(bot);
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+    tracing::error!(target: "telegram", "Boot wake: bot not available after 30s");
+    None
+}
+
+/// Ping every Telegram-bound session that was active shortly before boot but
+/// is not currently being resumed, so its topic does not look dead (#1227).
+///
+/// The on-disk journal only rescues turns that were literally mid-loop at the
+/// kill instant; between-turn sessions have no row (#1224 re-registers their
+/// delivery routes, which drains parked reports, but that happens quietly).
+/// Nothing tells such a topic that the platform survived, so it looks dead
+/// until someone pokes it. This pass closes that with a single lightweight
+/// message to the topic each session belongs to — it runs no turn and
+/// re-executes nothing, it is purely informational.
+///
+/// Sessions whose ids are in `already_resumed` are skipped: those were roused
+/// by a full continuation prompt via `resume_session` already, and would
+/// otherwise get a redundant nudge. Returns how many nudges were scheduled.
+pub async fn wake_recently_active(
+    pool: crate::db::Pool,
+    state: Arc<TelegramState>,
+    already_resumed: &std::collections::HashSet<Uuid>,
+) -> usize {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let since_epoch = now.saturating_sub(WAKE_RECENT_SECS);
+    let repo = crate::db::SessionBindingRepository::new(pool);
+    let Ok(bindings) = repo.recent_for_channel("telegram", since_epoch).await else {
+        tracing::warn!(target: "telegram", "Boot wake could not read recent session bindings");
+        return 0;
+    };
+
+    let mut scheduled = 0usize;
+    for b in bindings {
+        let Ok(sid) = Uuid::parse_str(&b.session_id) else { continue };
+        if already_resumed.contains(&sid) {
+            continue;
+        }
+        let Ok(chat_id) = b.chat_id.parse::<i64>() else { continue };
+        let thread_id = b
+            .thread_id
+            .map(|t| teloxide::types::ThreadId(teloxide::types::MessageId(t)));
+        let state = state.clone();
+        tokio::spawn(async move {
+            let Some(bot) = wait_for_bot(&state).await else { return };
+            // 429 discipline (#816): several wakes can land in the same chat
+            // at once right after a resume stream, so wait the window out and
+            // retry once with fresh content, matching delivery.rs / flow.rs.
+            let text = wake_text();
+            let send_now = |fresh: String| {
+                let mut req = bot
+                    .send_message(teloxide::types::ChatId(chat_id), fresh)
+                    .parse_mode(teloxide::types::ParseMode::Html);
+                if let Some(tid) = thread_id {
+                    req = req.message_thread_id(tid);
+                }
+                req
+            };
+            match send_now(text.clone()).await {
+                Ok(_) => {}
+                Err(teloxide::RequestError::RetryAfter(secs)) => {
+                    super::rate_limit::wait_out(
+                        "boot wake",
+                        secs.duration(),
+                        " on first delivery, retrying once",
+                    )
+                    .await;
+                    if let Err(e) = send_now(text).await {
+                        tracing::warn!(target: "telegram", "boot wake failed on 429 retry for session {sid}: {e}");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("boot wake failed for session {sid}: {e}");
+                }
+            }
+        });
+        scheduled += 1;
+    }
+
+    if scheduled > 0 {
+        tracing::info!(
+            target: "telegram",
+            "Scheduled boot wake for {scheduled} recently-active session(s) (#1227)"
+        );
+    }
+    scheduled
+}

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -1476,13 +1476,12 @@ async fn cmd_chat_inner(
     // Wake (#1227): recently-active bound sessions that were NOT mid-turn at
     // boot have no journal row, so they look dead until someone pokes one.
     // #1224 re-registers their routes (draining parked reports) at connect,
-    // but quietly — nothing tells the topic the platform survived. Send each
-    // a single lightweight nudge so it does not appear dead. Purely
-    // informational; it runs no turn and re-executes nothing.
+    // but quietly. Log the stranded set so it is auditable; purely
+    // informational — it runs no turn, re-executes nothing, sends no message
+    // (the former "I'm back" bubble was removed per #34).
     #[cfg(feature = "telegram")]
     crate::channels::telegram::resume::wake_recently_active(
         db.pool().clone(),
-        telegram_state.clone(),
         &resumed_session_ids,
     )
     .await;

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -1183,6 +1183,10 @@ async fn cmd_chat_inner(
     // agent reads context and picks up naturally — no loops, no leaking restart signals.
     // Routes responses back to the originating channel (TUI, Telegram, Discord, etc.).
     let resume_event_sender = app.event_sender();
+    // Sessions roused by the resume path below (see the wake pass, #1227) so
+    // they are not nudged a second time by it.
+    let mut resumed_session_ids: std::collections::HashSet<uuid::Uuid> =
+        std::collections::HashSet::new();
     {
         let pending_repo = crate::db::PendingRequestRepository::new(db.pool().clone());
         match pending_repo.get_interrupted().await {
@@ -1204,6 +1208,7 @@ async fn cmd_chat_inner(
                         if !seen.insert(session_id) {
                             continue;
                         }
+                        resumed_session_ids.insert(session_id);
                         // Restore the session's saved working directory before
                         // resuming so the agent runs tools in the right CWD.
                         // Note: agent_service shares one global WD lock across
@@ -1467,6 +1472,20 @@ async fn cmd_chat_inner(
             Err(e) => tracing::warn!("Failed to check for interrupted requests: {}", e),
         }
     }
+
+    // Wake (#1227): recently-active bound sessions that were NOT mid-turn at
+    // boot have no journal row, so they look dead until someone pokes one.
+    // #1224 re-registers their routes (draining parked reports) at connect,
+    // but quietly — nothing tells the topic the platform survived. Send each
+    // a single lightweight nudge so it does not appear dead. Purely
+    // informational; it runs no turn and re-executes nothing.
+    #[cfg(feature = "telegram")]
+    crate::channels::telegram::resume::wake_recently_active(
+        db.pool().clone(),
+        telegram_state.clone(),
+        &resumed_session_ids,
+    )
+    .await;
 
     // Channel manager — handles dynamic spawn/stop of channel agents on config reload
     let channel_manager = Arc::new(crate::channels::ChannelManager::new(

--- a/src/db/repository/session_binding.rs
+++ b/src/db/repository/session_binding.rs
@@ -98,4 +98,43 @@ impl SessionBindingRepository {
             .context("Failed to list session bindings")?;
         Ok(mapped)
     }
+
+    /// Bindings for one channel whose `updated_at` is at least `since_epoch`
+    /// (unix seconds), least-recently-changed first.
+    ///
+    /// The boot-time wake pass (#1227) uses this to find sessions that were
+    /// active around a restart, so it can ping their topics that the platform
+    /// survived — without waking every historical session. The INNER JOIN
+    /// against `sessions` drops bindings whose session was deleted, matching
+    /// [`Self::all_for_channel`] (#1224).
+    pub async fn recent_for_channel(&self, channel: &str, since_epoch: i64) -> Result<Vec<SessionBinding>> {
+        let ch = channel.to_string();
+        let mapped = self
+            .pool
+            .get()
+            .await
+            .context("Failed to get connection")?
+            .interact(move |conn| {
+                conn.prepare(
+                    "SELECT b.session_id, b.channel, b.chat_id, b.thread_id \
+                     FROM session_bindings b \
+                     JOIN sessions s ON s.id = b.session_id \
+                     WHERE b.channel = ?1 AND b.updated_at >= ?2 \
+                     ORDER BY b.updated_at ASC",
+                )?
+                .query_map(params![ch, since_epoch], |row| {
+                    Ok(SessionBinding {
+                        session_id: row.get("session_id")?,
+                        channel: row.get("channel")?,
+                        chat_id: row.get("chat_id")?,
+                        thread_id: row.get("thread_id")?,
+                    })
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()
+            })
+            .await
+            .map_err(interact_err)?
+            .context("Failed to list recent session bindings")?;
+        Ok(mapped)
+    }
 }


### PR DESCRIPTION
## Problem

After a daemon restart, sessions that were **between turns** at kill time (not mid-tool-loop) were never recovered: the pending-journal resume only covers turns with a `pending_requests` row, so every recently-active session without one sat silent until a human nudged its topic. [adolfousier/opencrabs#1227](https://github.com/adolfousier/opencrabs/issues/1227) documents this blind window.

## Fix

At boot, after the journal resume pass, a **wake pass** scans `session_bindings` via a new `recent_for_channel(...)` query (sessions active within the last 600 s) minus the set the journal already resumed, and pings each stranded session's bound topic once — runs no turn, re-executes nothing, never double-fires with the journal path (disjoint sets, verified).

The wake is **log-only by design**: no UX bubble is sent. The pass logs the stranded set per boot:

- `Boot wake pass (log-only, #34): recently-active sessions not resumed: [...]` (only when the set is non-empty)
- `Scheduled boot wake for N recently-active session(s) (#1227)`

This replaces an earlier draft that sent a "back online" bubble; the bubble was removed (and its hand-rolled 429-retry send path with it) in favor of the audit log line — see fork context [leshchenko1979/opencrabs#34](https://github.com/leshchenko1979/opencrabs/issues/34).

| File | Change |
|---|---|
| `src/cli/ui.rs` | wake call after the resume block + `resumed_session_ids` dedup |
| `src/channels/telegram/resume.rs` | `wake_recently_active` + 600 s window, log-only |
| `src/db/repository/session_binding.rs` | `recent_for_channel(…)` query on the existing `(channel, updated_at)` index |

## Verification

- Smoke-tested live on the fork across multiple restarts: recently-active sessions are discovered and logged on boot, zero UX bubbles, no double-resume with the journal path.
- Compile + test gate: [leshchenko1979/opencrabs run 33352385762](https://github.com/leshchenko1979/opencrabs/actions/runs/33352385762) — `PR-lane gates (2efb91898e51258f066ab6080320f3835bce3457)` success (fmt + clippy + `cargo test --locked --all-features`, 7000+ tests).

Closes #1227
