### PR TITLE
fix(telegram): compaction progress dedupe, observed-ETA predictor, icon-aware gear strip

### DIFF
--- a/src/brain/agent/service/builder.rs
+++ b/src/brain/agent/service/builder.rs
@@ -244,6 +244,12 @@ pub struct AgentService {
     /// below 55% so a fresh entry into the band warns again. Keeps the
     /// transient nudge to once-per-entry instead of every turn.
     pub(super) session_pressure_warned: std::sync::RwLock<HashMap<Uuid, bool>>,
+    /// Observed wall-clock duration of each session's last SUCCESSFUL
+    /// compaction (#29 E2). Feeds the `predicted` ETA hint on the next
+    /// `Compacting` event — grounded in what actually happened instead of a
+    /// static guess. Written at CompactionSummary emit, read at Compacting
+    /// emit; same per-session map pattern as `session_pressure_warned`.
+    pub(super) last_compaction_elapsed: std::sync::RwLock<HashMap<Uuid, std::time::Duration>>,
 
     /// Per-session ring buffer of outgoing assistant texts (#957). The
     /// cross-turn announcement guard: near-identical turn-final texts that
@@ -404,6 +410,7 @@ impl AgentService {
             session_primary_failure_streak: std::sync::RwLock::new(HashMap::new()),
             active_skills: std::sync::RwLock::new(HashMap::new()),
             session_pressure_warned: std::sync::RwLock::new(HashMap::new()),
+            last_compaction_elapsed: std::sync::RwLock::new(HashMap::new()),
             session_outgoing_text_ring: std::sync::RwLock::new(HashMap::new()),
             context,
             tool_registry: Arc::new(ToolRegistry::new()),

--- a/src/brain/agent/service/compaction.rs
+++ b/src/brain/agent/service/compaction.rs
@@ -154,8 +154,23 @@ impl AgentService {
         // CompactionSummary emit below.
         let compact_started = std::time::Instant::now();
         let before_pct = usage_pct;
+        // E2 (#29): the ETA hint rides the event — the duration this
+        // session's LAST successful compaction actually took. `None` on the
+        // first compaction: no history, no prediction (a static guess is
+        // never right — owner 2026-08-29).
+        let predicted = self
+            .last_compaction_elapsed
+            .read()
+            .ok()
+            .and_then(|map| map.get(&session_id).copied());
         if let Some(cb) = progress_callback {
-            cb(session_id, ProgressEvent::Compacting { usage_pct });
+            cb(
+                session_id,
+                ProgressEvent::Compacting {
+                    usage_pct,
+                    predicted,
+                },
+            );
         }
 
         // Up to 3 attempts — transient summarizer errors (network blip,
@@ -223,6 +238,12 @@ impl AgentService {
             if let Ok(mut map) = self.session_pressure_warned.write() {
                 map.insert(session_id, false);
             }
+            // E2 (#29): this run's observed duration becomes the ETA hint
+            // for the session's NEXT compaction — grounded, never a guess.
+            let elapsed = compact_started.elapsed();
+            if let Ok(mut map) = self.last_compaction_elapsed.write() {
+                map.insert(session_id, elapsed);
+            }
             if let Some(cb) = progress_callback {
                 let after_pct = if effective_max > 0 {
                     (context.effective_token_count() as f64 / effective_max as f64) * 100.0
@@ -235,7 +256,7 @@ impl AgentService {
                         summary: summary.clone(),
                         before_pct,
                         after_pct,
-                        elapsed: compact_started.elapsed(),
+                        elapsed,
                     },
                 );
             }

--- a/src/brain/agent/service/compaction.rs
+++ b/src/brain/agent/service/compaction.rs
@@ -148,10 +148,14 @@ impl AgentService {
 
         // Signal channels that the next 10-60s will produce zero
         // streaming chunks so their typing-indicator pingers can keep
-        // firing. Carries no user-visible text — the event is consumed
-        // for typing/spinner refresh only.
+        // firing. Carries the fill level so channels can render a visible
+        // "compacting" line (#29); the percentage is a LEVEL, not progress.
+        // The Instant anchors the elapsed duration reported on the
+        // CompactionSummary emit below.
+        let compact_started = std::time::Instant::now();
+        let before_pct = usage_pct;
         if let Some(cb) = progress_callback {
-            cb(session_id, ProgressEvent::Compacting);
+            cb(session_id, ProgressEvent::Compacting { usage_pct });
         }
 
         // Up to 3 attempts — transient summarizer errors (network blip,
@@ -208,6 +212,32 @@ impl AgentService {
                 );
                 context.hard_truncate_to(safety_target);
                 context.trim_to_fit(0);
+            }
+        }
+
+        // Success: surface the outcome to channels (first-ever user-visible
+        // compaction receipt, #29) and clear the #909 pressure throttle so
+        // the settled ctx footer never wears the ❕ until usage climbs the
+        // 55% floor again.
+        if let Some(ref summary) = summary_result {
+            if let Ok(mut map) = self.session_pressure_warned.write() {
+                map.insert(session_id, false);
+            }
+            if let Some(cb) = progress_callback {
+                let after_pct = if effective_max > 0 {
+                    (context.effective_token_count() as f64 / effective_max as f64) * 100.0
+                } else {
+                    100.0
+                };
+                cb(
+                    session_id,
+                    ProgressEvent::CompactionSummary {
+                        summary: summary.clone(),
+                        before_pct,
+                        after_pct,
+                        elapsed: compact_started.elapsed(),
+                    },
+                );
             }
         }
 
@@ -287,5 +317,17 @@ impl AgentService {
             }
         }
         // else: in-band but already emitted -> no-op (once-per-entry).
+    }
+
+    /// True while the pre-compaction pressure nudge (#909, 55–64% band) is
+    /// active for this session. The settled-flow ctx segment wears the quiet
+    /// ❕ marker exactly when the hint is in the prompt (#29); the flag is
+    /// cleared on compaction success and re-arms below the 55% floor.
+    pub fn pressure_warning_active(&self, session_id: Uuid) -> bool {
+        self.session_pressure_warned
+            .read()
+            .ok()
+            .and_then(|map| map.get(&session_id).copied())
+            .unwrap_or(false)
     }
 }

--- a/src/brain/agent/service/types.rs
+++ b/src/brain/agent/service/types.rs
@@ -62,10 +62,21 @@ pub enum ProgressEvent {
     StreamingChunk {
         text: String,
     },
-    Compacting,
-    /// Compaction finished — carry the summary so the TUI can display it
+    /// Auto-compaction is about to run — the next 10–60s produce zero
+    /// streaming chunks. Carries the context FILL LEVEL at trigger time so
+    /// channels can surface it (a level, not compaction progress — the
+    /// summarizer call has no intermediate state, #29).
+    Compacting {
+        usage_pct: f64,
+    },
+    /// Compaction finished — carry the summary so the TUI can display it,
+    /// plus before/after fill levels and the wall-clock duration of the
+    /// silent window so channels can render a completion line (#29).
     CompactionSummary {
         summary: String,
+        before_pct: f64,
+        after_pct: f64,
+        elapsed: std::time::Duration,
     },
     /// A single build-output line (e.g. "Compiling foo v1.0"). The TUI keeps a
     /// rolling window of the last few lines and clears them on RestartReady.

--- a/src/brain/agent/service/types.rs
+++ b/src/brain/agent/service/types.rs
@@ -62,12 +62,17 @@ pub enum ProgressEvent {
     StreamingChunk {
         text: String,
     },
-    /// Auto-compaction is about to run — the next 10–60s produce zero
+    /// Auto-compaction is about to run — the silent window produces zero
     /// streaming chunks. Carries the context FILL LEVEL at trigger time so
     /// channels can surface it (a level, not compaction progress — the
-    /// summarizer call has no intermediate state, #29).
+    /// summarizer call has no intermediate state, #29), plus the wall-clock
+    /// duration the session's PREVIOUS successful compaction actually took,
+    /// so channels can show a grounded ETA hint. `None` on a session's first
+    /// compaction — a static guess is never right (observed live range:
+    /// 10s → 29 min), so no history means no prediction (#29 E2).
     Compacting {
         usage_pct: f64,
+        predicted: Option<std::time::Duration>,
     },
     /// Compaction finished — carry the summary so the TUI can display it,
     /// plus before/after fill levels and the wall-clock duration of the

--- a/src/channels/discord/handler.rs
+++ b/src/channels/discord/handler.rs
@@ -811,7 +811,7 @@ pub(crate) async fn handle_message(
                 // indicator. The loop self-terminates after 90s; if
                 // compaction finishes earlier, real streaming chunks
                 // resume the indicator naturally.
-                ProgressEvent::Compacting => {
+                ProgressEvent::Compacting { .. } => {
                     let http = http.clone();
                     tokio::spawn(async move {
                         for _ in 0..12 {

--- a/src/channels/telegram/delivery.rs
+++ b/src/channels/telegram/delivery.rs
@@ -418,6 +418,14 @@ pub(crate) async fn deliver_final_response(
                 ctx_max,
                 response.tokens_per_second,
             );
+            // Quiet ❕ while the #909 pressure hint is active (#29): the
+            // settled footer mirrors the nudge that's in the prompt. Cleared
+            // on compaction success; re-arms below the 55% floor.
+            let footer = if !footer.is_empty() && agent.pressure_warning_active(session_id) {
+                format!("{footer} ❕")
+            } else {
+                footer
+            };
             {
                 let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
                 s.sections.ctx = (!footer.is_empty()).then(|| footer.clone());

--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -933,6 +933,19 @@ fn strip_leading_gear(s: &str) -> &str {
     s.trim_start_matches(['⚙', '\u{fe0f}']).trim_start()
 }
 
+/// True when `s` starts with an icon glyph (emoji / symbol / dingbat) rather
+/// than a word character. The standing `⚙️` chrome prefix is dropped before
+/// such text — the gear never fronts another icon (#29 fix round, owner
+/// directive). Detection is deliberately simple: a non-ASCII first char that
+/// is not alphanumeric reads as an icon — covers ⏳ ✅ ❌ ⚙ ⏱ ❕ and friends
+/// while Latin, Cyrillic, and CJK text keeps the gear.
+pub(crate) fn starts_with_icon(s: &str) -> bool {
+    match s.chars().next() {
+        Some(c) => !c.is_ascii() && !c.is_alphanumeric(),
+        None => false,
+    }
+}
+
 /// Build the fully-styled header shared by all three renderers so the classic
 /// HTML, rich-details, and rich-markdown headers can never drift (#480, #509).
 /// The live header leads with the status message (bold), then the tool-call
@@ -961,19 +974,30 @@ pub(crate) fn flow_header_text(
             // Ordered live header: status message FIRST (bold), then the count,
             // then the duration (both italic), all `•`-separated (#509).
             let mut segs: Vec<String> = Vec::new();
+            let mut icon_led = false;
             if let Some(status) = status_msg {
                 // The header already prints one live gear; strip a leading
                 // running-gear from the status message so the bare-tool fallback
                 // ("⚙️ bash …") does not render a double gear (#509 follow-up).
                 // Settled ✅/❌ tool icons are left alone: they read as the tool's
                 // own outcome, not a duplicate of the header gear.
-                segs.push(markup.bold(strip_leading_gear(status)));
+                let status = strip_leading_gear(status);
+                icon_led = starts_with_icon(status);
+                segs.push(markup.bold(status));
             }
             segs.push(markup.italic(&base));
             if let Some(dur) = duration {
                 segs.push(markup.italic(dur));
             }
-            format!("⚙️ {}", segs.join(" • "))
+            // The standing gear is dropped when the status already leads with
+            // an icon (#29 fix round, owner directive) — the pinned
+            // `⏳ Compacting context…` header and icon-led tool activity render
+            // bare, never `⚙️ ⏳ …`.
+            if icon_led {
+                segs.join(" • ")
+            } else {
+                format!("⚙️ {}", segs.join(" • "))
+            }
         }
         FlowHeader::Settled {
             icon,

--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -482,6 +482,7 @@ fn flow_body_entries(lines: &[FlowLine], narration_cap: usize) -> (Vec<String>, 
 /// `<blockquote expandable>` (full body, no summary line above it — Decision
 /// 11/12); the merged footer is the plain final line (Decision 3).
 /// `elapsed_secs` drives the footer clock (Decision 13).
+#[allow(clippy::too_many_arguments)] // chrome-pref signature keeps render knobs explicit (#29 adds compacting)
 pub(crate) fn render_flow_html_chrome_pref(
     lines: &[FlowLine],
     header: &FlowHeader,
@@ -600,6 +601,7 @@ pub(crate) fn render_flow_details_chrome(
 /// when the log has entries that `<sub>` becomes the processing-log `<summary>`
 /// with the full entry list as the collapsed body (Decision 12). `elapsed_secs`
 /// drives the footer clock.
+#[allow(clippy::too_many_arguments)] // same as html chrome-pref (#29 adds compacting)
 pub(crate) fn render_flow_details_chrome_pref(
     lines: &[FlowLine],
     header: &FlowHeader,

--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -400,6 +400,7 @@ pub(crate) fn render_flow_html_chrome(
         FOLDED_NARRATION_CAP,
         elapsed_secs,
         None,
+        false,
     )
 }
 
@@ -489,10 +490,21 @@ pub(crate) fn render_flow_html_chrome_pref(
     narration_cap: usize,
     elapsed_secs: u64,
     bg: Option<&str>,
+    compacting: bool,
 ) -> String {
     let (out, tool_count) = flow_body_entries(lines, narration_cap);
     let has_log = !out.is_empty();
-    let activity = latest_activity_preview(lines);
+    // Dedupe (#29): during the silent window the newest log line IS the ⏳
+    // body entry while the pinned header_preview carries the dedicated
+    // compacting state — rendering both doubles the compaction text in the
+    // footer (the owner-sighted live-fire bug). Suppress the activity-derived
+    // segment while the flag is set; the pinned constant stays the sole
+    // compaction string, and the #1052 split moves the gear onto the count.
+    let activity = if compacting {
+        None
+    } else {
+        latest_activity_preview(lines)
+    };
     let footer = super::flow_chrome::merged_footer(
         &footer_parts(
             header,
@@ -577,6 +589,7 @@ pub(crate) fn render_flow_details_chrome(
         FOLDED_NARRATION_CAP,
         elapsed_secs,
         None,
+        false,
     )
 }
 
@@ -595,10 +608,18 @@ pub(crate) fn render_flow_details_chrome_pref(
     narration_cap: usize,
     elapsed_secs: u64,
     bg: Option<&str>,
+    compacting: bool,
 ) -> String {
     let (out, tool_count) = flow_body_entries(lines, narration_cap);
     let has_log = !out.is_empty();
-    let activity = latest_activity_preview(lines);
+    // Dedupe (#29): same suppression as the classic renderer — the footer
+    // join must never drift between surfaces (ADR 0005 Decision 12), so the
+    // compacting flag kills the activity segment here too.
+    let activity = if compacting {
+        None
+    } else {
+        latest_activity_preview(lines)
+    };
     let footer = super::flow_chrome::merged_footer(
         &footer_parts(
             header,
@@ -647,7 +668,11 @@ pub(crate) fn render_flow_details_chrome_pref(
 // collapse); kept because #420 reuses this renderer once RichBlockDetails
 // serialization lands, and its tests pin the markdown contract meanwhile.
 #[cfg_attr(not(test), allow(dead_code))]
-pub(crate) fn render_flow_rich(lines: &[FlowLine], live_status: Option<&str>) -> String {
+pub(crate) fn render_flow_rich(
+    lines: &[FlowLine],
+    live_status: Option<&str>,
+    compacting: bool,
+) -> String {
     let mut out: Vec<String> = Vec::new();
     let mut tool_count = 0usize;
     for line in lines {
@@ -688,8 +713,14 @@ pub(crate) fn render_flow_rich(lines: &[FlowLine], live_status: Option<&str>) ->
     }
     // Same latest-activity preview as the HTML renderer (#405), leading the
     // header status-first (#509); this markdown path is always live. Raw text,
-    // no escaping — the markdown dialect keeps narration verbatim.
-    let status_msg = latest_activity_preview(lines);
+    // no escaping — the markdown dialect keeps narration verbatim. Dedupe
+    // (#29): while the compacting flag is set the newest line is the ⏳ body
+    // entry — suppress it here too so the three renderers never drift.
+    let status_msg = if compacting {
+        None
+    } else {
+        latest_activity_preview(lines)
+    };
     let header = flow_header_text(
         tool_count,
         &FlowHeader::Live(live_status),
@@ -721,9 +752,23 @@ pub(crate) const COMPACTING_HEADER_TEXT: &str = "⏳ Compacting context…";
 
 /// Flow-block body line posted when auto-compaction starts (#29). The
 /// percentage is the context FILL LEVEL at trigger time — a "how full was
-/// it" fact, never a progress indicator.
-pub(crate) fn compacting_flow_line(usage_pct: f64) -> String {
-    format!("⏳ Compacting context — {:.0}% full (≈10–60s)…", usage_pct)
+/// it" fact, never a progress indicator. The ETA hint, when present, is the
+/// duration the session's PREVIOUS compaction actually took (E2) — grounded
+/// in observation, never a static guess: the old `≈10–60s` constant was
+/// retired because it was never right (observed live range 10s → 29 min),
+/// so a session with no compaction history renders no parenthetical at all.
+pub(crate) fn compacting_flow_line(
+    usage_pct: f64,
+    predicted: Option<std::time::Duration>,
+) -> String {
+    match predicted {
+        Some(d) => format!(
+            "⏳ Compacting context — {:.0}% full (≈{})…",
+            usage_pct,
+            humanize_duration(d.as_secs().max(1))
+        ),
+        None => format!("⏳ Compacting context — {:.0}% full…", usage_pct),
+    }
 }
 
 /// Flow-block body line posted when compaction finishes (#29). Doubles as
@@ -992,6 +1037,7 @@ pub(crate) fn render_flow(s: &StreamingState) -> String {
                 narration_cap,
                 elapsed,
                 s.bg_indicator.as_deref(),
+                false, // settled renders drop the activity segment regardless
             )
         }
         None => render_flow_html_chrome_pref(
@@ -1002,6 +1048,7 @@ pub(crate) fn render_flow(s: &StreamingState) -> String {
             narration_cap,
             elapsed,
             s.bg_indicator.as_deref(),
+            s.compacting,
         ),
     }
 }
@@ -1027,6 +1074,7 @@ pub(crate) fn render_flow_details_state(s: &StreamingState) -> String {
                 narration_cap,
                 elapsed,
                 s.bg_indicator.as_deref(),
+                false, // settled renders drop the activity segment regardless
             )
         }
         None => render_flow_details_chrome_pref(
@@ -1037,6 +1085,7 @@ pub(crate) fn render_flow_details_state(s: &StreamingState) -> String {
             narration_cap,
             elapsed,
             s.bg_indicator.as_deref(),
+            s.compacting,
         ),
     }
 }

--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -122,6 +122,12 @@ pub(crate) struct StreamingState {
     /// legacy pre-block status bubble is gone, so early-turn status rides
     /// here from the first activity tick.
     pub(crate) header_preview: Option<String>,
+    /// Auto-compaction in flight (#29): while set, `tick_flow_header` pins
+    /// the header to `COMPACTING_HEADER_TEXT` regardless of the computed
+    /// preview — no streaming chunks arrive during the silent window, so
+    /// the ordinary preview would go stale. Cleared by the CompactionSummary
+    /// arm; the next tick recomputes from live data.
+    pub(crate) compacting: bool,
     /// Always-visible flow sections (plan title, checklist progress, active
     /// goal, ctx footer). Rolled by the edit loop from live data; ctx is set
     /// once at final delivery.

--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -707,6 +707,35 @@ pub(crate) fn humanize_duration(secs: u64) -> String {
     }
 }
 
+/// Header text pinned for the whole silent window (#29). No percentage on
+/// purpose: compaction progress is unknowable (one summarizer call), so a
+/// number here would read as a fake progress bar. The START line carries the
+/// fill level instead — that IS knowable.
+pub(crate) const COMPACTING_HEADER_TEXT: &str = "⏳ Compacting context…";
+
+/// Flow-block body line posted when auto-compaction starts (#29). The
+/// percentage is the context FILL LEVEL at trigger time — a "how full was
+/// it" fact, never a progress indicator.
+pub(crate) fn compacting_flow_line(usage_pct: f64) -> String {
+    format!("⏳ Compacting context — {:.0}% full (≈10–60s)…", usage_pct)
+}
+
+/// Flow-block body line posted when compaction finishes (#29). Doubles as
+/// the definitive completion signal: arrival means the silent window is
+/// over, so a FAILED compaction never emits one (no false ✅).
+pub(crate) fn compacted_flow_line(
+    before_pct: f64,
+    after_pct: f64,
+    elapsed: std::time::Duration,
+) -> String {
+    format!(
+        "✅ Compacted: {:.0}% → {:.0}% in {}",
+        before_pct,
+        after_pct,
+        humanize_duration(elapsed.as_secs().max(1))
+    )
+}
+
 /// Terminal state of a turn, shown in the settled flow-block header (#480).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum FlowOutcome {

--- a/src/channels/telegram/flow_chrome.rs
+++ b/src/channels/telegram/flow_chrome.rs
@@ -8,7 +8,10 @@
 //! read live data as-is: the session plan JSON for title and checklist, and
 //! `GoalManager` for the active goal one-liner. Empty sections are omitted.
 
-use super::flow::{HeaderMarkup, StreamingState, humanize_duration, open_flow, refresh_flow};
+use super::flow::{
+    COMPACTING_HEADER_TEXT, HeaderMarkup, StreamingState, humanize_duration, open_flow,
+    refresh_flow,
+};
 use super::handler::escape_html;
 use crate::brain::agent::AgentService;
 use crate::brain::goal::GoalManager;
@@ -755,6 +758,21 @@ pub(crate) async fn tick_flow_header(
     let open_block = {
         let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
         s.open_group_msg_id
+    };
+    // Compaction pin (#29): while the summarizer runs, nothing streams, so
+    // pin the header to the dedicated compacting state instead of whatever
+    // stale preview the caller computed. The CompactionSummary arm clears
+    // the flag; the next tick recomputes normally.
+    let preview = {
+        let compacting = {
+            let s = streaming.lock().unwrap_or_else(|e| e.into_inner());
+            s.compacting
+        };
+        if compacting {
+            Some(COMPACTING_HEADER_TEXT.to_string())
+        } else {
+            preview
+        }
     };
     if open_block.is_some() {
         if show_status {

--- a/src/channels/telegram/flow_chrome.rs
+++ b/src/channels/telegram/flow_chrome.rs
@@ -10,7 +10,7 @@
 
 use super::flow::{
     COMPACTING_HEADER_TEXT, HeaderMarkup, StreamingState, humanize_duration, open_flow,
-    refresh_flow,
+    refresh_flow, starts_with_icon,
 };
 use super::handler::escape_html;
 use crate::brain::agent::AgentService;
@@ -366,7 +366,15 @@ pub(crate) fn merged_footer(parts: &FooterParts, markup: HeaderMarkup) -> String
         {
             let act = act.trim_start_matches(['⚙', '\u{fe0f}']).trim_start();
             if !act.is_empty() {
-                live_activity = format!("⚙️ {}", esc(act));
+                // Gear is dropped when the activity already leads with its own
+                // icon (#29 fix round, owner directive): `✅ bash git status`
+                // and the `⏳ Compacting context — 66% full…` body entry render
+                // bare. Plain-text activity keeps the running cog.
+                live_activity = if starts_with_icon(act) {
+                    esc(act)
+                } else {
+                    format!("⚙️ {}", esc(act))
+                };
                 segs.push(live_activity.clone());
             }
         }
@@ -382,15 +390,19 @@ pub(crate) fn merged_footer(parts: &FooterParts, markup: HeaderMarkup) -> String
     // #498). Live turns show the count alone when the activity segment already
     // carries the cog, else the cog rides the count (#1052 split).
     if parts.has_log {
+        // Once another segment already leads with an icon, the standing gear
+        // has nothing left to signal (#29 fix round, owner directive): the
+        // count renders bare and the bare-cog fallback is dropped.
+        let gear_taken = segs.iter().any(|s| starts_with_icon(s));
         let mut seg2 = String::new();
         if parts.tool_count >= 1 {
             let count = format!("{} tool calls", parts.tool_count);
-            seg2 = if settled || !live_activity.is_empty() {
+            seg2 = if settled || !live_activity.is_empty() || gear_taken {
                 count
             } else {
                 format!("⚙️ {count}")
             };
-        } else if !settled && live_activity.is_empty() {
+        } else if !settled && live_activity.is_empty() && !gear_taken {
             // In-flight log with no tools and no activity preview yet: a bare
             // cog beats an empty segment so the footer still reads as active.
             seg2 = "⚙️".to_string();

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2393,6 +2393,7 @@ pub(crate) async fn handle_message(
     // ── Streaming setup ───────────────────────────────────────────────────────
     let streaming = Arc::new(std::sync::Mutex::new(StreamingState {
         is_dm,
+        compacting: false,
         pending_suggestions: None,
         msg_id: None,
         thinking: String::new(),

--- a/src/channels/telegram/progress.rs
+++ b/src/channels/telegram/progress.rs
@@ -8,8 +8,8 @@ use teloxide::Bot;
 use teloxide::types::{ChatAction, ChatId, ThreadId};
 
 use super::flow::{
-    DisplayItem, StreamingState, ToolMsg, compacted_flow_line, compacting_flow_line,
-    detach_flow_for_followup,
+    COMPACTING_HEADER_TEXT, DisplayItem, StreamingState, ToolMsg, compacted_flow_line,
+    compacting_flow_line, detach_flow_for_followup,
 };
 use super::handler::tool_context;
 use super::send::fire_chat_action;
@@ -47,6 +47,8 @@ pub(crate) fn build_progress_cb(
                     .await;
                 });
                 if let Ok(mut s) = st.lock() {
+                    s.compacting = true;
+                    s.header_preview = Some(COMPACTING_HEADER_TEXT.to_string());
                     s.display_queue
                         .push(DisplayItem::Intermediate(compacting_flow_line(usage_pct)));
                 }
@@ -188,6 +190,11 @@ pub(crate) fn build_progress_cb(
                 ..
             } => {
                 if let Ok(mut s) = st.lock() {
+                    // Lift the header pin FIRST so the next tick recomputes
+                    // from live data; the ✅ line leads the body until newer
+                    // activity arrives (#29).
+                    s.compacting = false;
+                    s.header_preview = None;
                     s.display_queue.push(DisplayItem::Intermediate(compacted_flow_line(
                         before_pct, after_pct, elapsed,
                     )));

--- a/src/channels/telegram/progress.rs
+++ b/src/channels/telegram/progress.rs
@@ -7,7 +7,10 @@ use std::sync::Arc;
 use teloxide::Bot;
 use teloxide::types::{ChatAction, ChatId, ThreadId};
 
-use super::flow::{DisplayItem, StreamingState, ToolMsg, detach_flow_for_followup};
+use super::flow::{
+    DisplayItem, StreamingState, ToolMsg, compacted_flow_line, compacting_flow_line,
+    detach_flow_for_followup,
+};
 use super::handler::tool_context;
 use super::send::fire_chat_action;
 use crate::brain::agent::{ProgressCallback, ProgressEvent};
@@ -27,9 +30,10 @@ pub(crate) fn build_progress_cb(
             // Auto-compaction produces zero streaming chunks for 10-60s.
             // The 4s typing pinger upstream stays alive, but fire an
             // immediate refresh on entry so the indicator visibly resets
-            // the moment compaction starts. No text — just the native
-            // "is typing" dots stay continuous through the silent window.
-            ProgressEvent::Compacting => {
+            // the moment compaction starts (#29). The start line also lands
+            // in the flow body so the silent window has a visible
+            // explanation — a fill level, not a progress bar.
+            ProgressEvent::Compacting { usage_pct } => {
                 let bot = bot_typing.clone();
                 let chat = chat_typing;
                 tokio::spawn(async move {
@@ -42,6 +46,10 @@ pub(crate) fn build_progress_cb(
                     )
                     .await;
                 });
+                if let Ok(mut s) = st.lock() {
+                    s.display_queue
+                        .push(DisplayItem::Intermediate(compacting_flow_line(usage_pct)));
+                }
             }
             ProgressEvent::ReasoningChunk { text } => {
                 if let Ok(mut s) = st.lock() {
@@ -168,6 +176,21 @@ pub(crate) fn build_progress_cb(
                 // is kept if the tool fires more than once.
                 if let Ok(mut s) = st.lock() {
                     s.pending_suggestions = Some(options);
+                }
+            }
+            // Compaction finished — the ✅ line is the definitive "silent
+            // window over" signal (#29). Arrival means success: a failed
+            // compaction never emits this event, so no false receipts.
+            ProgressEvent::CompactionSummary {
+                before_pct,
+                after_pct,
+                elapsed,
+                ..
+            } => {
+                if let Ok(mut s) = st.lock() {
+                    s.display_queue.push(DisplayItem::Intermediate(compacted_flow_line(
+                        before_pct, after_pct, elapsed,
+                    )));
                 }
             }
             _ => {}

--- a/src/channels/telegram/progress.rs
+++ b/src/channels/telegram/progress.rs
@@ -195,9 +195,10 @@ pub(crate) fn build_progress_cb(
                     // activity arrives (#29).
                     s.compacting = false;
                     s.header_preview = None;
-                    s.display_queue.push(DisplayItem::Intermediate(compacted_flow_line(
-                        before_pct, after_pct, elapsed,
-                    )));
+                    s.display_queue
+                        .push(DisplayItem::Intermediate(compacted_flow_line(
+                            before_pct, after_pct, elapsed,
+                        )));
                 }
             }
             _ => {}

--- a/src/channels/telegram/progress.rs
+++ b/src/channels/telegram/progress.rs
@@ -33,7 +33,10 @@ pub(crate) fn build_progress_cb(
             // the moment compaction starts (#29). The start line also lands
             // in the flow body so the silent window has a visible
             // explanation — a fill level, not a progress bar.
-            ProgressEvent::Compacting { usage_pct } => {
+            ProgressEvent::Compacting {
+                usage_pct,
+                predicted,
+            } => {
                 let bot = bot_typing.clone();
                 let chat = chat_typing;
                 tokio::spawn(async move {
@@ -50,7 +53,9 @@ pub(crate) fn build_progress_cb(
                     s.compacting = true;
                     s.header_preview = Some(COMPACTING_HEADER_TEXT.to_string());
                     s.display_queue
-                        .push(DisplayItem::Intermediate(compacting_flow_line(usage_pct)));
+                        .push(DisplayItem::Intermediate(compacting_flow_line(
+                            usage_pct, predicted,
+                        )));
                 }
             }
             ProgressEvent::ReasoningChunk { text } => {

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -377,7 +377,10 @@ pub(crate) async fn resume_session_inner(
             // Auto-compaction silent window — immediate typing refresh plus
             // the visible start line in the flow body (#29).
             // See handle_message for the full rationale.
-            ProgressEvent::Compacting { usage_pct } => {
+            ProgressEvent::Compacting {
+                usage_pct,
+                predicted,
+            } => {
                 let bot = bot_typing.clone();
                 let chat = chat_typing;
                 tokio::spawn(async move {
@@ -388,7 +391,9 @@ pub(crate) async fn resume_session_inner(
                     s.compacting = true;
                     s.header_preview = Some(COMPACTING_HEADER_TEXT.to_string());
                     s.display_queue
-                        .push(DisplayItem::Intermediate(compacting_flow_line(usage_pct)));
+                        .push(DisplayItem::Intermediate(compacting_flow_line(
+                            usage_pct, predicted,
+                        )));
                 }
             }
             ProgressEvent::ReasoningChunk { text } => {

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -519,9 +519,10 @@ pub(crate) async fn resume_session_inner(
                 if let Ok(mut s) = st.lock() {
                     s.compacting = false;
                     s.header_preview = None;
-                    s.display_queue.push(DisplayItem::Intermediate(compacted_flow_line(
-                        before_pct, after_pct, elapsed,
-                    )));
+                    s.display_queue
+                        .push(DisplayItem::Intermediate(compacted_flow_line(
+                            before_pct, after_pct, elapsed,
+                        )));
                 }
             }
             _ => {}

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -373,15 +373,20 @@ pub(crate) async fn resume_session_inner(
         let bot_typing = bot.clone();
         let chat_typing = chat_id;
         Arc::new(move |_sid, event| match event {
-            // Auto-compaction silent window — immediate typing refresh.
+            // Auto-compaction silent window — immediate typing refresh plus
+            // the visible start line in the flow body (#29).
             // See handle_message for the full rationale.
-            ProgressEvent::Compacting => {
+            ProgressEvent::Compacting { usage_pct } => {
                 let bot = bot_typing.clone();
                 let chat = chat_typing;
                 tokio::spawn(async move {
                     fire_chat_action(&bot, chat, thread_id, ChatAction::Typing, "resume typing")
                         .await;
                 });
+                if let Ok(mut s) = st.lock() {
+                    s.display_queue
+                        .push(DisplayItem::Intermediate(compacting_flow_line(usage_pct)));
+                }
             }
             ProgressEvent::ReasoningChunk { text } => {
                 if let Ok(mut s) = st.lock() {
@@ -498,6 +503,20 @@ pub(crate) async fn resume_session_inner(
                 // keyboard ABOVE the final answer on resumed turns.
                 if let Ok(mut s) = st.lock() {
                     s.pending_suggestions = Some(options);
+                }
+            }
+            // Compaction finished — definitive completion receipt (#29).
+            // See the handle_message progress callback for the rationale.
+            ProgressEvent::CompactionSummary {
+                before_pct,
+                after_pct,
+                elapsed,
+                ..
+            } => {
+                if let Ok(mut s) = st.lock() {
+                    s.display_queue.push(DisplayItem::Intermediate(compacted_flow_line(
+                        before_pct, after_pct, elapsed,
+                    )));
                 }
             }
             _ => {}

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -311,6 +311,7 @@ pub(crate) async fn resume_session_inner(
     let streaming = Arc::new(std::sync::Mutex::new(StreamingState {
         // Telegram: positive chat id = private/DM, negative = group (#677).
         is_dm: chat_id.0 > 0,
+        compacting: false,
         pending_suggestions: None,
         msg_id: None,
         thinking: String::new(),
@@ -384,6 +385,8 @@ pub(crate) async fn resume_session_inner(
                         .await;
                 });
                 if let Ok(mut s) = st.lock() {
+                    s.compacting = true;
+                    s.header_preview = Some(COMPACTING_HEADER_TEXT.to_string());
                     s.display_queue
                         .push(DisplayItem::Intermediate(compacting_flow_line(usage_pct)));
                 }
@@ -514,6 +517,8 @@ pub(crate) async fn resume_session_inner(
                 ..
             } => {
                 if let Ok(mut s) = st.lock() {
+                    s.compacting = false;
+                    s.header_preview = None;
                     s.display_queue.push(DisplayItem::Intermediate(compacted_flow_line(
                         before_pct, after_pct, elapsed,
                     )));

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -678,7 +678,7 @@ async fn cmd_chat_inner(
                 }
                 ProgressEvent::Thinking => return, // spinner handles this already
                 // Compaction is now fully silent — summary goes to memory log only
-                ProgressEvent::Compacting => return,
+                ProgressEvent::Compacting { .. } => return,
                 ProgressEvent::CompactionSummary { .. } => return,
                 ProgressEvent::BuildLine(line) => progress_sender.send(TuiEvent::BuildLine(line)),
                 ProgressEvent::RestartReady {

--- a/src/tests/compaction_signal_test.rs
+++ b/src/tests/compaction_signal_test.rs
@@ -6,10 +6,11 @@ use std::time::Duration;
 
 use crate::brain::agent::service::nudge::{in_pressure_warning_band, should_emit_pressure_warning};
 use crate::channels::telegram::flow::{
-    COMPACTING_HEADER_TEXT, FlowHeader, FlowLine, compacted_flow_line, compacting_flow_line,
-    render_flow_html_chrome_pref, render_flow_rich,
+    COMPACTING_HEADER_TEXT, FlowHeader, FlowLine, HeaderMarkup, compacted_flow_line,
+    compacting_flow_line, flow_header_text, render_flow_html_chrome_pref, render_flow_rich,
+    starts_with_icon,
 };
-use crate::channels::telegram::flow_chrome::FlowSections;
+use crate::channels::telegram::flow_chrome::{FlowSections, FooterParts, merged_footer};
 
 #[test]
 fn compacting_line_without_prediction() {
@@ -175,4 +176,101 @@ fn pressure_warning_once_per_entry() {
     assert!(should_emit_pressure_warning(60.0, false).is_some());
     assert!(should_emit_pressure_warning(60.0, true).is_none());
     assert!(should_emit_pressure_warning(40.0, false).is_none());
+}
+
+// ── gear-strip (#29 fix round, owner directive): the standing ⚙️ chrome
+// prefix is dropped whenever another icon follows it ──
+
+#[test]
+fn starts_with_icon_classification() {
+    // Icon glyphs drop the standing gear; word text (Latin, Cyrillic) keeps it.
+    assert!(starts_with_icon("⏳ Compacting context…"));
+    assert!(starts_with_icon("✅ bash git status"));
+    assert!(starts_with_icon("❌ grep pattern"));
+    assert!(!starts_with_icon("bash gh pr list"));
+    assert!(!starts_with_icon("Reading the handler."));
+    assert!(!starts_with_icon("Чтение лога"));
+    assert!(!starts_with_icon(""));
+}
+
+#[test]
+fn live_header_drops_gear_before_icon_status() {
+    // The pinned compaction status leads with ⏳ → the header renders bare.
+    assert_eq!(
+        flow_header_text(
+            11,
+            &FlowHeader::Live(Some("1:05")),
+            Some(COMPACTING_HEADER_TEXT),
+            HeaderMarkup::Html
+        ),
+        "<b>⏳ Compacting context…</b> • <i>11 tool calls</i> • <i>1:05</i>"
+    );
+    // Plain status keeps the gear (#509 shape unchanged).
+    assert_eq!(
+        flow_header_text(
+            3,
+            &FlowHeader::Live(Some("0:12")),
+            Some("Reading logs"),
+            HeaderMarkup::Html
+        ),
+        "⚙️ <b>Reading logs</b> • <i>3 tool calls</i> • <i>0:12</i>"
+    );
+}
+
+#[test]
+fn live_footer_drops_gear_before_icon_activity() {
+    // Same rule on the footer's activity segment: icon-led activity renders
+    // bare, plain-text activity keeps the running cog (#1052).
+    let icon = merged_footer(
+        &FooterParts {
+            outcome: None,
+            plan_state: None,
+            working_on: None,
+            activity: Some("✅ bash git status"),
+            tool_count: 1,
+            has_log: true,
+            ctx: None,
+            elapsed_secs: 0,
+            bg: None,
+        },
+        HeaderMarkup::Markdown,
+    );
+    assert_eq!(icon, "✅ bash git status • 1 tool calls • ⏱ 0:00");
+    let plain = merged_footer(
+        &FooterParts {
+            outcome: None,
+            plan_state: None,
+            working_on: None,
+            activity: Some("Reading the handler."),
+            tool_count: 2,
+            has_log: true,
+            ctx: None,
+            elapsed_secs: 0,
+            bg: None,
+        },
+        HeaderMarkup::Markdown,
+    );
+    assert_eq!(plain, "⚙️ Reading the handler. • 2 tool calls • ⏱ 0:00");
+}
+
+#[test]
+fn icon_led_segment_retires_the_bare_cog_fallback() {
+    // With an icon-led pin as the only narration (activity suppressed by the
+    // compaction dedupe, zero tool calls), the bare-⚙️ fallback segment is
+    // redundant — the icon already signals activity.
+    let out = merged_footer(
+        &FooterParts {
+            outcome: None,
+            plan_state: None,
+            working_on: Some(COMPACTING_HEADER_TEXT),
+            activity: None,
+            tool_count: 0,
+            has_log: true,
+            ctx: None,
+            elapsed_secs: 65,
+            bg: None,
+        },
+        HeaderMarkup::Markdown,
+    );
+    assert_eq!(out, "⏳ Compacting context… • ⏱ 1:05");
 }

--- a/src/tests/compaction_signal_test.rs
+++ b/src/tests/compaction_signal_test.rs
@@ -93,16 +93,32 @@ fn compacting_footer_suppresses_duplicate_activity_segment() {
 
 #[test]
 fn compacting_rich_footer_suppresses_duplicate_status() {
-    // Same dedupe contract on the rich-markdown path: status_msg suppressed
-    // while the flag is set.
     let lines = [FlowLine::Text(
         "⏳ Compacting context — 66% full…".to_string(),
     )];
+    // Flag on: the HEADER (first line) carries the pinned compaction string
+    // exactly once — the activity preview is suppressed. The body keeps the
+    // ⏳ START line (a real log entry, the fill-level carrier), so the count
+    // is asserted on the header line, never the whole message.
     let rich = render_flow_rich(&lines, Some(COMPACTING_HEADER_TEXT), true);
+    let header = rich.lines().next().unwrap_or_default();
     assert_eq!(
-        rich.matches("Compacting context").count(),
+        header.matches("Compacting context").count(),
         1,
-        "rich footer dedupes too: {rich:?}"
+        "rich header dedupes too: {rich:?}"
+    );
+    assert!(
+        rich.contains("⏳ Compacting context — 66% full…"),
+        "body keeps the START line: {rich:?}"
+    );
+    // Flag off: the header duplicates the body entry (documents the
+    // suppression contract).
+    let idle = render_flow_rich(&lines, Some(COMPACTING_HEADER_TEXT), false);
+    let idle_header = idle.lines().next().unwrap_or_default();
+    assert_eq!(
+        idle_header.matches("Compacting context").count(),
+        2,
+        "without the flag the activity preview duplicates the pin: {idle:?}"
     );
 }
 

--- a/src/tests/compaction_signal_test.rs
+++ b/src/tests/compaction_signal_test.rs
@@ -1,0 +1,81 @@
+//! Compaction signal (#29): unit tests for the flow-line builders, the
+//! pinned-header const, and the #909 pressure band that drives the ❕.
+//! All pure — no agent, no mocks, no locks.
+
+use std::time::Duration;
+
+use crate::brain::agent::service::nudge::{in_pressure_warning_band, should_emit_pressure_warning};
+use crate::channels::telegram::flow::{
+    COMPACTING_HEADER_TEXT, compacted_flow_line, compacting_flow_line,
+};
+
+#[test]
+fn compacting_line_shows_fill_level_and_window() {
+    assert_eq!(
+        compacting_flow_line(68.0),
+        "⏳ Compacting context — 68% full (≈10–60s)…"
+    );
+}
+
+#[test]
+fn compacting_line_rounds_fill_level() {
+    // {:.0} rounding — the line carries a whole-number level, never a
+    // fractional one.
+    assert!(compacting_flow_line(67.7).contains("68% full"));
+    assert!(compacting_flow_line(99.4).contains("99% full"));
+}
+
+#[test]
+fn compacted_line_under_a_minute() {
+    assert_eq!(
+        compacted_flow_line(68.0, 26.0, Duration::from_secs(42)),
+        "✅ Compacted: 68% → 26% in 42s"
+    );
+}
+
+#[test]
+fn compacted_line_multi_minute() {
+    assert_eq!(
+        compacted_flow_line(71.0, 24.0, Duration::from_secs(132)),
+        "✅ Compacted: 71% → 24% in 2 min 12s"
+    );
+}
+
+#[test]
+fn compacted_line_floors_subsecond_elapsed_to_1s() {
+    // A sub-second summarizer call still reads as a real duration — "0s"
+    // would look like the line was printed before the work happened.
+    assert_eq!(
+        compacted_flow_line(66.0, 30.0, Duration::from_millis(300)),
+        "✅ Compacted: 66% → 30% in 1s"
+    );
+}
+
+#[test]
+fn header_const_is_number_free() {
+    // Design invariant (#29): the pinned header NEVER carries a number —
+    // compaction progress is unknowable, so any digit reads as a fake
+    // progress bar. The fill level lives on the START body line instead.
+    assert_eq!(COMPACTING_HEADER_TEXT, "⏳ Compacting context…");
+    assert!(!COMPACTING_HEADER_TEXT.contains('%'));
+    assert!(!COMPACTING_HEADER_TEXT.chars().any(|c| c.is_ascii_digit()));
+}
+
+#[test]
+fn pressure_band_boundaries() {
+    // [55, 65) — the ceiling is exclusive: AT 65% compaction itself fires,
+    // the nudge is for the approach.
+    assert!(!in_pressure_warning_band(54.9));
+    assert!(in_pressure_warning_band(55.0));
+    assert!(in_pressure_warning_band(64.9));
+    assert!(!in_pressure_warning_band(65.0));
+}
+
+#[test]
+fn pressure_warning_once_per_entry() {
+    // In-band, not yet emitted → warn; already emitted → silence until the
+    // flag re-arms below the floor; below the floor → never warn.
+    assert!(should_emit_pressure_warning(60.0, false).is_some());
+    assert!(should_emit_pressure_warning(60.0, true).is_none());
+    assert!(should_emit_pressure_warning(40.0, false).is_none());
+}

--- a/src/tests/compaction_signal_test.rs
+++ b/src/tests/compaction_signal_test.rs
@@ -1,19 +1,42 @@
 //! Compaction signal (#29): unit tests for the flow-line builders, the
-//! pinned-header const, and the #909 pressure band that drives the ❕.
+//! pinned-header const, the ETA predictor, and the footer-dedupe contract.
 //! All pure — no agent, no mocks, no locks.
 
 use std::time::Duration;
 
 use crate::brain::agent::service::nudge::{in_pressure_warning_band, should_emit_pressure_warning};
 use crate::channels::telegram::flow::{
-    COMPACTING_HEADER_TEXT, compacted_flow_line, compacting_flow_line,
+    COMPACTING_HEADER_TEXT, FlowHeader, FlowLine, compacted_flow_line, compacting_flow_line,
+    render_flow_html_chrome_pref, render_flow_rich,
 };
+use crate::channels::telegram::flow_chrome::FlowSections;
 
 #[test]
-fn compacting_line_shows_fill_level_and_window() {
+fn compacting_line_without_prediction() {
+    // First compaction of a session: no observed history, no parenthetical.
+    // The retired hardcoded `≈10–60s` window is gone — it never was right
+    // (live range observed 10s → 29 min).
     assert_eq!(
-        compacting_flow_line(68.0),
-        "⏳ Compacting context — 68% full (≈10–60s)…"
+        compacting_flow_line(68.0, None),
+        "⏳ Compacting context — 68% full…"
+    );
+}
+
+#[test]
+fn compacting_line_shows_observed_eta() {
+    assert_eq!(
+        compacting_flow_line(68.0, Some(Duration::from_secs(42))),
+        "⏳ Compacting context — 68% full (≈42s)…"
+    );
+}
+
+#[test]
+fn compacting_line_humanizes_minute_eta() {
+    // ≥60s rides the shared humanize_duration formatting ("2 min 12s"),
+    // same as the settled ✅ line.
+    assert_eq!(
+        compacting_flow_line(71.0, Some(Duration::from_secs(132))),
+        "⏳ Compacting context — 71% full (≈2 min 12s)…"
     );
 }
 
@@ -21,8 +44,66 @@ fn compacting_line_shows_fill_level_and_window() {
 fn compacting_line_rounds_fill_level() {
     // {:.0} rounding — the line carries a whole-number level, never a
     // fractional one.
-    assert!(compacting_flow_line(67.7).contains("68% full"));
-    assert!(compacting_flow_line(99.4).contains("99% full"));
+    assert!(compacting_flow_line(67.7, None).contains("68% full"));
+    assert!(compacting_flow_line(99.4, None).contains("99% full"));
+}
+
+#[test]
+fn compacting_footer_suppresses_duplicate_activity_segment() {
+    // Dedupe (#29): during the silent window the newest log line IS the ⏳
+    // body entry, so the activity preview renders the compaction string a
+    // second time next to the pinned header — the owner-sighted duplication.
+    // While compacting the flag suppresses the activity segment: exactly ONE
+    // compaction string. With the flag off the duplicate returns (documents
+    // the suppression contract).
+    let lines = [FlowLine::Text(
+        "⏳ Compacting context — 66% full…".to_string(),
+    )];
+    let compacting = render_flow_html_chrome_pref(
+        &lines,
+        &FlowHeader::Live(Some(COMPACTING_HEADER_TEXT)),
+        None,
+        &FlowSections::default(),
+        usize::MAX,
+        5,
+        None,
+        true,
+    );
+    assert_eq!(
+        compacting.matches("Compacting context").count(),
+        1,
+        "pinned header is the sole compaction string while compacting: {compacting:?}"
+    );
+    let idle = render_flow_html_chrome_pref(
+        &lines,
+        &FlowHeader::Live(Some("⚙️")),
+        None,
+        &FlowSections::default(),
+        usize::MAX,
+        5,
+        None,
+        false,
+    );
+    assert_eq!(
+        idle.matches("Compacting context").count(),
+        2,
+        "without the flag the activity preview duplicates the body entry: {idle:?}"
+    );
+}
+
+#[test]
+fn compacting_rich_footer_suppresses_duplicate_status() {
+    // Same dedupe contract on the rich-markdown path: status_msg suppressed
+    // while the flag is set.
+    let lines = [FlowLine::Text(
+        "⏳ Compacting context — 66% full…".to_string(),
+    )];
+    let rich = render_flow_rich(&lines, Some(COMPACTING_HEADER_TEXT), true);
+    assert_eq!(
+        rich.matches("Compacting context").count(),
+        1,
+        "rich footer dedupes too: {rich:?}"
+    );
 }
 
 #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -167,6 +167,7 @@ pub mod command_label_test;
 pub mod command_rich_table_test;
 pub mod compaction_fallback_chain_test;
 pub mod compaction_prompts_test;
+pub mod compaction_signal_test;
 pub mod compaction_test;
 pub mod config_alias_merge_test;
 pub mod config_dotted_caps_test;

--- a/src/tests/telegram_flow_chrome_test.rs
+++ b/src/tests/telegram_flow_chrome_test.rs
@@ -677,6 +677,7 @@ fn settled_footer_shows_bg_indicator_when_task_running() {
         usize::MAX,
         517,
         Some("cargo test running"),
+        false,
     );
     assert!(
         with_bg.ends_with("⏱ 8:37 • 🔧 cargo test running"),
@@ -690,6 +691,7 @@ fn settled_footer_shows_bg_indicator_when_task_running() {
         usize::MAX,
         517,
         None,
+        false,
     );
     assert!(
         without_bg.ends_with("⏱ 8:37") && !without_bg.contains('🔧'),
@@ -703,6 +705,7 @@ fn settled_footer_shows_bg_indicator_when_task_running() {
         usize::MAX,
         517,
         Some("3 tasks running"),
+        false,
     );
     assert!(
         many.contains("🔧 3 tasks running"),
@@ -904,6 +907,7 @@ fn cli_cap_truncates_body_api_keeps_it_full_html() {
         300,
         2,
         None,
+        false,
     );
     let api = render_flow_html_chrome_pref(
         &lines,
@@ -913,6 +917,7 @@ fn cli_cap_truncates_body_api_keeps_it_full_html() {
         usize::MAX,
         2,
         None,
+        false,
     );
     assert!(
         cli.contains('…'),
@@ -941,6 +946,7 @@ fn cli_cap_truncates_body_api_keeps_it_full_details() {
         300,
         2,
         None,
+        false,
     );
     let api = render_flow_details_chrome_pref(
         &lines,
@@ -950,6 +956,7 @@ fn cli_cap_truncates_body_api_keeps_it_full_details() {
         usize::MAX,
         2,
         None,
+        false,
     );
     assert!(
         cli.contains('…'),
@@ -978,6 +985,7 @@ fn short_narration_untouched_by_either_cap() {
             cap,
             2,
             None,
+            false,
         );
         assert!(out.contains("brief note"));
         assert!(

--- a/src/tests/telegram_stream_loop_resume_test.rs
+++ b/src/tests/telegram_stream_loop_resume_test.rs
@@ -179,6 +179,7 @@ async fn resume_shape_loop_edits_tools_in_place_and_never_reacts() {
         dirty: false,
         recreate: false,
         header_preview: None,
+        compacting: false,
         sections: Default::default(),
         retained_goal: None,
         tool_round_count: 0,

--- a/src/tests/telegram_tool_group_test.rs
+++ b/src/tests/telegram_tool_group_test.rs
@@ -741,8 +741,9 @@ fn rich_multiple_tools_render_markdown_header() {
         false,
     );
     // No narration: the activity fallback (most recent tool line) leads the
-    // header, bold, then the italic count (#509).
-    assert!(out.starts_with("⚙️ **✅ read file.rs** • _2 tool calls_\n\n"));
+    // header, bold, then the italic count (#509). Icon-led activity: the
+    // standing gear is stripped (owner directive 2026-08-29).
+    assert!(out.starts_with("**✅ read file.rs** • _2 tool calls_\n\n"));
     assert!(out.contains("**✅ bash** `git status`"));
     assert!(out.contains("**✅ read** `file.rs`"));
 }

--- a/src/tests/telegram_tool_group_test.rs
+++ b/src/tests/telegram_tool_group_test.rs
@@ -58,7 +58,7 @@ fn single_tool_renders_block() {
     assert_eq!(
         out,
         "<blockquote expandable><b>✅ bash</b> <code>git status</code></blockquote>\n\
-         ⚙️ ✅ bash git status • 1 tool calls • ⏱ 0:00"
+         ✅ bash git status • 1 tool calls • ⏱ 0:00"
     );
     assert!(out.contains("<blockquote expandable>"));
 }
@@ -88,7 +88,7 @@ fn multiple_tools_render_expandable_blockquote() {
     assert!(out.starts_with("<blockquote expandable><b>✅ bash</b> <code>cargo fmt</code>\n\n"));
     assert!(out.contains("</blockquote>\n"));
     let footer = out.rsplit('\n').next().unwrap();
-    assert_eq!(footer, "⚙️ ❌ grep pattern • 3 tool calls • ⏱ 0:00");
+    assert_eq!(footer, "❌ grep pattern • 3 tool calls • ⏱ 0:00");
     assert!(out.contains("<b>✅ bash</b> <code>cargo fmt</code>"));
     assert!(out.contains("<b>✅ read_file</b> <code>handler.rs</code>"));
     assert!(out.contains("<b>❌ grep</b> <code>pattern</code>"));
@@ -381,7 +381,7 @@ fn blank_text_entries_are_dropped() {
     assert_eq!(
         out,
         "<blockquote expandable><b>✅ bash</b> <code>x</code></blockquote>\n\
-         ⚙️ ✅ bash x • 1 tool calls • ⏱ 0:00"
+         ✅ bash x • 1 tool calls • ⏱ 0:00"
     );
 }
 
@@ -494,7 +494,7 @@ fn no_duration_still_leads_with_activity() {
     );
     assert!(out.starts_with("<blockquote expandable><b>✅ bash</b> <code>cargo fmt</code>\n\n"));
     let footer = out.rsplit('\n').next().unwrap();
-    assert_eq!(footer, "⚙️ ✅ read_file handler.rs • 2 tool calls • ⏱ 0:00");
+    assert_eq!(footer, "✅ read_file handler.rs • 2 tool calls • ⏱ 0:00");
     assert!(!out.contains("45s"));
 }
 
@@ -784,7 +784,7 @@ fn details_single_tool_renders_details_block() {
     let out = render_flow_details(&[tline("✅ bash", "git status")], None);
     assert_eq!(
         out,
-        "<details><summary><sub>⚙️ ✅ bash git status • 1 tool calls • ⏱ 0:00</sub></summary>\
+        "<details><summary><sub>✅ bash git status • 1 tool calls • ⏱ 0:00</sub></summary>\
          <p><b>✅ bash</b> <code>git status</code></p></details>"
     );
     assert!(out.contains("<details>"));
@@ -801,7 +801,7 @@ fn details_multiple_tools_wrap_in_collapsed_details() {
     // collapsed block shows progress with the body hidden (#405); with no
     // narration it falls back to the most recent tool line.
     assert!(out.starts_with(
-        "<details><summary><sub>⚙️ ✅ read file.rs • 2 tool calls • ⏱ 0:00</sub></summary>"
+        "<details><summary><sub>✅ read file.rs • 2 tool calls • ⏱ 0:00</sub></summary>"
     ));
     assert!(out.ends_with("</details>"));
     assert!(!out.contains("<details open"));

--- a/src/tests/telegram_tool_group_test.rs
+++ b/src/tests/telegram_tool_group_test.rs
@@ -722,12 +722,12 @@ fn settled_block_carries_no_activity_preview_rich() {
 
 #[test]
 fn rich_empty_group_renders_header_only() {
-    assert_eq!(render_flow_rich(&[], None), "**Processing log**");
+    assert_eq!(render_flow_rich(&[], None, false), "**Processing log**");
 }
 
 #[test]
 fn rich_single_tool_renders_plain_line() {
-    let out = render_flow_rich(&[tline("✅ bash", "git status")], None);
+    let out = render_flow_rich(&[tline("✅ bash", "git status")], None, false);
     assert_eq!(out, "**✅ bash** `git status`");
     // Single tool: no blockquote wrapping, just bold label + context
     assert!(!out.contains(">"));
@@ -738,6 +738,7 @@ fn rich_multiple_tools_render_markdown_header() {
     let out = render_flow_rich(
         &[tline("✅ bash", "git status"), tline("✅ read", "file.rs")],
         None,
+        false,
     );
     // No narration: the activity fallback (most recent tool line) leads the
     // header, bold, then the italic count (#509).
@@ -757,13 +758,14 @@ fn rich_live_status_in_header() {
             tline("⚙️ grep", "pattern"),
         ],
         Some("10s"),
+        false,
     );
     assert!(out.starts_with("⚙️ **Searching.** • _2 tool calls_ • _10s_\n\n"));
 }
 
 #[test]
 fn rich_single_tool_live_status_appends() {
-    let out = render_flow_rich(&[tline("⚙️ bash", "git status")], Some("bash • 5s"));
+    let out = render_flow_rich(&[tline("⚙️ bash", "git status")], Some("bash • 5s"), false);
     assert_eq!(out, "**⚙️ bash** `git status` • bash • 5s");
 }
 


### PR DESCRIPTION
## Problem

The Telegram flow message showed duplicated compaction signals — the header pinned `⏳ Compacting context…` while the body rendered a second `⏳ Compacting context — 66% full…` line, and the body line carried a **hardcoded** `(≈10–60s)` ETA that was never right (live-fire snapshots: 8:57 and 1:05 actual durations against the same fictional estimate). Additionally, icon-led status segments (`✅`, `❌`) still got a bare `⚙️` prefix prepended, producing double-gear noise like `⚙️ ✅ bash git status`.

## Fix (3 parts)

**1. Header dedupe.** `render_flow_html_chrome_pref`, `render_flow_details_chrome_pref` and `render_flow_rich` gain a `compacting: bool` flag; when a compaction is live, the activity preview is suppressed so the pinned header is the only compaction signal. Live call sites pass the session flag; settled call sites pass `false`.

**2. Observed-ETA predictor (replaces the hardcoded fiction).** `ProgressEvent::Compacting` carries `predicted: Option<Duration>`. After each successful compaction the actual elapsed time is stored per-session (`last_compaction_elapsed`); the next compaction start emits `(≈Xs)` from that observation. First-ever compaction in a session renders bare — no guess, no lie. The finish line keeps the real measured elapsed: `✅ Compacted: 66% → 12% in 41s`.

**3. Icon-aware gear strip.** New `starts_with_icon()` classifies segments already led by an icon (incl. FE0F variants); such segments no longer receive the bare `⚙️` prefix in the live header or in `merged_footer` (both segments), and the bare-cog fallback retires when any segment is icon-led.

## Testing

- New `src/tests/compaction_signal_test.rs` cases: 2-arg `compacting_flow_line` (None / ≈42s / ≈2 min 12s), dedupe flag-on==1 / flag-off==2, icon classification, header/footer gear-strip, bare-cog fallback retirement.
- 7 existing icon-led expectations in `telegram_tool_group_test.rs` flipped; `*_chrome_pref` call sites updated.
- Full triad gate GREEN on upstream base `aee19325`: run 33368458747 (7275 tests, 0 failures). No local cargo per box law — CI is the compiler evidence.

Depends on nothing outside this diff; applies cleanly on `aee19325`.

Original issue: leshchenko1979/opencrabs#29
