### PR TITLE
fix(telegram): DRY the suggestion pick-record rewrite — classic host keeps the choice

### DIFF
--- a/src/channels/telegram/agent.rs
+++ b/src/channels/telegram/agent.rs
@@ -415,46 +415,51 @@ impl TelegramAgent {
                                                     InlineKeyboardMarkup::new(
                                                         Vec::<Vec<teloxide::types::InlineKeyboardButton>>::new(),
                                                     );
-                                                let outcome: Result<(), String> = match host_info {
-                                                    Some((full, true)) => {
-                                                        super::rich::api::edit_rich_html(
-                                                            bot_clone.api_url().as_str(),
-                                                            bot_clone.token(),
-                                                            chat_id.0,
-                                                            mid.0,
-                                                            &format!("{full}\n\n{picked}"),
-                                                            Some(&serde_json::json!(empty_kb)),
-                                                            "turn",
-                                                            "-",
-                                                        )
+                                                // #39: the pick record is baked into the body
+                                                // BEFORE any transport arm runs — one format
+                                                // site, so no arm can drop the choice again
+                                                // (the classic merged host used to edit the
+                                                // answer HTML alone and lose the record).
+                                                let rewrite =
+                                                    super::suggest_options::pick_rewrite(
+                                                        host_info
+                                                            .as_ref()
+                                                            .map(|(full, rich)| (full.as_str(), *rich)),
+                                                        picked,
+                                                    );
+                                                let outcome: Result<(), String> = match rewrite {
+                                                    super::suggest_options::PickRewrite::RichHost(
+                                                        body,
+                                                    ) => super::rich::api::edit_rich_html(
+                                                        bot_clone.api_url().as_str(),
+                                                        bot_clone.token(),
+                                                        chat_id.0,
+                                                        mid.0,
+                                                        &body,
+                                                        Some(&serde_json::json!(empty_kb)),
+                                                        "turn",
+                                                        "-",
+                                                    )
+                                                    .await
+                                                    .map(|_| ())
+                                                    .map_err(|e| e.to_string()),
+                                                    super::suggest_options::PickRewrite::ClassicHost(
+                                                        body,
+                                                    ) => bot_clone
+                                                        .edit_message_text(chat_id, mid, &body)
+                                                        .parse_mode(teloxide::types::ParseMode::Html)
+                                                        .reply_markup(empty_kb)
                                                         .await
                                                         .map(|_| ())
-                                                        .map_err(|e| e.to_string())
-                                                    }
-                                                    host_info => {
-                                                        let req = match host_info {
-                                                            Some((full, _)) => bot_clone
-                                                                .edit_message_text(
-                                                                    chat_id, mid, &full,
-                                                                )
-                                                                .parse_mode(
-                                                                    teloxide::types::ParseMode::
-                                                                        Html,
-                                                                )
-                                                                .reply_markup(empty_kb),
-                                                            None => bot_clone
-                                                                .edit_message_text(
-                                                                    chat_id, mid, &picked,
-                                                                )
-                                                                .parse_mode(
-                                                                    teloxide::types::ParseMode::
-                                                                        Html,
-                                                                ),
-                                                        };
-                                                        req.await
-                                                            .map(|_| ())
-                                                            .map_err(|e| e.to_string())
-                                                    }
+                                                        .map_err(|e| e.to_string()),
+                                                    super::suggest_options::PickRewrite::Standalone(
+                                                        body,
+                                                    ) => bot_clone
+                                                        .edit_message_text(chat_id, mid, &body)
+                                                        .parse_mode(teloxide::types::ParseMode::Html)
+                                                        .await
+                                                        .map(|_| ())
+                                                        .map_err(|e| e.to_string()),
                                                 };
                                                 if let Err(e) = outcome {
                                                     tracing::warn!(

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -53,6 +53,45 @@ pub(crate) fn echo_fallback(text: &str, chooser: Option<&str>) -> String {
     }
 }
 
+/// What a tapped suggestion block is rewritten into (#39).
+///
+/// The pick record is baked into the body BEFORE any transport arm runs,
+/// so no arm can drop it: a merged host — rich or classic — keeps its
+/// answer HTML and gains the pick record; a standalone block becomes the
+/// pick record. Before this shape the append lived inside the rich arm
+/// only, and the classic merged host silently lost the choice (owner
+/// report 2026-08-29 23:51Z).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PickRewrite {
+    /// Rich merged host: body rides `edit_rich_html`, empty markup strips
+    /// the dead buttons.
+    RichHost(String),
+    /// Classic merged host: body rides `edit_message_text` + empty markup
+    /// to strip the dead buttons.
+    ClassicHost(String),
+    /// Standalone suggestion block: body rides plain `edit_message_text`.
+    Standalone(String),
+}
+
+/// The single construction site for a post-tap body (#39).
+///
+/// `host` is `(html, rich)` of the merged host bubble when the tapped
+/// message IS it; merged host → answer HTML + pick record, standalone →
+/// pick record alone.
+pub(crate) fn pick_rewrite(host: Option<(&str, bool)>, picked: String) -> PickRewrite {
+    match host {
+        Some((full, rich)) => {
+            let body = format!("{full}\n\n{picked}");
+            if rich {
+                PickRewrite::RichHost(body)
+            } else {
+                PickRewrite::ClassicHost(body)
+            }
+        }
+        None => PickRewrite::Standalone(picked),
+    }
+}
+
 /// Button-width calibration, measured 2026-08-25 on Alexey's client
 /// (`sendRichMessage` probes, messages 29975 + 29991): a single full-width
 /// button fits <=50 chars on one line and wraps by 54; shared rows only

--- a/src/tests/telegram_followup_pick_test.rs
+++ b/src/tests/telegram_followup_pick_test.rs
@@ -12,7 +12,9 @@
 //!
 //! Fixtures are synthetic and carry no user identifiers.
 
-use crate::channels::telegram::suggest_options::{echo_fallback, picked_block};
+use crate::channels::telegram::suggest_options::{
+    PickRewrite, echo_fallback, pick_rewrite, picked_block,
+};
 
 const CHOICE: &str = "Update the SKILL.md with the new callback routing";
 
@@ -100,4 +102,69 @@ fn the_fallback_echo_names_the_chooser_too() {
     assert!(echo.starts_with("> "), "fallback must stay quoted: {echo}");
     assert!(echo.contains("Daniel"));
     assert!(echo.contains(CHOICE));
+}
+
+// ── Post-tap rewrite body (#39) ─────────────────────────────────────────────
+
+#[test]
+fn classic_host_body_keeps_answer_and_pick() {
+    // The exact regression from the owner report 2026-08-29 23:51Z: the
+    // classic merged host edited the answer HTML alone and the pick
+    // record vanished. The body must carry BOTH, answer first.
+    let rewrite = pick_rewrite(
+        Some(("<b>the answer</b>", false)),
+        picked_block(CHOICE, None),
+    );
+    let PickRewrite::ClassicHost(body) = rewrite else {
+        panic!("a classic host must stay classic: {rewrite:?}")
+    };
+    assert!(
+        body.starts_with("<b>the answer</b>"),
+        "answer html first: {body}"
+    );
+    assert!(body.contains(CHOICE), "pick record survives: {body}");
+    assert!(body.contains('\u{25b6}'), "pick marker survives: {body}");
+}
+
+#[test]
+fn rich_host_body_keeps_answer_and_pick() {
+    let rewrite = pick_rewrite(
+        Some(("<b>the answer</b>", true)),
+        picked_block(CHOICE, None),
+    );
+    let PickRewrite::RichHost(body) = rewrite else {
+        panic!("a rich host must stay rich: {rewrite:?}")
+    };
+    assert!(
+        body.starts_with("<b>the answer</b>"),
+        "answer html first: {body}"
+    );
+    assert!(body.contains(CHOICE), "pick record survives: {body}");
+}
+
+#[test]
+fn standalone_body_is_the_pick_record_alone() {
+    let record = picked_block(CHOICE, None);
+    assert_eq!(
+        pick_rewrite(None, record.clone()),
+        PickRewrite::Standalone(record)
+    );
+}
+
+#[test]
+fn the_rich_flag_decides_the_transport_not_the_body() {
+    // Same host html, same pick — only the rich flag flips, so the two
+    // bodies must match byte for byte; only the variant differs.
+    let picked = picked_block(CHOICE, None);
+    let classic = pick_rewrite(Some(("host", false)), picked.clone());
+    let rich = pick_rewrite(Some(("host", true)), picked);
+    fn body_of(r: &PickRewrite) -> &str {
+        match r {
+            PickRewrite::RichHost(b) | PickRewrite::ClassicHost(b) | PickRewrite::Standalone(b) => {
+                b.as_str()
+            }
+        }
+    }
+    assert_eq!(body_of(&classic), body_of(&rich));
+    assert_ne!(classic, rich, "the variant must flip with the flag");
 }


### PR DESCRIPTION
## Problem

On the classic merged-host arm, the suggestion pick-record rewrite lived *inside* each transport arm: the arm rebuilt the bubble with the answer HTML only and appended the pick record inline (`format!` duplicated across arms). The classic-host arm dropped the pick record entirely — tapping an option recorded the choice but the bubble never showed it (owner report 2026-08-29 23:51Z, smoke v5: keyboard stripped, choice never shown).

## Fix

Bake the pick-record rewrite into the body **before** the transport arms:

- `pick_rewrite()` + `PickRewrite` handle the record once, upstream of the arms — no arm can drop it again
- removes the duplicated inline append per arm (DRY)
- classic host now edits answer + record with the dead keyboard stripped, same as the rich host

## Changes

| File | Delta |
|---|---|
| `src/channels/telegram/agent.rs` | 81 lines — rewrite hoisted before the transport arms |
| `src/channels/telegram/suggest_options.rs` | +39 — `pick_rewrite()` / `PickRewrite` |
| `src/tests/telegram_followup_pick_test.rs` | +69 — classic/rich/standalone shapes + regression for the exact drop |

## Verification

- Live smoke on the fork (2026-08-30, owner-confirmed): tap on option → pick recorded on the message, keyboard stripped
- Single commit, cherry-picks cleanly onto current upstream `main` (`34bd8ff2`)
- CI: `pr-checks` must be GREEN before merge

## Provenance

Developed and smoked on the fork; harvested per owner directive (2026-08-31).

Tracked as leshchenko1979/opencrabs#39
