### PR TITLE
fix(memory): heal missing chunk_hash column on legacy stores

### DIFF
--- a/src/memory/db.rs
+++ b/src/memory/db.rs
@@ -537,15 +537,20 @@ impl Store {
         seq: usize,
         chunk_hash: &str,
     ) -> Result<bool, String> {
+        // `optional()` turns "no such row" into None, so the closure itself
+        // must read the column as Option<String>: a healed legacy row has a
+        // NULL chunk_hash, and reading it as plain String would raise
+        // InvalidColumnType(Null) instead of falling through to re-embed (#14).
         let stored_hash: Option<String> = self
             .conn
             .query_row(
                 "SELECT chunk_hash FROM content_vectors WHERE hash = ?1 AND seq = ?2",
                 params![hash, seq as i64],
-                |r| r.get(0),
+                |r| r.get::<_, Option<String>>(0),
             )
             .optional()
-            .map_err(|e| format!("chunk_needs_embedding: {e}"))?;
+            .map_err(|e| format!("chunk_needs_embedding: {e}"))?
+            .flatten();
 
         match stored_hash {
             None => Ok(true),                         // No embedding exists yet

--- a/src/memory/db.rs
+++ b/src/memory/db.rs
@@ -146,7 +146,39 @@ impl Store {
             )
             .map_err(|e| format!("Failed to initialize schema: {e}"))?;
 
+        // Column heal (#14): the DDL above is CREATE TABLE IF NOT EXISTS, a
+        // no-op on tables created by older builds. A content_vectors table
+        // that predates #1107 (2026-08-19) has no chunk_hash column, and
+        // chunk_needs_embedding then fails on every chunk of every backfill
+        // cycle. Probe and add the column when it is missing; idempotent.
+        self.ensure_chunk_hash_column()?;
+
         self.create_fts_triggers()
+    }
+
+    /// Add `chunk_hash` to `content_vectors` when the table predates it (#14).
+    ///
+    /// SQLite has no `ADD COLUMN IF NOT EXISTS`, so probe `pragma_table_info`
+    /// and ALTER only when the column is absent. On a fresh store the DDL
+    /// above already created the column and this stays a single read.
+    fn ensure_chunk_hash_column(&self) -> Result<(), String> {
+        let has_column: bool = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('content_vectors')
+                 WHERE name = 'chunk_hash'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .map_err(|e| format!("chunk_hash column probe: {e}"))?;
+
+        if !has_column {
+            self.conn
+                .execute_batch("ALTER TABLE content_vectors ADD COLUMN chunk_hash TEXT;")
+                .map_err(|e| format!("chunk_hash column heal: {e}"))?;
+        }
+        Ok(())
     }
 
     /// FTS5 external-content sync triggers. Copied verbatim from qmd: the

--- a/src/migrations/20260818000001_add_chunk_hash.sql
+++ b/src/migrations/20260818000001_add_chunk_hash.sql
@@ -1,7 +1,0 @@
--- Add chunk_hash column to content_vectors for per-chunk caching (#1107).
---
--- Without this, every append to a brain file re-embeds the entire file
--- (~100 chunks) because the document hash changes. With per-chunk hashes,
--- only chunks whose content actually changed are re-embedded.
-
-ALTER TABLE content_vectors ADD COLUMN chunk_hash TEXT;

--- a/src/tests/content_vectors_heal_test.rs
+++ b/src/tests/content_vectors_heal_test.rs
@@ -93,11 +93,10 @@ fn heals_legacy_database_and_preserves_rows() {
     // The cache check works again: NULL chunk_hash on the legacy row means
     // re-embed (true), a fresh hash for a new chunk means re-embed (true),
     // and an unchanged hash means skip (false).
-    assert_eq!(
+    assert!(
         store
             .chunk_needs_embedding("dochash", 0, "any")
             .expect("cache check on healed store"),
-        true,
         "legacy row with NULL chunk_hash must be re-embedded"
     );
     store
@@ -114,18 +113,16 @@ fn heals_legacy_database_and_preserves_rows() {
             Some("c1"),
         )
         .expect("insert_embedding on healed store");
-    assert_eq!(
-        store
+    assert!(
+        !store
             .chunk_needs_embedding("dochash", 1, "c1")
             .expect("cache check after insert"),
-        false,
         "unchanged chunk must be skipped"
     );
-    assert_eq!(
+    assert!(
         store
             .chunk_needs_embedding("dochash", 1, "c2")
             .expect("cache check after content change"),
-        true,
         "changed chunk must be re-embedded"
     );
 }
@@ -157,11 +154,10 @@ fn fresh_database_has_chunk_hash_from_ddl() {
 
     let store = Store::open(&db_path).expect("open fresh store");
     assert!(has_chunk_hash_column(&db_path));
-    assert_eq!(
+    assert!(
         store
             .chunk_needs_embedding("h", 0, "c")
             .expect("cache check on fresh store"),
-        true,
         "no embedding exists yet on a fresh store"
     );
 }

--- a/src/tests/content_vectors_heal_test.rs
+++ b/src/tests/content_vectors_heal_test.rs
@@ -1,0 +1,167 @@
+//! Regression tests for the `chunk_hash` column heal (#14).
+//!
+//! `CREATE TABLE IF NOT EXISTS` never amends a table an older build already
+//! created, so every memory.db whose `content_vectors` predates the
+//! `chunk_hash` column (#1107, 2026-08-19) kept the old schema forever — and
+//! every `chunk_needs_embedding` call failed with "no such column" (#14),
+//! killing the backfill cache check and spamming WARNs. The heal in
+//! `Store::initialize` adds the column on open; these tests pin that
+//! behavior on a database created with the pre-#1107 schema.
+
+use crate::memory::db::Store;
+use rusqlite::Connection;
+
+/// Create a memory.db with the PRE-#1107 `content_vectors` schema (no
+/// `chunk_hash` column) holding one legacy embedded-chunk row.
+fn create_legacy_db(path: &std::path::Path) {
+    let conn = Connection::open(path).expect("open legacy db");
+    conn.execute_batch(
+        r"
+        CREATE TABLE content (
+            hash TEXT PRIMARY KEY,
+            doc TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            collection TEXT NOT NULL,
+            path TEXT NOT NULL,
+            title TEXT NOT NULL,
+            hash TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            modified_at TEXT NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY (hash) REFERENCES content(hash) ON DELETE CASCADE,
+            UNIQUE(collection, path)
+        );
+        CREATE TABLE content_vectors (
+            hash TEXT NOT NULL,
+            seq INTEGER NOT NULL DEFAULT 0,
+            pos INTEGER NOT NULL DEFAULT 0,
+            model TEXT NOT NULL,
+            embedded_at TEXT NOT NULL,
+            PRIMARY KEY (hash, seq)
+        );
+        INSERT INTO content (hash, doc, created_at)
+            VALUES ('dochash', 'doc body', '2026-08-01T00:00:00Z');
+        INSERT INTO content_vectors (hash, seq, pos, model, embedded_at)
+            VALUES ('dochash', 0, 0, 'test-model', '2026-08-01T00:00:00Z');
+        ",
+    )
+    .expect("create legacy schema");
+}
+
+/// True when the `content_vectors` table on disk has a `chunk_hash` column.
+/// Reads through a separate connection so the check is independent of the
+/// store's own handle.
+fn has_chunk_hash_column(db_path: &std::path::Path) -> bool {
+    let conn = Connection::open(db_path).expect("reopen db for schema probe");
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('content_vectors')
+             WHERE name = 'chunk_hash'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("probe content_vectors schema");
+    count > 0
+}
+
+/// Opening a pre-#1107 store adds the missing column, keeps the rows, and
+/// makes `chunk_needs_embedding` work again.
+#[test]
+fn heals_legacy_database_and_preserves_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("legacy.db");
+    create_legacy_db(&db_path);
+
+    let store = Store::open(&db_path).expect("open heals the legacy store");
+
+    assert!(
+        has_chunk_hash_column(&db_path),
+        "chunk_hash column must exist after open"
+    );
+
+    // The legacy row survived the ALTER.
+    let conn = Connection::open(&db_path).unwrap();
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM content_vectors", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(rows, 1, "legacy content_vectors rows must be preserved");
+    drop(conn);
+
+    // The cache check works again: NULL chunk_hash on the legacy row means
+    // re-embed (true), a fresh hash for a new chunk means re-embed (true),
+    // and an unchanged hash means skip (false).
+    assert_eq!(
+        store
+            .chunk_needs_embedding("dochash", 0, "any")
+            .expect("cache check on healed store"),
+        true,
+        "legacy row with NULL chunk_hash must be re-embedded"
+    );
+    store
+        .ensure_vector_table(384)
+        .expect("vector table on healed store");
+    store
+        .insert_embedding(
+            "dochash",
+            1,
+            0,
+            &[0.0, 1.0],
+            "test-model",
+            "2026-08-01T00:00:00Z",
+            Some("c1"),
+        )
+        .expect("insert_embedding on healed store");
+    assert_eq!(
+        store
+            .chunk_needs_embedding("dochash", 1, "c1")
+            .expect("cache check after insert"),
+        false,
+        "unchanged chunk must be skipped"
+    );
+    assert_eq!(
+        store
+            .chunk_needs_embedding("dochash", 1, "c2")
+            .expect("cache check after content change"),
+        true,
+        "changed chunk must be re-embedded"
+    );
+}
+
+/// The heal is idempotent: reopening an already-healed store must not fail
+/// (a duplicate ALTER would raise "duplicate column name").
+#[test]
+fn heal_is_idempotent_across_reopens() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("legacy.db");
+    create_legacy_db(&db_path);
+
+    Store::open(&db_path).expect("first open heals");
+    assert!(has_chunk_hash_column(&db_path));
+
+    let reopened = Store::open(&db_path).expect("second open must stay clean");
+    assert!(has_chunk_hash_column(&db_path));
+    reopened
+        .chunk_needs_embedding("dochash", 0, "any")
+        .expect("cache check on reopened store");
+}
+
+/// A brand-new store has the column straight from the DDL — the heal probe
+/// runs and adds nothing.
+#[test]
+fn fresh_database_has_chunk_hash_from_ddl() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("fresh.db");
+
+    let store = Store::open(&db_path).expect("open fresh store");
+    assert!(has_chunk_hash_column(&db_path));
+    assert_eq!(
+        store
+            .chunk_needs_embedding("h", 0, "c")
+            .expect("cache check on fresh store"),
+        true,
+        "no embedding exists yet on a fresh store"
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -185,6 +185,7 @@ pub mod config_types_loader_test;
 pub mod config_update_test;
 pub mod config_watcher_test;
 pub mod config_write_path_test;
+pub mod content_vectors_heal_test;
 pub mod context_provider_anchor_test;
 pub mod context_store_concurrent_save_test;
 pub mod context_window_test;


### PR DESCRIPTION
## Summary

`content_vectors` tables created before adolfousier/opencrabs#1107 (2026-08-19) never receive the `chunk_hash` column: the fix migration shipped with #1107 is dead code — the main DB layer runs a hardcoded migration list that does not reference it, and the memory store (the only place `content_vectors` lives) runs zero migrations by design. Every `chunk_needs_embedding` call on such a store fails, so embedding cache-invalidation is permanently broken and each backfill cycle re-embeds everything while spamming WARNs (59,098 WARN lines on one production box on 08-29 alone).

## What this does

- `Store::initialize` probes `pragma_table_info('content_vectors')` after the DDL and runs `ALTER TABLE … ADD COLUMN chunk_hash TEXT` only when the column is absent — idempotent, heals every legacy `memory.db` on first open, no writes on fresh DBs.
- Deletes the dead migration `src/migrations/20260818000001_add_chunk_hash.sql` (verified zero consumers).
- Fixes a latent defect the heal exposed: `chunk_needs_embedding` read `chunk_hash` as plain `String` (`.optional()` only maps "no such row" → `None`), so a healed legacy row with `NULL chunk_hash` raised `InvalidColumnType(Null)` instead of counting as needs-embedding. Now read as `Option<String>` + `.flatten()`; `NULL` means re-embed, as the doc comment always promised.
- Regression tests `src/tests/content_vectors_heal_test.rs`: legacy heal + row preservation, idempotent reopen (no duplicate-column error), fresh-DB no-op.

## Verification

- GREEN gate on this exact head: [pr-checks run 33433873373](https://github.com/leshchenko1979/opencrabs/actions/runs/33433873373) (job `PR-lane gates (d6f2ab83fca03499985628165cf3e0ecdd4315ff)`, success).
- Production smoke on the fork deployment that carries these commits: `chunk_needs_embedding` WARN cliff — last WARN 12:11:28Z, zero in the following 7h40m (31,737 that day vs 59,098 on 08-29); all three affected `memory.db` stores healed on restart, rows preserved, legacy rows with `NULL chunk_hash` correctly re-embed on next backfill.
- Original issue: leshchenko1979/opencrabs#14
