### PR TITLE
fix(telegram): per-user-turn plan-card restick; drop legacy 90s cooldown; consolidate typing loops

### DIFF
--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2411,7 +2411,6 @@ pub(crate) async fn handle_message(
         is_dm,
         compacting: false,
         pending_suggestions: None,
-        pending_trailer: None,
         msg_id: None,
         thinking: String::new(),
         tool_msgs: Vec::new(),
@@ -2820,7 +2819,6 @@ pub(crate) async fn handle_message(
                 combined,
                 agent_for_resume,
                 state_for_resume,
-                true, // end-of-turn detached flush is a push-initiated wake (#12)
             )
             .await
             {
@@ -2865,7 +2863,6 @@ pub(crate) async fn handle_message(
                     combined,
                     agent.clone(),
                     telegram_state.clone(),
-                    true, // stranded-reaction flush is a push-initiated wake (#12)
                 )
                 .await
                 {
@@ -2893,11 +2890,10 @@ pub(crate) async fn handle_message(
     if let Some(options) = suggestions {
         // Merge candidate (#tg-suggest-merge): the bubble the final response
         // landed in, captured by deliver_final_response. Attaching the
-        // keyboard THERE kills the separate "Suggested next" bubble. The
-        // #31 sign-off trailer rides along — it renders after the buttons.
-        let (merge_host, trailer) = {
+        // keyboard THERE kills the separate "Suggested next" bubble.
+        let merge_host = {
             let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-            (s.final_bubble.take(), s.pending_trailer.take())
+            s.final_bubble.take()
         };
         super::suggest_options::render_suggestions(
             &bot,
@@ -2907,7 +2903,6 @@ pub(crate) async fn handle_message(
             thread_id,
             options,
             merge_host,
-            trailer,
         )
         .await;
     }
@@ -3062,7 +3057,6 @@ pub(crate) async fn handle_reaction(
                     context_text: midturn,
                     display_text: format!("[System: {user_name} reacted with {emoji} mid-turn]"),
                     origin: crate::brain::agent::PushOrigin::Ingress,
-                    bg_meta: None,
                 },
             );
             tracing::info!(
@@ -3308,7 +3302,6 @@ pub(crate) fn build_midturn_queued_message(
             ),
             display_text: invocation.to_string(),
             origin: crate::brain::agent::PushOrigin::Ingress,
-            bg_meta: None,
         },
         None => crate::brain::agent::QueuedUserMessage {
             context_text: format!(
@@ -3318,7 +3311,6 @@ pub(crate) fn build_midturn_queued_message(
             ),
             display_text: display_text.to_string(),
             origin: crate::brain::agent::PushOrigin::Ingress,
-            bg_meta: None,
         },
     }
 }

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -1880,6 +1880,7 @@ pub(crate) async fn handle_message(
             std::sync::Arc::new(move || probe_state.channel_ownership_of(session_id)),
         );
     }
+
     // Archive any shared images under the session's project files dir (when the
     // session is assigned to a project) so a project's media lives together and
     // survives the tmp purge. Rewrites the <<IMG:tmp>> marker to the archived
@@ -2419,6 +2420,7 @@ pub(crate) async fn handle_message(
         is_dm,
         compacting: false,
         pending_suggestions: None,
+        pending_trailer: None,
         msg_id: None,
         thinking: String::new(),
         tool_msgs: Vec::new(),
@@ -2724,17 +2726,25 @@ pub(crate) async fn handle_message(
                 .sections
                 .plan_kb
         };
-        // Re-stick on a cooldown, not every settle (#814). Doing it every turn
-        // cost a delete PLUS a create on top of the refreshes already firing
-        // from the streaming path, which is what put the card within reach of
-        // flood control and produced duplicate cards. Skipping the re-stick
-        // still refreshes in place below, so the card stays correct; it just
-        // stays where it is until the next re-stick is due.
-        if crate::utils::plan_files::take_plan_just_archived(session_id).await {
+        // Re-stick on EVERY user-message settle (owner-approved #62): the card
+        // must stay reachable for the Approve button while a pre-approval plan
+        // is being discussed, and a restick per human turn is paced by typing
+        // speed, not by machine loops. Flood safety is NOT this gate's job:
+        // the fresh post goes through the G3 sends governor, the in-place
+        // refresh below rides G2 (#1211), so the old 90s RESTICK_COOLDOWN
+        // (#814) was a pre-governor duplicate — deleted. The ONLY gate left is
+        // the shared sticky-stack budget (#1150): a flow restick moments ago
+        // already spent this chat's delete+create allowance; skipping here
+        // costs nothing (no cooldown is recorded — retry next settle) and the
+        // refresh below still edits in place.
+        if crate::utils::plan_files::peek_plan_just_archived(session_id).await {
             // Plan completed THIS settle (#1158, #1231): finalize the tracked
             // card (✅ header, keyboard stripped, one-shot untrack) and re-stick
             // the completed card to the bottom of the thread instead of
-            // re-sticking or refreshing a now-archived plan.
+            // re-sticking or refreshing a now-archived plan. Finalize consumes
+            // the flag only after the notice LANDED (#16): a flood-aborted
+            // finalize leaves it in place, so the next settle retries instead
+            // of losing the completion notice forever.
             super::plan_card::finalize_plan_card(
                 &bot,
                 msg.chat.id,
@@ -2744,18 +2754,15 @@ pub(crate) async fn handle_message(
             )
             .await;
         } else {
-            const RESTICK_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(90);
-            if telegram_state
-                .should_restick_plan_card(session_id, RESTICK_COOLDOWN)
-                .await
-                // Shared sticky-stack budget (#1150): a flow restick moments ago
-                // already spent this chat's delete+create allowance; skipping here
-                // is safe — the refresh below still edits in place, and the next
-                // settle or flow restick reorders.
-            && telegram_state.claim_sticky_action(
-                msg.chat.id.0,
-                super::state::TelegramState::STICKY_STACK_MIN_INTERVAL,
-            ) {
+            // Gate the claim on a tracked card (in-memory only — cheap): a
+            // cardless settle must not spend the sticky budget, or the
+            // flow-block restick starves for 15s after EVERY settle (#62).
+            if telegram_state.plan_card_cached(session_id).await.is_some()
+                && telegram_state.claim_sticky_action(
+                    msg.chat.id.0,
+                    super::state::TelegramState::STICKY_STACK_MIN_INTERVAL,
+                )
+            {
                 super::plan_card::remove_plan_card(&bot, msg.chat.id, &telegram_state, session_id)
                     .await;
             }
@@ -2822,6 +2829,7 @@ pub(crate) async fn handle_message(
                 combined,
                 agent_for_resume,
                 state_for_resume,
+                true, // end-of-turn detached flush is a push-initiated wake (#12)
             )
             .await
             {
@@ -2866,6 +2874,7 @@ pub(crate) async fn handle_message(
                     combined,
                     agent.clone(),
                     telegram_state.clone(),
+                    true, // stranded-reaction flush is a push-initiated wake (#12)
                 )
                 .await
                 {
@@ -2893,10 +2902,11 @@ pub(crate) async fn handle_message(
     if let Some(options) = suggestions {
         // Merge candidate (#tg-suggest-merge): the bubble the final response
         // landed in, captured by deliver_final_response. Attaching the
-        // keyboard THERE kills the separate "Suggested next" bubble.
-        let merge_host = {
+        // keyboard THERE kills the separate "Suggested next" bubble. The
+        // #31 sign-off trailer rides along — it renders after the buttons.
+        let (merge_host, trailer) = {
             let mut s = streaming.lock().unwrap_or_else(|e| e.into_inner());
-            s.final_bubble.take()
+            (s.final_bubble.take(), s.pending_trailer.take())
         };
         super::suggest_options::render_suggestions(
             &bot,
@@ -2906,6 +2916,7 @@ pub(crate) async fn handle_message(
             thread_id,
             options,
             merge_host,
+            trailer,
         )
         .await;
     }
@@ -3060,6 +3071,7 @@ pub(crate) async fn handle_reaction(
                     context_text: midturn,
                     display_text: format!("[System: {user_name} reacted with {emoji} mid-turn]"),
                     origin: crate::brain::agent::PushOrigin::Ingress,
+                    bg_meta: None,
                 },
             );
             tracing::info!(
@@ -3305,6 +3317,7 @@ pub(crate) fn build_midturn_queued_message(
             ),
             display_text: invocation.to_string(),
             origin: crate::brain::agent::PushOrigin::Ingress,
+            bg_meta: None,
         },
         None => crate::brain::agent::QueuedUserMessage {
             context_text: format!(
@@ -3314,6 +3327,7 @@ pub(crate) fn build_midturn_queued_message(
             ),
             display_text: display_text.to_string(),
             origin: crate::brain::agent::PushOrigin::Ingress,
+            bg_meta: None,
         },
     }
 }

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -17,10 +17,10 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use teloxide::prelude::*;
 use teloxide::types::{
-    ChatAction, ChatKind, FileId, InlineKeyboardMarkup, MessageId, ParseMode, ReplyParameters,
+    ChatKind, FileId, InlineKeyboardMarkup, MessageId, ParseMode, ReplyParameters,
 };
 
-use super::send::{best_effort_delete, fire_chat_action, message_in_thread};
+use super::send::{best_effort_delete, message_in_thread};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -1431,23 +1431,14 @@ pub(crate) async fn handle_message(
         truncate_str(&text, 50)
     );
 
-    // Start typing indicator loop — cancelled via guard on all return paths
+    // Start typing indicator loop — cancelled via guard on all return paths.
+    // Consolidated on typing.rs (#62): same turn-phase loop spawn_typing
+    // uses. The session id is not known yet (resolution happens below), so
+    // this is the bare turn loop; the detached tail is attached later via
+    // spawn_typing_after_turn once the id exists.
     let typing_cancel = CancellationToken::new();
     let _typing_guard = TypingGuard(typing_cancel.clone());
-    tokio::spawn({
-        let bot = bot.clone();
-        let chat = msg.chat.id;
-        let cancel = typing_cancel.clone();
-        async move {
-            loop {
-                fire_chat_action(&bot, chat, thread_id, ChatAction::Typing, "typing loop").await;
-                tokio::select! {
-                    _ = cancel.cancelled() => break,
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(4)) => {}
-                }
-            }
-        }
-    });
+    super::typing::spawn_typing_turn(bot.clone(), msg.chat.id, thread_id, typing_cancel.clone());
 
     let is_owner = tg_cfg.is_owner(&user_id.to_string());
 

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -197,10 +197,6 @@ pub struct TelegramState {
     ///
     /// Per session, so unrelated chats never wait on each other.
     plan_card_locks: Mutex<HashMap<Uuid, std::sync::Arc<tokio::sync::Mutex<()>>>>,
-    /// Session → when the card was last re-stuck (deleted and reposted at the
-    /// bottom). The re-stick costs two writes, so it is worth doing
-    /// occasionally to keep the card reachable and ruinous to do every settle.
-    plan_card_restick: Mutex<HashMap<Uuid, std::time::Instant>>,
     /// Photo batching buffer: (chat_id, user_id, media_group_id) → Vec<(img_marker, Option<caption>)>
     /// When user sends multiple photos in an album, we buffer them and only fire the agent
     /// after a quiet period (no new photos for 3s). Keyed by media_group_id to avoid merging
@@ -324,7 +320,6 @@ impl TelegramState {
             plan_card_store: Mutex::new(None),
             plan_card_backoff: Mutex::new(HashMap::new()),
             plan_card_locks: Mutex::new(HashMap::new()),
-            plan_card_restick: Mutex::new(HashMap::new()),
             photo_buffer: Mutex::new(HashMap::new()),
             photo_debounce: Mutex::new(HashMap::new()),
             text_buffer: Mutex::new(HashMap::new()),
@@ -819,6 +814,21 @@ impl TelegramState {
         Some(card)
     }
 
+    /// In-memory-only card check (#62): whether a card message id is live in
+    /// THIS process. Unlike [`Self::plan_card`] it never rehydrates from the
+    /// store, so it is cheap enough to gate the per-settle restick claim —
+    /// cardless settles must not spend the shared sticky budget (#1150) they
+    /// do not need, or the flow-block restick would starve for 15s after
+    /// every settle. A card tracked by a previous process but not yet
+    /// re-posted here skips at most one restick: the refresh below re-posted
+    /// and re-tracked it, so the next settle resticks normally.
+    pub(crate) async fn plan_card_cached(
+        &self,
+        session_id: Uuid,
+    ) -> Option<(teloxide::types::MessageId, String)> {
+        self.plan_cards.lock().await.get(&session_id).cloned()
+    }
+
     /// The lock serialising card writes for a session (#822).
     ///
     /// Returned as an `Arc` so the caller holds it across its API calls; the
@@ -857,28 +867,6 @@ impl TelegramState {
             .lock()
             .await
             .insert(session_id, std::time::Instant::now() + wait);
-    }
-
-    /// Should the card be re-stuck (deleted and reposted at the bottom) now?
-    ///
-    /// Records the decision, so a `true` starts the cooldown. Re-sticking keeps
-    /// the card from being buried by streamed output, but costs a delete plus a
-    /// create; doing it every settle is what put the card within reach of flood
-    /// control (#814, regression from 3c45e41a).
-    pub(crate) async fn should_restick_plan_card(
-        &self,
-        session_id: Uuid,
-        cooldown: std::time::Duration,
-    ) -> bool {
-        let now = std::time::Instant::now();
-        let mut map = self.plan_card_restick.lock().await;
-        match map.get(&session_id) {
-            Some(last) if now.duration_since(*last) < cooldown => false,
-            _ => {
-                map.insert(session_id, now);
-                true
-            }
-        }
     }
 
     /// Give the plan-card map durable backing. Called once at startup.

--- a/src/channels/telegram/typing.rs
+++ b/src/channels/telegram/typing.rs
@@ -28,22 +28,21 @@ use super::send::fire_chat_action;
 /// this stays under that to avoid a visible flicker between ticks.
 const TICK: Duration = Duration::from_secs(4);
 
-/// Keep "typing" alive for the turn, then for as long as the session has
-/// background commands running.
-///
-/// `cancel` ends the turn phase, exactly as before. `background` is `None` on
-/// surfaces with no background manager wired, which collapses this to the
-/// original behaviour.
-pub(crate) fn spawn_typing(
+/// Turn-phase loop: immediate first action, then re-send every `TICK` until
+/// `cancel` fires. The building block — [`spawn_typing`] layers the detached
+/// tail on top of it. Surfaces that must start typing BEFORE they know the
+/// session id (message intake, before session resolution) spawn this directly
+/// and pair it with [`spawn_typing_after_turn`] once the id is known.
+pub(crate) fn spawn_typing_turn(
     bot: Bot,
     chat_id: ChatId,
     thread_id: Option<ThreadId>,
     cancel: CancellationToken,
-    background: Option<Arc<BackgroundTaskManager>>,
-    session_id: Uuid,
 ) {
     tokio::spawn(async move {
-        // Phase 1: the turn is running.
+        // Fire immediately: the user JUST sent a message — show typing now,
+        // not after the first tick.
+        fire_chat_action(&bot, chat_id, thread_id, ChatAction::Typing, "typing loop").await;
         loop {
             tokio::select! {
                 _ = cancel.cancelled() => break,
@@ -53,9 +52,25 @@ pub(crate) fn spawn_typing(
                 }
             }
         }
-
-        keep_typing_while_detached(bot, chat_id, thread_id, background, session_id).await;
     });
+}
+
+/// Keep "typing" alive for the turn, then for as long as the session has
+/// background commands running.
+///
+/// `cancel` ends the turn phase, exactly as before. `background` is `None` on
+/// surfaces with no background manager wired, which collapses this to the
+/// turn loop only.
+pub(crate) fn spawn_typing(
+    bot: Bot,
+    chat_id: ChatId,
+    thread_id: Option<ThreadId>,
+    cancel: CancellationToken,
+    background: Option<Arc<BackgroundTaskManager>>,
+    session_id: Uuid,
+) {
+    spawn_typing_turn(bot.clone(), chat_id, thread_id, cancel.clone());
+    spawn_typing_after_turn(bot, chat_id, thread_id, cancel, background, session_id);
 }
 
 /// The tail of [`spawn_typing`], for callers that only learn their session id

--- a/src/utils/plan_files.rs
+++ b/src/utils/plan_files.rs
@@ -532,6 +532,16 @@ pub async fn take_plan_just_archived(session_id: Uuid) -> bool {
     }
 }
 
+/// Peek the "just archived" stamp WITHOUT consuming it (#62).
+///
+/// The settle restick gate re-checks every settle (per-turn restick), so a
+/// consuming read there would starve every later turn. Gate sites peek; the
+/// one-shot consumer that finalizes the completed card still calls
+/// [`take_plan_just_archived`].
+pub async fn peek_plan_just_archived(session_id: Uuid) -> bool {
+    plan_just_archived_path(session_id).await.exists()
+}
+
 /// True when the newest file under this session's `archive/` was written
 /// within `max_age` (#1158). tool_loop archives a plan at EVERY settling
 /// plan-turn, so "an archive exists" cannot distinguish completion-now from


### PR DESCRIPTION
## Summary

Three Telegram plan-card / typing changes, shipped and live-verified on our fork before this PR:

### 1. Drop the legacy 90s plan-card restick cooldown — restick per user-turn settle

`RESTICK_COOLDOWN` (#814) was written 2026-07-26 when no proactive flood layer existed. Since the governors (#1211) landed, its job is done better elsewhere: the fresh card post rides the G3 sends governor, the in-place refresh rides G2's latest-wins edit queue. The 90s blindfold remained only as a duplication — and it had a real defect: the cooldown window was recorded *before* the shared sticky-stack budget (#1150) was claimed, so a restick that lost the 15s sticky race still burned the whole 90s window (user-visible: a pre-approval plan card buried mid-discussion because every restick attempt silently lost the race).

New behavior: the card resticks on **every user-message settle**, gated only by the #1150 shared sticky budget (mechanism coordination, not flood control), and only when a card is actually tracked (in-memory `plan_card_cached` check — cardless settles don't spend the sticky budget, which would starve the flow-block restick every settle).

The archived-plan flag gate changes from a consuming `take` to a non-consuming `peek` (`peek_plan_just_archived`): the gate re-checks every settle, so a one-shot read there would starve every later turn. The one-shot finalize consumer still calls `take_plan_just_archived`.

### 2. Consolidate typing tick loops on typing.rs

The turn-phase 4s typing loop was hand-rolled inline in `handler.rs` (a pre-#812-era copy). Extracted as `spawn_typing_turn` (immediate first fire — the inline version's semantics), with `spawn_typing` composing turn + tail, and `spawn_typing_after_turn` unchanged. One loop implementation, one #812-aware path; the resume-path single fire (#29 `Compacting` callback) is untouched.

### 3. Verification

- Full pr-checks suite GREEN on the fork (lint, clippy, all-features tests), checkout-ref verified: run [33524254476](https://github.com/leshchenko1979/opencrabs/actions/runs/33524254476).
- Live smoke on the production box (binary `57663e4c`): first post-deploy normal settle → old card deleted 0.8s after settle, fresh card posted bottom-of-thread. Per-turn restick observed working with no flood events (governor telemetry clean).
- Origin of the cooldown-deletion decision includes a full flood-prevention inventory of the tree: governors (proactive, kept), reactive Retry-After backstop (kept, complementary), #1150 sticky budget (kept, coordination) — the 90s cooldown was the only legacy duplicate.

Related fork issue and implementation trail: leshchenko1979/opencrabs#62