### PR TITLE
feat(nudge): shared variation directive for loop guards + loud break breadcrumb

### DIFF
--- a/src/brain/agent/service/nudge.rs
+++ b/src/brain/agent/service/nudge.rs
@@ -135,3 +135,43 @@ pub fn should_emit_pressure_warning(usage_pct: f64, already_emitted: bool) -> Op
         None
     }
 }
+
+// ── Shared variation directive (#32) ──
+//
+// Born from the 2026-08-29 incident: a ship call recurred through the
+// loop-guard ladder (nudge at 3-in-8, break at 4-in-8) and the turn broke
+// silently. The reason the call failed sat in the first tool result — the
+// work had already been done by a sibling lane — but no guard message made
+// the model read it and act on it. The directive is that missing instruction,
+// stated once so every loop-breaker that fires on a recurring call teaches
+// the same lesson in the same words. Callers keep their own mechanism
+// sentence and compose this around it; the shared part is the behavioural
+// core (read the result, verify state, vary or report completion).
+
+/// The behavioural core shared by every guard that fires on a recurring
+/// call (#32): stop re-issuing, read the result already in hand, verify
+/// current state, then vary the action or report completion.
+///
+/// Pure so the wording is testable without a provider.
+pub fn variation_directive() -> &'static str {
+    "Do not re-issue the same call. Read the reason in the result you already have: it often \
+     says the work is already done or the input is wrong. Verify current state before acting \
+     again, then take a genuinely different action — different flags, a different command, or \
+     report completion if there is nothing left to do."
+}
+
+/// User-visible breadcrumb appended to the final response when a loop
+/// guard BREAKS a turn (#32).
+///
+/// Before this existed the break was silent: the guard logged a WARN,
+/// the model's partial text went out as the final message, and nothing
+/// told the user the turn had ended on a guard trip — the 2026-08-29
+/// incident sat that way until the owner pinged. The breadcrumb names
+/// the trip, states that no work is queued, and hands control back
+/// explicitly.
+pub fn loop_guard_breadcrumb(call_label: &str, count: usize, window: usize) -> String {
+    format!(
+        "⚠️ Loop guard ended this turn: '{call_label}' recurred {count}x in the last {window} \
+         steps. Nothing is queued — say the word to resume."
+    )
+}

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -5827,6 +5827,17 @@ impl AgentService {
                                 near_in_window,
                                 NEAR_WINDOW,
                             );
+                            // Loud break (#32): append a user-visible breadcrumb so the turn
+                            // does not end silent — the user sees the guard tripped, nothing
+                            // is queued, and how to resume.
+                            let call_label = normalized_call.split(':').next().unwrap_or("tool");
+                            response.content.push(ContentBlock::Text {
+                                text: crate::brain::agent::service::nudge::loop_guard_breadcrumb(
+                                    call_label,
+                                    near_in_window,
+                                    NEAR_WINDOW,
+                                ),
+                            });
                             final_response = Some(response);
                             break;
                         }
@@ -5854,10 +5865,10 @@ impl AgentService {
                                 "[System: You have issued nearly identical tool calls {} times \
                                  in the last {} steps. They differ only in numbers, counters, \
                                  or whitespace, so they return the same kind of result. \
-                                 Repeating near-duplicate calls will not move you forward. Use \
-                                 the output you already have, or take a genuinely different \
-                                 action. Do not re-issue another near-identical call.]",
-                                near_in_window, NEAR_WINDOW,
+                                 Repeating near-duplicate calls will not move you forward. {}]",
+                                near_in_window,
+                                NEAR_WINDOW,
+                                crate::brain::agent::service::nudge::variation_directive(),
                             )));
                             near_match_nudged = true;
                             continue;
@@ -5911,6 +5922,16 @@ impl AgentService {
                             repeat_in_window,
                             REPEAT_WINDOW,
                         );
+                        // Loud break (#32): append a user-visible breadcrumb so the turn
+                        // does not end silent — the user sees the guard tripped, nothing
+                        // is queued, and how to resume.
+                        response.content.push(ContentBlock::Text {
+                            text: crate::brain::agent::service::nudge::loop_guard_breadcrumb(
+                                &tool_label,
+                                repeat_in_window,
+                                REPEAT_WINDOW,
+                            ),
+                        });
                         final_response = Some(response);
                         break;
                     }

--- a/src/brain/tools/bash.rs
+++ b/src/brain/tools/bash.rs
@@ -1149,9 +1149,10 @@ pub(crate) fn check_recent_failure(session_id: Uuid, cmd: &str) -> Option<String
                 .unwrap_or("(no detail captured)");
             return Some(format!(
                 "You already ran this exact command in the last {} bash calls and it failed. \
-                 Don't retry the same string — try a different approach (different flags, a \
-                 different command, or address the root cause).\n\nPrevious error:\n{}",
-                RECENT_BASH_WINDOW, snippet
+                 {}\n\nPrevious error:\n{}",
+                RECENT_BASH_WINDOW,
+                crate::brain::agent::service::nudge::variation_directive(),
+                snippet
             ));
         }
     }

--- a/src/tests/bash_retry_loop_test.rs
+++ b/src/tests/bash_retry_loop_test.rs
@@ -149,3 +149,26 @@ fn rejection_message_names_the_window_size() {
     let msg = check_recent_failure(sid, "x").expect("should block");
     assert!(msg.contains(&RECENT_BASH_WINDOW.to_string()));
 }
+
+#[test]
+fn rejection_message_carries_the_shared_variation_directive() {
+    // #32: the Layer-3 rejection must teach the same lesson every
+    // loop-breaker teaches — read the result in hand, verify state,
+    // vary or report completion. The 2026-08-29 incident was exactly
+    // this fixture: a ship call retried after a sibling lane had
+    // already shipped, the reason sitting in the first result.
+    let sid = Uuid::new_v4();
+    record_bash_outcome(
+        sid,
+        "oc-deploy ship --sha abc123".to_string(),
+        true,
+        Some("already shipped by sibling lane".to_string()),
+    );
+    let msg = check_recent_failure(sid, "oc-deploy ship --sha abc123").expect("should block");
+    assert!(msg.contains("Do not re-issue the same call"), "{msg}");
+    assert!(msg.contains("result you already have"), "{msg}");
+    assert!(msg.contains("report completion"), "{msg}");
+    // The frame and the quoted error survive the rewording.
+    assert!(msg.contains("already ran this exact command"), "{msg}");
+    assert!(msg.contains("Previous error:"), "{msg}");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -687,6 +687,7 @@ pub mod usage_grouping_test;
 pub mod usage_ledger_test;
 pub mod user_correction_metadata_test;
 pub mod utc_timestamp_test;
+pub mod variation_directive_test;
 pub mod voice_onboarding_test;
 pub mod voice_stt_dispatch_test;
 pub mod wait_agent_resolver_test;

--- a/src/tests/variation_directive_test.rs
+++ b/src/tests/variation_directive_test.rs
@@ -1,0 +1,69 @@
+//! The shared variation directive (#32).
+//!
+//! Born from the 2026-08-29 incident: a ship call recurred through the
+//! loop-guard ladder (nudge at 3-in-8, break at 4-in-8) and the turn broke
+//! silently. The reason the call failed sat in the first tool result — the
+//! work had already been done by a sibling lane — but no guard message made
+//! the model read it and act on it. The directive is that missing
+//! instruction, stated once and shared by every loop-breaker that composes
+//! it (bash Layer-3 rejection, tool-loop near-match nudge).
+//!
+//! Fixtures are synthetic and carry no user identifiers.
+
+use crate::brain::agent::service::nudge::{loop_guard_breadcrumb, variation_directive};
+
+#[test]
+fn it_forbids_reissuing_the_same_call() {
+    // The opening sentence is the stop order. Without it the rest reads as a
+    // suggestion and a determined retry walks straight through it.
+    let d = variation_directive();
+    assert!(d.contains("Do not re-issue the same call"), "{d}");
+}
+
+#[test]
+fn it_points_at_the_result_already_in_hand() {
+    // The load-bearing lesson from the incident: the answer was already in
+    // the first tool result. The directive must send the model back to read
+    // it, not just tell it to try something else.
+    let d = variation_directive();
+    assert!(d.contains("result you already have"), "{d}");
+    assert!(
+        d.contains("already done"),
+        "must name the common reason: {d}"
+    );
+}
+
+#[test]
+fn it_requires_a_state_check_before_reacting() {
+    // "Verify current state" is what turns "the work is already done" from
+    // a guess into a check — the incident model never re-checked.
+    let d = variation_directive();
+    assert!(d.contains("Verify current state"), "{d}");
+}
+
+#[test]
+fn it_offers_completion_as_an_exit() {
+    // Same escape-hatch logic as FINISHED_ESCAPE: if the state check shows
+    // nothing left to do, reporting completion must be a sanctioned action,
+    // or the model invents a pointless call to comply.
+    let d = variation_directive();
+    assert!(d.contains("report completion"), "{d}");
+}
+
+#[test]
+fn the_break_breadcrumb_names_the_call_count_and_window() {
+    // The user must see WHICH call tripped the guard and how hard, or the
+    // breadcrumb reads as a generic apology and teaches nothing.
+    let b = loop_guard_breadcrumb("bash", 4, 8);
+    assert!(b.contains("'bash' recurred 4x in the last 8 steps"), "{b}");
+}
+
+#[test]
+fn the_break_breadcrumb_says_nothing_is_queued_and_how_to_resume() {
+    // The 2026-08-29 incident: the break was silent for half an hour
+    // because nothing said the turn had ended and no work was pending.
+    // Both facts must be visible — nothing queued, and the word to resume.
+    let b = loop_guard_breadcrumb("oc-deploy", 4, 8);
+    assert!(b.contains("Nothing is queued"), "{b}");
+    assert!(b.contains("say the word to resume"), "{b}");
+}


### PR DESCRIPTION
## Summary

Introduces a single shared `variation_directive()` in `nudge.rs` and composes it into two loop-guard sites, so every recovery nudge tells the model HOW to vary its next attempt instead of only THAT it should:

- `variation_directive()` — shared wording core (+4 wording tests, new `variation_directive_test.rs`)
- bash Layer-3 rejection path composes the directive into its retry nudge
- near-match loop-guard nudge composes the directive
- **Loud break:** both loop-guard break sites now append a user-visible breadcrumb: `⚠️ Loop guard ended this turn: '<call>' recurred Nx in the last 8 steps. Nothing is queued — say the word to resume.` — the turn no longer ends silently

## Port provenance

Carried on our fork as 4 commits (`bf827bb1`, `a12a226f`, `3258c892`, `59eddf42`), squashed for this PR (net +162/−7 across 6 files). Manual port (not cherry-pick) off upstream `34bd8ff2` — 3-way apply was clean on all 6 files with zero conflicts. Edition-2024 clean, fully-qualified paths (no import drift).

## Testing

- New tests: `variation_directive_test.rs` (directive wording + composition), extended `bash_retry_loop_test.rs` (Layer-3 rejection includes the directive)
- pr-checks GREEN on this head: run 33469378447 (fork carrier gate, dispatch ref `0c57dfb0`)
- Live on the fork fleet since cycle 5 (shipped `2d0615ec`), smoke-verified with non-vacuous string probes

## Notes

- Loop-guard live-fire UX leg (a natural breadcrumb render in a real trip) is still uncorroborated on the fork — corroborating when one fires.

Reported-from fork issue: leshchenko1979/opencrabs#32 (https://github.com/leshchenko1979/opencrabs/issues/32)