### PR TITLE
feat(telegram): mermaid regen nudge with renderer error text

### DIFF
--- a/src/brain/agent/service/nudge.rs
+++ b/src/brain/agent/service/nudge.rs
@@ -135,3 +135,21 @@ pub fn should_emit_pressure_warning(usage_pct: f64, already_emitted: bool) -> Op
         None
     }
 }
+// ── Mermaid regen nudge (#37) ──
+
+/// In-loop correction for a model whose mermaid fence failed the render
+/// preflight with a deterministic parse error (#37). Quotes the renderer's
+/// own error text — it names the offending line or token — and states the
+/// regen budget so the model knows how many attempts remain. Same shape as
+/// the other nudges: a `[System: …]` bracket the loop injects as a user
+/// message after echoing the assistant's broken text.
+#[cfg(feature = "telegram")]
+pub(crate) fn mermaid_regen_nudge(errors: &[String], attempt: u32, max: u32) -> String {
+    let quoted = errors.join("\n");
+    format!(
+        "[System: Your mermaid diagram failed to render — mermaid.ink returned:\n{quoted}\n\
+         This is a syntax error in the fence you wrote (the renderer text above names the \
+         offending line or token). Fix the mermaid source and re-emit the COMPLETE corrected \
+         fence in your reply — keep everything else you wrote. Regen attempt {attempt}/{max}.]"
+    )
+}

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -1458,12 +1458,23 @@ impl AgentService {
         // scaffolding that already failed on the primary (#979).
         let mut pre_nudge_len: Option<usize> = None;
         const EMPTY_REASONING_MAX_NUDGES: u32 = 5;
+        // Mermaid regen budget (#37): how many parse-error nudges a fence
+        // gets before the reply ships and degrades to the usual failure
+        // block. Owner dial: 3 (2026-08-29).
+        #[cfg_attr(not(feature = "telegram"), allow(unused))]
+        const MERMAID_REGEN_MAX_NUDGES: u32 = 3;
         // Local reasoning models (notably Qwen3.6-35B on MLX) periodically
         // emit an EOS token mid-sentence — the response looks complete from
         // a protocol standpoint (proper finish_reason=stop + usage chunk)
         // but the visible text ends mid-word ("Standard Get I"). One-shot
         // nudge to continue from where they left off.
         let mut truncated_mid_sentence_retry_used: bool = false;
+        // Mermaid regen attempts spent (#37): each spend echoes the broken
+        // text as an assistant message and injects the renderer's error as
+        // a user-role [System: ...] nudge — same shape as the empty-answer
+        // ladder.
+        #[cfg_attr(not(feature = "telegram"), allow(unused))]
+        let mut mermaid_regen_retries: u32 = 0;
         // One-shot nudge for the browser screenshot-spam pattern detected
         // by the semantic-loop check below the per-iteration tool dispatch.
         // Reset per turn; fires at most once.
@@ -5492,6 +5503,60 @@ impl AgentService {
                     // cross-provider fallback for the continuation request.
                     current_iter_is_truncation_continue = true;
                     continue;
+                }
+
+                // Mermaid regen nudge (#37): if any fence in the reply fails
+                // to parse DETERMINISTICALLY, hand the model the renderer's
+                // own error text before the reply goes final — same shape as
+                // the empty-answer ladder: echo the broken text as an
+                // assistant message, inject the correction as a user-role
+                // [System: ...] nudge, re-run the iteration. Transient
+                // renderer failures stay silent here (preflight reports parse
+                // errors only) and keep the delivery path's degrade-to-block
+                // behaviour. Gated to channel sessions — the CLI has no
+                // mermaid delivery, so there is nothing to regenerate.
+                #[cfg(feature = "telegram")]
+                if mermaid_regen_retries < MERMAID_REGEN_MAX_NUDGES
+                    && !is_cli_provider
+                    && progress_callback.is_some()
+                    && crate::channels::telegram::rich::mermaid::should_render_mermaid(
+                        &iteration_text,
+                    )
+                {
+                    let parse_errors =
+                        crate::channels::telegram::rich::mermaid::preflight_parse_errors(
+                            &iteration_text,
+                        )
+                        .await;
+                    if !parse_errors.is_empty() {
+                        mermaid_regen_retries += 1;
+                        let attempt = mermaid_regen_retries;
+                        tracing::warn!(
+                            fences_broken = parse_errors.len(),
+                            attempt,
+                            budget = MERMAID_REGEN_MAX_NUDGES,
+                            "mermaid preflight parse errors; nudging regen"
+                        );
+                        if let Some(ref cb) = progress_callback {
+                            cb(
+                                session_id,
+                                ProgressEvent::SelfHealingAlert {
+                                    message: format!(
+                                        "Mermaid render failed — regen \
+                                         {attempt}/{MERMAID_REGEN_MAX_NUDGES}"
+                                    ),
+                                },
+                            );
+                        }
+                        let nudge = crate::brain::agent::service::nudge::mermaid_regen_nudge(
+                            &parse_errors,
+                            attempt,
+                            MERMAID_REGEN_MAX_NUDGES,
+                        );
+                        context.add_message(Message::assistant(iteration_text));
+                        context.add_message(Message::user(nudge));
+                        continue;
+                    }
                 }
 
                 if iteration > 0 {

--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -1457,6 +1457,10 @@ pub(crate) fn progress_key(text: &str) -> Option<&'static str> {
         Some("fallback-attempt")
     } else if t.starts_with("Retry ") {
         Some("provider-retry")
+    } else if t.starts_with("Mermaid render failed") {
+        // The regen-nudge counter (#37): 1/3 → 2/3 → 3/3 supersedes in
+        // place like the empty-answer nudge counter.
+        Some("mermaid-regen")
     } else {
         None
     }

--- a/src/channels/telegram/rich/ast.rs
+++ b/src/channels/telegram/rich/ast.rs
@@ -53,8 +53,15 @@ pub enum MermaidResult {
     /// The renderer accepted the diagram; carries the image URL to embed.
     Image(String),
     /// The renderer rejected the diagram or was unreachable; carries a
-    /// legible error note for the failure block.
+    /// legible error note for the failure block. Transient in nature
+    /// (timeout, unreachable, photo-box bust, server error) — the same
+    /// source may render fine on a later attempt.
     Failed(String),
+    /// The renderer rejected the diagram with a deterministic PARSE error
+    /// (HTTP 4xx carrying the renderer's own error text). The source is
+    /// broken as written; the note names the offending construct so the
+    /// model can fix the fence and re-emit it (#37 regen nudge).
+    ParseError(String),
 }
 
 /// A bulleted or numbered list.

--- a/src/channels/telegram/rich/mermaid.rs
+++ b/src/channels/telegram/rich/mermaid.rs
@@ -320,6 +320,24 @@ pub(crate) async fn prevalidate(source: &str) -> MermaidResult {
     finish(source, classify_render_failure(status, &body))
 }
 
+/// Pre-render every mermaid fence in `text` and collect the PARSE errors
+/// (#37). Called from the tool loop before the reply is final: each fence
+/// is resolved through [`prevalidate`] — which populates the render cache, so
+/// the delivery path reuses every outcome instead of re-asking the
+/// renderer — and only deterministic parse rejections are reported.
+/// Transient failures stay silent here; the delivery path degrades them
+/// to legible failure blocks as before. An empty `Vec` means every fence
+/// rendered.
+pub(crate) async fn preflight_parse_errors(text: &str) -> Vec<String> {
+    let mut errors = Vec::new();
+    for fence in find_mermaid_fences(text) {
+        if let MermaidResult::ParseError(note) = prevalidate(&fence.source).await {
+            errors.push(note);
+        }
+    }
+    errors
+}
+
 /// Classify a non-image renderer response (#37): HTTP 4xx — except the
 /// transient 408/429 — is a deterministic PARSE rejection of this exact
 /// source; mermaid.ink answers it with plain-text error text naming the

--- a/src/channels/telegram/rich/mermaid.rs
+++ b/src/channels/telegram/rich/mermaid.rs
@@ -13,8 +13,8 @@
 //! hangs; every failure path yields [`MermaidResult::Failed`].
 
 use super::ast::{Block, MermaidResult};
-use futures::FutureExt;
 use futures::future::BoxFuture;
+use futures::FutureExt;
 
 /// Base URL of the mermaid.ink image renderer. The diagram source is
 /// base64url-appended. NOTE: this sends the diagram text to a third party.
@@ -243,7 +243,22 @@ pub(crate) async fn prevalidate(source: &str) -> MermaidResult {
     // Not a usable image: surface the renderer's own error text (mermaid.ink
     // returns a plain-text parse error) so the failure block is legible.
     let body = resp.text().await.unwrap_or_default();
-    MermaidResult::Failed(error_note(status, &body))
+    classify_render_failure(status, &body)
+}
+
+/// Classify a non-image renderer response (#37): HTTP 4xx — except the
+/// transient 408/429 — is a deterministic PARSE rejection of this exact
+/// source; mermaid.ink answers it with plain-text error text naming the
+/// offending construct, which the model can act on (regen nudge). Anything
+/// else (server errors, odd non-image responses) is transient/infra and
+/// keeps the plain note. Pure, so the branching is unit-testable without a
+/// network call.
+pub(crate) fn classify_render_failure(status: u16, body: &str) -> MermaidResult {
+    if (400..500).contains(&status) && !matches!(status, 408 | 429) {
+        MermaidResult::ParseError(error_note(status, body))
+    } else {
+        MermaidResult::Failed(error_note(status, body))
+    }
 }
 
 /// Whether an HTTP response represents a usable rendered image. Split out so
@@ -281,7 +296,9 @@ pub(crate) fn replacement_for(
                 }),
             )
         }
-        MermaidResult::Failed(err) => (markdown_failure_block(err, source), None),
+        MermaidResult::Failed(err) | MermaidResult::ParseError(err) => {
+            (markdown_failure_block(err, source), None)
+        }
     }
 }
 

--- a/src/channels/telegram/rich/mermaid.rs
+++ b/src/channels/telegram/rich/mermaid.rs
@@ -13,8 +13,11 @@
 //! hangs; every failure path yields [`MermaidResult::Failed`].
 
 use super::ast::{Block, MermaidResult};
-use futures::future::BoxFuture;
 use futures::FutureExt;
+use futures::future::BoxFuture;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
 
 /// Base URL of the mermaid.ink image renderer. The diagram source is
 /// base64url-appended. NOTE: this sends the diagram text to a third party.
@@ -200,12 +203,83 @@ pub(crate) fn ink_url(source: &str) -> String {
     )
 }
 
+// ── Render cache (#37) ──
+//
+// The regen-nudge preflight validates the same fence the delivery path
+// validates moments later, and mermaid.ink renders are deterministic:
+// identical source, identical outcome. Caching the fresh outcome spares the
+// renderer the duplicate round-trip — and spares the delivery path a second
+// chance to hit a transient wobble on an already-proven source. Only
+// deterministic outcomes are stored: rendered image URLs and parse errors.
+// Transient `Failed` outcomes are never pinned, because the same source may
+// render fine seconds later.
+
+/// Freshness window for cached render outcomes (#37).
+const RENDER_CACHE_TTL_SECS: u64 = 600;
+
+/// Most cached render outcomes held; the oldest entry is evicted when the
+/// cap is reached (#37).
+const RENDER_CACHE_CAP: usize = 64;
+
+/// Cached render outcomes keyed by diagram source: insertion time plus the
+/// outcome itself (#37).
+static RENDER_CACHE: LazyLock<Mutex<HashMap<String, (Instant, MermaidResult)>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// A fresh cached render outcome for `source`, if any (#37). Expired
+/// entries are swept on every lookup so an idle cache cannot bloat.
+pub(crate) fn cache_get(source: &str) -> Option<MermaidResult> {
+    let mut cache = RENDER_CACHE.lock().ok()?;
+    let now = Instant::now();
+    cache.retain(|_, (at, _)| now.duration_since(*at) < Duration::from_secs(RENDER_CACHE_TTL_SECS));
+    cache.get(source).map(|(_, outcome)| outcome.clone())
+}
+
+/// Store a deterministic render outcome for `source` (#37). Only
+/// [`MermaidResult::Image`] and [`MermaidResult::ParseError`] are
+/// stored; transient failures are skipped so a retryable outage is never
+/// pinned as a stuck failure block. Evicts the oldest entry at the cap.
+pub(crate) fn cache_put(source: &str, outcome: &MermaidResult) {
+    if !matches!(
+        outcome,
+        MermaidResult::Image(_) | MermaidResult::ParseError(_)
+    ) {
+        return;
+    }
+    let Ok(mut cache) = RENDER_CACHE.lock() else {
+        return;
+    };
+    if cache.len() >= RENDER_CACHE_CAP && !cache.contains_key(source) {
+        let oldest = cache
+            .iter()
+            .min_by_key(|(_, (at, _))| *at)
+            .map(|(k, _)| k.clone());
+        if let Some(key) = oldest {
+            cache.remove(&key);
+        }
+    }
+    cache.insert(source.to_string(), (Instant::now(), outcome.clone()));
+}
+
+/// Hand the render outcome to the caller, caching it first when it is
+/// deterministic (#37).
+fn finish(source: &str, outcome: MermaidResult) -> MermaidResult {
+    cache_put(source, &outcome);
+    outcome
+}
+
 /// Pre-validate a single mermaid diagram against the renderer. Returns
 /// [`MermaidResult::Image`] with the embed URL only on HTTP 200 + an
 /// `image/*` content type; every other outcome (non-200, non-image, timeout,
 /// transport error, client build failure) yields [`MermaidResult::Failed`]
 /// with a legible note. Never panics, never hangs past the timeout.
 pub(crate) async fn prevalidate(source: &str) -> MermaidResult {
+    // A fresh cached outcome (image URL or parse error) spares the renderer
+    // the duplicate round-trip (#37).
+    if let Some(cached) = cache_get(source) {
+        return cached;
+    }
+
     let url = ink_url(source);
 
     let client = match reqwest::Client::builder()
@@ -237,13 +311,13 @@ pub(crate) async fn prevalidate(source: &str) -> MermaidResult {
         .to_string();
 
     if is_image_response(status, &content_type) {
-        return MermaidResult::Image(url);
+        return finish(source, MermaidResult::Image(url));
     }
 
     // Not a usable image: surface the renderer's own error text (mermaid.ink
     // returns a plain-text parse error) so the failure block is legible.
     let body = resp.text().await.unwrap_or_default();
-    classify_render_failure(status, &body)
+    finish(source, classify_render_failure(status, &body))
 }
 
 /// Classify a non-image renderer response (#37): HTTP 4xx — except the

--- a/src/channels/telegram/rich/render_html.rs
+++ b/src/channels/telegram/rich/render_html.rs
@@ -77,7 +77,9 @@ fn render_block(block: &Block, wrap_p: bool) -> String {
         // super::mermaid so the escaping stays in one place.
         Block::Mermaid { source, result } => match result {
             MermaidResult::Image(url) => super::mermaid::image_html(url),
-            MermaidResult::Failed(err) => super::mermaid::failure_html(err, source),
+            MermaidResult::Failed(err) | MermaidResult::ParseError(err) => {
+                super::mermaid::failure_html(err, source)
+            }
         },
         Block::Quote(inner) => format!(
             "<blockquote>{}</blockquote>",

--- a/src/tests/flow_progress_key_test.rs
+++ b/src/tests/flow_progress_key_test.rs
@@ -70,3 +70,18 @@ fn provider_retries_also_supersede() {
         Some("provider-retry")
     );
 }
+
+#[test]
+fn mermaid_regen_attempts_share_one_key() {
+    // The regen counter (#37) supersedes in place the same way the
+    // empty-answer nudge counter does.
+    let keys: Vec<_> = (1..=3)
+        .map(|n| progress_key(&format!("🔧 Mermaid render failed — regen {n}/3")))
+        .collect();
+    assert!(keys.iter().all(|k| *k == Some("mermaid-regen")));
+    // No emoji: the key is derived from the message, not its decoration.
+    assert_eq!(
+        progress_key("Mermaid render failed — regen 1/3"),
+        Some("mermaid-regen")
+    );
+}

--- a/src/tests/nudge_text_test.rs
+++ b/src/tests/nudge_text_test.rs
@@ -8,6 +8,8 @@
 //!
 //! Fixtures are synthetic and carry no user identifiers.
 
+#[cfg(feature = "telegram")]
+use crate::brain::agent::service::nudge::mermaid_regen_nudge;
 use crate::brain::agent::service::nudge::{no_tool_calls_nudge, uncalled_commands_nudge};
 
 #[test]
@@ -107,4 +109,20 @@ fn a_nudge_is_framed_as_a_system_message() {
         assert!(nudge.starts_with("[System:"), "{nudge}");
         assert!(nudge.ends_with(']'), "{nudge}");
     }
+}
+
+// ── Mermaid regen nudge (#37) ──
+
+#[cfg(feature = "telegram")]
+#[test]
+fn mermaid_regen_nudge_quotes_renderer_errors_and_counts_attempts() {
+    let errors = vec!["Parse error on line 2: Lexical error".to_string()];
+    let nudge = mermaid_regen_nudge(&errors, 1, 3);
+    assert!(
+        nudge.contains("Parse error on line 2: Lexical error"),
+        "must quote the renderer's own error text: {nudge}"
+    );
+    assert!(nudge.contains("Regen attempt 1/3"), "{nudge}");
+    assert!(nudge.starts_with("[System:"), "{nudge}");
+    assert!(nudge.ends_with(']'), "{nudge}");
 }

--- a/src/tests/telegram_mermaid_test.rs
+++ b/src/tests/telegram_mermaid_test.rs
@@ -12,9 +12,9 @@ use crate::channels::telegram::rich::api::build_body_markdown_media;
 use crate::channels::telegram::rich::ast::{Block, Inline, MermaidResult};
 use crate::channels::telegram::rich::markdown_to_html_mermaid;
 use crate::channels::telegram::rich::mermaid::{
-    MediaEntry, base64url, error_note, failure_html, find_mermaid_fences, has_mermaid_fence,
-    image_html, ink_url, is_image_response, looks_like_mermaid_source, markdown_failure_block,
-    replacement_for, resolve_blocks, resolve_markdown_media,
+    MediaEntry, base64url, classify_render_failure, error_note, failure_html, find_mermaid_fences,
+    has_mermaid_fence, image_html, ink_url, is_image_response, looks_like_mermaid_source,
+    markdown_failure_block, replacement_for, resolve_blocks, resolve_markdown_media,
 };
 
 // ---------------------------------------------------------------------------
@@ -280,6 +280,54 @@ fn replacement_for_failed_emits_failure_block_and_no_entry() {
     assert!(md.contains("Mermaid diagram could not be rendered"));
     assert!(md.contains("Parse error"));
     assert!(md.contains("graph TD;"));
+}
+
+#[test]
+fn replacement_for_parse_error_matches_failed_block_shape() {
+    // #37: a deterministic parse rejection degrades to the same legible
+    // failure block as a transient failure — the regen nudge is a
+    // loop-side concern, delivery treats both identically.
+    let outcome = MermaidResult::ParseError("Parse error on line 2: X".into());
+    let (md, entry) = replacement_for(&outcome, 0, "graph TD;");
+    assert!(
+        entry.is_none(),
+        "parse-error outcome must not carry a media entry"
+    );
+    assert!(md.contains("Mermaid diagram could not be rendered"));
+    assert!(md.contains("Parse error on line 2: X"));
+    assert!(md.contains("graph TD;"));
+}
+
+// ---------------------------------------------------------------------------
+// classify_render_failure (#37)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn classify_render_failure_4xx_is_parse_error() {
+    match classify_render_failure(400, "Parse error on line 3: syntax error") {
+        MermaidResult::ParseError(note) => assert!(note.contains("Parse error on line 3")),
+        other => panic!("expected ParseError, got {other:?}"),
+    }
+}
+
+#[test]
+fn classify_render_failure_transient_statuses_stay_failed() {
+    // 408/429 are transient (timeout/rate limit) even though they are 4xx;
+    // 5xx and anything odd is infra, not a model mistake.
+    for status in [408u16, 429, 500, 502] {
+        match classify_render_failure(status, "body") {
+            MermaidResult::Failed(note) => assert!(note.contains("body")),
+            other => panic!("status {status}: expected Failed, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn classify_render_failure_empty_body_names_status() {
+    match classify_render_failure(400, "   ") {
+        MermaidResult::ParseError(note) => assert!(note.contains("HTTP 400")),
+        other => panic!("expected ParseError, got {other:?}"),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests/telegram_mermaid_test.rs
+++ b/src/tests/telegram_mermaid_test.rs
@@ -12,9 +12,10 @@ use crate::channels::telegram::rich::api::build_body_markdown_media;
 use crate::channels::telegram::rich::ast::{Block, Inline, MermaidResult};
 use crate::channels::telegram::rich::markdown_to_html_mermaid;
 use crate::channels::telegram::rich::mermaid::{
-    MediaEntry, base64url, classify_render_failure, error_note, failure_html, find_mermaid_fences,
-    has_mermaid_fence, image_html, ink_url, is_image_response, looks_like_mermaid_source,
-    markdown_failure_block, replacement_for, resolve_blocks, resolve_markdown_media,
+    MediaEntry, base64url, cache_get, cache_put, classify_render_failure, error_note, failure_html,
+    find_mermaid_fences, has_mermaid_fence, image_html, ink_url, is_image_response,
+    looks_like_mermaid_source, markdown_failure_block, replacement_for, resolve_blocks,
+    resolve_markdown_media,
 };
 
 // ---------------------------------------------------------------------------
@@ -328,6 +329,33 @@ fn classify_render_failure_empty_body_names_status() {
         MermaidResult::ParseError(note) => assert!(note.contains("HTTP 400")),
         other => panic!("expected ParseError, got {other:?}"),
     }
+}
+
+// ---------------------------------------------------------------------------
+// render cache (#37)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn render_cache_hit_returns_cached_outcome() {
+    let source = "graph TD\n    CacheHitProbe --> A";
+    let outcome = MermaidResult::ParseError("Parse error on line 2".into());
+    cache_put(source, &outcome);
+    assert_eq!(cache_get(source), Some(outcome));
+}
+
+#[test]
+fn render_cache_miss_on_unknown_source() {
+    assert_eq!(cache_get("graph TD\n    NeverCachedProbe --> Z"), None);
+}
+
+#[test]
+fn render_cache_never_stores_transient_failures() {
+    let source = "graph TD\n    TransientProbe --> B";
+    cache_put(
+        source,
+        &MermaidResult::Failed("diagram renderer timed out".into()),
+    );
+    assert_eq!(cache_get(source), None);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Broken mermaid fences (PARSE errors at the renderer) now trigger an in-loop regen nudge to the model, same kind as the existing UX nudge echoes — instead of silently shipping a degradation block.

## How

- `MermaidResult::ParseError(String)`: render failures with 4xx (except 408/429) classify as parse errors; transient infra failures stay `Failed`
- `preflight_parse_errors`: at the tool-loop exit seam, fences in the final text are pre-resolved and parse-error notes collected (populates the render cache — no double fetch on success)
- `mermaid_regen_nudge`: `[System: …]` message carrying the renderer's exact parse error text, injected in-loop with `continue` (regen attempt counter, budget 3)
- Echo: `ProgressEvent::SelfHealingAlert` flow-bubble line with stable `progress_key` = `mermaid-regen` (supersedes in place, never stacks)
- Render cache: TTL 600s, cap 64, caches only deterministic outcomes (successful images + parse errors); read side wired at the top of `prevalidate`
- Telegram-gated, no-op for CLI providers

## Verification

- CI gate GREEN on this head: [PR-lane gates run 33368730500](https://github.com/leshchenko1979/opencrabs/actions/runs/33368730500), checkout ref verified `29b85660`
- Live E2E smoke on the production box: deliberately broken fence → ParseError classify → preflight intercept → in-loop regen nudge (attempt 1/3) with the renderer's parse error text → corrected fence same turn → diagram delivered as photo (daemon log: `mermaid.ink render ok; delivering bytes=4159`)

Original issue: https://github.com/leshchenko1979/opencrabs/issues/37
