### PR TITLE
feat(memory): tree-sitter symbol/call-graph indexing for structural code queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5162,6 +5162,8 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-rust",
  "unicode-normalization",
  "unicode-segmentation",
  "unicode-width",
@@ -7648,6 +7650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8819,6 +8827,35 @@ checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
 dependencies = [
  "num-integer",
  "strength_reduce",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca0d1bf6fdd806e43ae5198f82f527056d359def39e54e67a0f478ac09dac081"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,8 @@ urlencoding = "2.1"
 syntect = { version = "5.2", default-features = false, features = ["default-fancy"] }
 pulldown-cmark = "0.13"
 strip-ansi = "0.1"
+tree-sitter = { version = "0.24", optional = true }
+tree-sitter-rust = { version = "0.23", optional = true }
 
 # Concurrent Data Structures
 once_cell = "1.20"
@@ -218,6 +220,7 @@ local-stt = ["rwhisper", "rodio", "hound", "rubato", "symphonia", "symphonia-ada
 local-tts = ["opusic-sys", "rubato"]
 browser = ["chromey"]
 pdfium = ["dep:pdfium-render"]
+code-graph = ["tree-sitter", "tree-sitter-rust"]
 [profile.dev]
 opt-level = 0
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,7 @@ rwhisper = { version = "0.4", optional = true, features = ["metal", "accelerate"
 winresource = "0.1"
 
 [features]
-default = ["telegram", "whatsapp", "discord", "slack", "trello", "local-stt", "local-tts", "browser", "rtk"]
+default = ["telegram", "whatsapp", "discord", "slack", "trello", "local-stt", "local-tts", "browser", "rtk", "code-graph"]
 # Profiling feature enables pprof on Unix only (no-op on Windows)
 profiling = []
 # RTK (Rust Token Killer) integration - filters bash command outputs to save 60-90% tokens

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@
 
 **Official docs:** [docs.opencrabs.com](https://docs.opencrabs.com) — comprehensive guides, architecture deep-dives, and reference material.
 
+The docs and the landing at [opencrabs.com](https://opencrabs.com) are available in six languages: English, Português (PT-PT), Español, Français, Русский and Bahasa Indonesia. Pick one from the language switcher in the menu bar; untranslated paragraphs fall back to English rather than going missing.
+
 ### Getting Started
 - [Installation & Quick Start](src/docs/start/GETTING_STARTED.md)
 - [Onboarding Wizard](src/docs/start/ONBOARDING.md)

--- a/src/brain/prompt_builder.rs
+++ b/src/brain/prompt_builder.rs
@@ -919,6 +919,9 @@ pub(crate) fn compiled_features() -> Vec<&'static str> {
     if cfg!(feature = "pdfium") {
         out.push("pdfium");
     }
+    if cfg!(feature = "code-graph") {
+        out.push("code-graph");
+    }
     if cfg!(feature = "profiling") {
         out.push("profiling");
     }

--- a/src/channels/telegram/rich/ast.rs
+++ b/src/channels/telegram/rich/ast.rs
@@ -113,6 +113,11 @@ pub enum Inline {
     Bold(Vec<Inline>),
     Italic(Vec<Inline>),
     Strike(Vec<Inline>),
+    /// `<sub>` small text. The rich dialect renders it natively; classic
+    /// Telegram HTML has no `<sub>`, so the renderer drops the tag and keeps
+    /// the content. Parsed as a node rather than left as text so a lone
+    /// `<sub>` in prose still escapes to visible characters.
+    Sub(Vec<Inline>),
     /// Inline `code` — content is literal, never re-parsed.
     Code(String),
     /// Inline `$math$` — content is literal, never re-parsed.

--- a/src/channels/telegram/rich/detect.rs
+++ b/src/channels/telegram/rich/detect.rs
@@ -18,7 +18,7 @@ use super::{list, table};
 /// checkbox, both of which the legacy path renders poorly (raw `| pipes |` and
 /// literal `- [ ]` respectively).
 pub(crate) fn prefers_rich_render(text: &str) -> bool {
-    contains_table(text) || contains_task_list(text)
+    contains_table(text) || contains_task_list(text) || contains_details(text)
 }
 
 /// Whether `text` contains a GitHub-flavored pipe table.
@@ -89,9 +89,24 @@ pub(crate) fn has_rich_structure(text: &str) -> bool {
                 || list::is_item(t)
                 || t.starts_with("```")
                 || t == "$$"
-                || t.starts_with("<details>")
-                || t.starts_with("<details ")
+                || is_details_open(t)
         })
+}
+
+/// A `<details>` collapse opener, bare or with attributes (`<details open>`).
+/// Shared by the rich gate and the classic HTML ladder so the two can never
+/// disagree about who renders a collapse block: [`has_rich_structure`] sends
+/// it to `sendRichMessage`, and when that send fails [`prefers_rich_render`]
+/// must route the fallback through the rich AST too. The line-based ladder
+/// escapes unknown tags, so a collapse that reached it surfaced its literal
+/// `<details>` / `<summary>` markup as visible text.
+pub(crate) fn is_details_open(t: &str) -> bool {
+    t.starts_with("<details>") || t.starts_with("<details ")
+}
+
+/// Whether `text` opens a `<details>` collapse block on any line.
+pub(crate) fn contains_details(text: &str) -> bool {
+    text.lines().any(|line| is_details_open(line.trim_start()))
 }
 
 /// A `# `..`###### ` ATX heading line (1-6 hashes followed by a space).

--- a/src/channels/telegram/rich/inline.rs
+++ b/src/channels/telegram/rich/inline.rs
@@ -54,6 +54,15 @@ pub(super) fn parse_inlines(input: &str) -> Vec<Inline> {
             i += span.len() + 4;
             continue;
         }
+        // `<sub>` small text, emitted by the flow and result cards for their
+        // summary lines. Recognised here so the HTML renderer can drop the
+        // tag instead of escaping it into visible `&lt;sub&gt;`.
+        if let Some(span) = tag_paired(rest, "sub") {
+            flush(&mut text, &mut out);
+            out.push(Inline::Sub(parse_inlines(span)));
+            i += span.len() + "<sub></sub>".len();
+            continue;
+        }
         if let Some(span) = paired(rest, "~~") {
             flush(&mut text, &mut out);
             out.push(Inline::Strike(parse_inlines(span)));
@@ -134,6 +143,18 @@ fn paired_word_bounded<'a>(input: &str, i: usize, rest: &'a str, delim: &str) ->
 fn paired<'a>(rest: &'a str, delim: &str) -> Option<&'a str> {
     let after = rest.strip_prefix(delim)?;
     let close = after.find(delim)?;
+    if close == 0 {
+        return None;
+    }
+    Some(&after[..close])
+}
+
+/// The content of a `<tag>`..`</tag>` pair at the start of `rest`, or `None`
+/// when `rest` does not open that tag or the pair never closes. Only a
+/// well-formed pair becomes a node, so an unmatched opener stays text.
+fn tag_paired<'a>(rest: &'a str, tag: &str) -> Option<&'a str> {
+    let after = rest.strip_prefix(&format!("<{tag}>"))?;
+    let close = after.find(&format!("</{tag}>"))?;
     if close == 0 {
         return None;
     }

--- a/src/channels/telegram/rich/render_html.rs
+++ b/src/channels/telegram/rich/render_html.rs
@@ -312,6 +312,17 @@ fn render_inline(inline: &Inline, s: &mut String, wrap_p: bool) {
         Inline::Bold(c) => wrap(s, "<b>", c, "</b>", wrap_p),
         Inline::Italic(c) => wrap(s, "<i>", c, "</i>", wrap_p),
         Inline::Strike(c) => wrap(s, "<s>", c, "</s>", wrap_p),
+        // Classic Telegram HTML has no <sub>; keep the content and drop the
+        // tag so a downgraded rich message never shows its own markup.
+        Inline::Sub(c) => {
+            if wrap_p {
+                wrap(s, "<sub>", c, "</sub>", wrap_p);
+            } else {
+                for x in c {
+                    render_inline(x, s, wrap_p);
+                }
+            }
+        }
         Inline::Code(t) | Inline::Math(t) => {
             s.push_str("<code>");
             s.push_str(&escape(t));
@@ -348,7 +359,7 @@ fn plain(inlines: &[Inline]) -> String {
 fn plain_one(inline: &Inline, s: &mut String) {
     match inline {
         Inline::Text(t) | Inline::Code(t) | Inline::Math(t) => s.push_str(t),
-        Inline::Bold(c) | Inline::Italic(c) | Inline::Strike(c) => {
+        Inline::Bold(c) | Inline::Italic(c) | Inline::Strike(c) | Inline::Sub(c) => {
             for x in c {
                 plain_one(x, s);
             }

--- a/src/channels/telegram/rich/render_json.rs
+++ b/src/channels/telegram/rich/render_json.rs
@@ -131,6 +131,7 @@ pub(crate) fn render_inline(inline: &Inline) -> Value {
             "type": "strikethrough",
             "content": render_inlines(content),
         }),
+        Inline::Sub(content) => json!({ "type": "sub", "content": render_inlines(content) }),
         Inline::Code(text) => json!({ "type": "code", "text": text }),
         Inline::Math(text) => json!({ "type": "math", "text": text }),
         Inline::Link { content, url } => json!({

--- a/src/memory/db.rs
+++ b/src/memory/db.rs
@@ -537,6 +537,25 @@ impl Store {
         Ok(())
     }
 
+    /// Row counts for the symbol graph tables: (symbols, call_edges, imports).
+    /// Used by logging and benchmark scaffolding.
+    #[cfg(feature = "code-graph")]
+    pub fn symbol_graph_counts(&self) -> Result<(i64, i64, i64), String> {
+        let symbols: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM symbols", [], |r| r.get(0))
+            .map_err(|e| format!("symbol_graph_counts symbols: {e}"))?;
+        let edges: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM call_edges", [], |r| r.get(0))
+            .map_err(|e| format!("symbol_graph_counts call_edges: {e}"))?;
+        let imports: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM imports", [], |r| r.get(0))
+            .map_err(|e| format!("symbol_graph_counts imports: {e}"))?;
+        Ok((symbols, edges, imports))
+    }
+
     /// Insert a symbol into the symbol graph.
     #[cfg(feature = "code-graph")]
     pub fn insert_symbol(
@@ -629,6 +648,7 @@ impl Store {
                 SELECT kind, file_path, start_line, end_line
                 FROM symbols
                 WHERE symbol_name = ?1
+                ORDER BY (file_path LIKE '%/tests/%'), kind
                 ",
             )
             .map_err(|e| format!("query_symbols_by_name prepare: {e}"))?;

--- a/src/memory/db.rs
+++ b/src/memory/db.rs
@@ -484,6 +484,226 @@ impl Store {
         Ok(())
     }
 
+    /// Create symbol graph tables for code-graph feature.
+    ///
+    /// Three tables:
+    /// - `symbols`: function/struct/enum/trait/impl/import definitions
+    /// - `call_edges`: caller → callee relationships
+    /// - `imports`: module import paths
+    #[cfg(feature = "code-graph")]
+    pub fn ensure_symbol_tables(&self) -> Result<(), String> {
+        self.conn
+            .execute_batch(
+                r"
+                CREATE TABLE IF NOT EXISTS symbols (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    symbol_name TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    file_path TEXT NOT NULL,
+                    start_line INTEGER NOT NULL,
+                    end_line INTEGER NOT NULL,
+                    indexed_at TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(symbol_name);
+                CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(file_path);
+                CREATE INDEX IF NOT EXISTS idx_symbols_kind ON symbols(kind);
+
+                CREATE TABLE IF NOT EXISTS call_edges (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    caller_symbol TEXT NOT NULL,
+                    callee_symbol TEXT NOT NULL,
+                    file_path TEXT NOT NULL,
+                    call_line INTEGER NOT NULL,
+                    indexed_at TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_call_edges_caller ON call_edges(caller_symbol);
+                CREATE INDEX IF NOT EXISTS idx_call_edges_callee ON call_edges(callee_symbol);
+
+                CREATE TABLE IF NOT EXISTS imports (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    module_path TEXT NOT NULL,
+                    file_path TEXT NOT NULL,
+                    import_line INTEGER NOT NULL,
+                    indexed_at TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_imports_module ON imports(module_path);
+                CREATE INDEX IF NOT EXISTS idx_imports_file ON imports(file_path);
+                ",
+            )
+            .map_err(|e| format!("ensure_symbol_tables: {e}"))?;
+        Ok(())
+    }
+
+    /// Insert a symbol into the symbol graph.
+    #[cfg(feature = "code-graph")]
+    pub fn insert_symbol(
+        &self,
+        symbol_name: &str,
+        kind: &str,
+        file_path: &str,
+        start_line: usize,
+        end_line: usize,
+    ) -> Result<(), String> {
+        let indexed_at = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                r"
+                INSERT INTO symbols (symbol_name, kind, file_path, start_line, end_line, indexed_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                ",
+                params![
+                    symbol_name,
+                    kind,
+                    file_path,
+                    start_line as i64,
+                    end_line as i64,
+                    indexed_at
+                ],
+            )
+            .map_err(|e| format!("insert_symbol: {e}"))?;
+        Ok(())
+    }
+
+    /// Insert a call edge (caller → callee).
+    #[cfg(feature = "code-graph")]
+    pub fn insert_call_edge(
+        &self,
+        caller_symbol: &str,
+        callee_symbol: &str,
+        file_path: &str,
+        call_line: usize,
+    ) -> Result<(), String> {
+        let indexed_at = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                r"
+                INSERT INTO call_edges (caller_symbol, callee_symbol, file_path, call_line, indexed_at)
+                VALUES (?1, ?2, ?3, ?4, ?5)
+                ",
+                params![
+                    caller_symbol,
+                    callee_symbol,
+                    file_path,
+                    call_line as i64,
+                    indexed_at
+                ],
+            )
+            .map_err(|e| format!("insert_call_edge: {e}"))?;
+        Ok(())
+    }
+
+    /// Insert an import.
+    #[cfg(feature = "code-graph")]
+    pub fn insert_import(
+        &self,
+        module_path: &str,
+        file_path: &str,
+        import_line: usize,
+    ) -> Result<(), String> {
+        let indexed_at = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                r"
+                INSERT INTO imports (module_path, file_path, import_line, indexed_at)
+                VALUES (?1, ?2, ?3, ?4)
+                ",
+                params![module_path, file_path, import_line as i64, indexed_at],
+            )
+            .map_err(|e| format!("insert_import: {e}"))?;
+        Ok(())
+    }
+
+    /// Query symbols by name (exact match).
+    #[cfg(feature = "code-graph")]
+    pub fn query_symbols_by_name(
+        &self,
+        name: &str,
+    ) -> Result<Vec<(String, String, usize, usize)>, String> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                r"
+                SELECT kind, file_path, start_line, end_line
+                FROM symbols
+                WHERE symbol_name = ?1
+                ",
+            )
+            .map_err(|e| format!("query_symbols_by_name prepare: {e}"))?;
+
+        let rows = stmt
+            .query_map(params![name], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)? as usize,
+                    row.get::<_, i64>(3)? as usize,
+                ))
+            })
+            .map_err(|e| format!("query_symbols_by_name: {e}"))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("query_symbols_by_name collect: {e}"))
+    }
+
+    /// Query call edges where the given symbol is the callee (who calls this function?).
+    #[cfg(feature = "code-graph")]
+    pub fn query_callers_of(&self, callee: &str) -> Result<Vec<(String, String, usize)>, String> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                r"
+                SELECT caller_symbol, file_path, call_line
+                FROM call_edges
+                WHERE callee_symbol = ?1
+                ",
+            )
+            .map_err(|e| format!("query_callers_of prepare: {e}"))?;
+
+        let rows = stmt
+            .query_map(params![callee], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)? as usize,
+                ))
+            })
+            .map_err(|e| format!("query_callers_of: {e}"))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("query_callers_of collect: {e}"))
+    }
+
+    /// Query call edges where the given symbol is the caller (what does this function call?).
+    #[cfg(feature = "code-graph")]
+    pub fn query_callees_of(&self, caller: &str) -> Result<Vec<(String, String, usize)>, String> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                r"
+                SELECT callee_symbol, file_path, call_line
+                FROM call_edges
+                WHERE caller_symbol = ?1
+                ",
+            )
+            .map_err(|e| format!("query_callees_of prepare: {e}"))?;
+
+        let rows = stmt
+            .query_map(params![caller], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)? as usize,
+                ))
+            })
+            .map_err(|e| format!("query_callees_of: {e}"))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("query_callees_of collect: {e}"))
+    }
+
     /// Insert (or replace) an embedding for one chunk of a content hash.
     /// `hash_seq` is `{hash}_{seq}` — the key format `vector_search.rs`
     /// reads, so it must not change.

--- a/src/memory/external.rs
+++ b/src/memory/external.rs
@@ -20,6 +20,9 @@ use super::db::Store;
 use super::{COLLECTION_EXTERNAL, external_excludes, extra_paths_config};
 use std::path::PathBuf;
 
+#[cfg(feature = "code-graph")]
+use super::symbol_extractor::SymbolExtractor;
+
 /// One configured extra path after resolution.
 #[derive(Debug)]
 pub(crate) struct ResolvedRoot {
@@ -213,6 +216,10 @@ pub(crate) fn reindex_external(store: &Store) -> ExternalReport {
         .collect();
 
     let mut on_disk: Vec<String> = Vec::new();
+
+    #[cfg(feature = "code-graph")]
+    let mut symbol_extractor = SymbolExtractor::new().ok();
+
     for root in &roots {
         for path in walk_root(root, &excludes) {
             let key = path.to_string_lossy().to_string();
@@ -225,7 +232,58 @@ pub(crate) fn reindex_external(store: &Store) -> ExternalReport {
                         &key,
                         &body,
                     ) {
-                        Ok(true) => report.indexed += 1,
+                        Ok(true) => {
+                            report.indexed += 1;
+
+                            // Extract symbols from Rust files (code-graph feature)
+                            #[cfg(feature = "code-graph")]
+                            if path.extension().and_then(|s| s.to_str()) == Some("rs")
+                                && let Some(ref mut extractor) = symbol_extractor
+                            {
+                                match extractor.extract(&path, &body) {
+                                    Ok((symbols, call_edges)) => {
+                                        // Store symbols (excluding imports)
+                                        for sym in symbols.iter().filter(|s| {
+                                            s.kind != super::symbol_extractor::SymbolKind::Import
+                                        }) {
+                                            let _ = store.insert_symbol(
+                                                &sym.name,
+                                                &sym.kind.to_string(),
+                                                &key,
+                                                sym.start_line,
+                                                sym.end_line,
+                                            );
+                                        }
+
+                                        // Store call edges
+                                        for edge in call_edges {
+                                            let _ = store.insert_call_edge(
+                                                &edge.caller,
+                                                &edge.callee,
+                                                &key,
+                                                edge.line,
+                                            );
+                                        }
+
+                                        // Store imports separately
+                                        for sym in symbols.iter().filter(|s| {
+                                            s.kind == super::symbol_extractor::SymbolKind::Import
+                                        }) {
+                                            let _ = store.insert_import(
+                                                &sym.name,
+                                                &key,
+                                                sym.start_line,
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::debug!(
+                                            "code-graph: failed to extract symbols from {key}: {e}"
+                                        );
+                                    }
+                                }
+                            }
+                        }
                         Ok(false) => {}
                         Err(e) => {
                             tracing::warn!("memory: failed to index external file {key}: {e}")

--- a/src/memory/external.rs
+++ b/src/memory/external.rs
@@ -20,9 +20,6 @@ use super::db::Store;
 use super::{COLLECTION_EXTERNAL, external_excludes, extra_paths_config};
 use std::path::PathBuf;
 
-#[cfg(feature = "code-graph")]
-use super::symbol_extractor::SymbolExtractor;
-
 /// One configured extra path after resolution.
 #[derive(Debug)]
 pub(crate) struct ResolvedRoot {
@@ -217,8 +214,9 @@ pub(crate) fn reindex_external(store: &Store) -> ExternalReport {
 
     let mut on_disk: Vec<String> = Vec::new();
 
-    #[cfg(feature = "code-graph")]
-    let mut symbol_extractor = SymbolExtractor::new().ok();
+    // Symbol extraction happens inside `index_file_sync_keyed` (the single
+    // indexing chokepoint), so both this cold walk and the periodic sweep
+    // populate the graph from one place.
 
     for root in &roots {
         for path in walk_root(root, &excludes) {
@@ -234,55 +232,6 @@ pub(crate) fn reindex_external(store: &Store) -> ExternalReport {
                     ) {
                         Ok(true) => {
                             report.indexed += 1;
-
-                            // Extract symbols from Rust files (code-graph feature)
-                            #[cfg(feature = "code-graph")]
-                            if path.extension().and_then(|s| s.to_str()) == Some("rs")
-                                && let Some(ref mut extractor) = symbol_extractor
-                            {
-                                match extractor.extract(&path, &body) {
-                                    Ok((symbols, call_edges)) => {
-                                        // Store symbols (excluding imports)
-                                        for sym in symbols.iter().filter(|s| {
-                                            s.kind != super::symbol_extractor::SymbolKind::Import
-                                        }) {
-                                            let _ = store.insert_symbol(
-                                                &sym.name,
-                                                &sym.kind.to_string(),
-                                                &key,
-                                                sym.start_line,
-                                                sym.end_line,
-                                            );
-                                        }
-
-                                        // Store call edges
-                                        for edge in call_edges {
-                                            let _ = store.insert_call_edge(
-                                                &edge.caller,
-                                                &edge.callee,
-                                                &key,
-                                                edge.line,
-                                            );
-                                        }
-
-                                        // Store imports separately
-                                        for sym in symbols.iter().filter(|s| {
-                                            s.kind == super::symbol_extractor::SymbolKind::Import
-                                        }) {
-                                            let _ = store.insert_import(
-                                                &sym.name,
-                                                &key,
-                                                sym.start_line,
-                                            );
-                                        }
-                                    }
-                                    Err(e) => {
-                                        tracing::debug!(
-                                            "code-graph: failed to extract symbols from {key}: {e}"
-                                        );
-                                    }
-                                }
-                            }
                         }
                         Ok(false) => {}
                         Err(e) => {

--- a/src/memory/index.rs
+++ b/src/memory/index.rs
@@ -179,6 +179,14 @@ pub(crate) fn index_file_sync_keyed(
         .insert_document(collection, doc_key, &title, &hash, &now, &now)
         .map_err(|e| format!("Failed to insert document: {e}"))?;
 
+    // Symbol-graph chokepoint: every indexing path funnels through here, so
+    // extracting at this one spot covers the cold external walk, the periodic
+    // sweep, and lazy refreshes alike (feature-gated, Rust files only).
+    #[cfg(feature = "code-graph")]
+    if doc_key.ends_with(".rs") {
+        super::symbol_extractor::extract_and_store(store, doc_key, body);
+    }
+
     tracing::debug!("Indexed {collection} document: {doc_key}");
     Ok(true)
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -33,6 +33,8 @@ pub(crate) mod search;
 pub(crate) mod settings;
 pub(crate) mod shared_sessions;
 pub(crate) mod store;
+#[cfg(feature = "code-graph")]
+pub(crate) mod symbol_extractor;
 pub(crate) mod types;
 pub mod vector_search;
 

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -10,6 +10,113 @@ use super::{
     embedding_api_configured,
 };
 
+/// Detect if a query is asking for structural code relationships.
+///
+/// Returns `Some((query_type, symbol))` where query_type is one of:
+/// - "calls" - "who calls X", "what calls X"
+/// - "called_by" - "what does X call", "what X calls"
+/// - "implements" - "show implementations of X", "who implements X"
+/// - "defined_in" - "where is X defined", "show definition of X"
+///
+/// Returns `None` for conceptual queries that should use BM25+vector.
+#[cfg(feature = "code-graph")]
+pub(crate) fn detect_structural_query(query: &str) -> Option<(String, String)> {
+    let query_lower = query.to_lowercase();
+
+    // "who calls X" / "what calls X" → find callers of X
+    if let Some(caps) = regex::Regex::new(r"(?i)(who|what)\s+calls\s+([a-zA-Z_][a-zA-Z0-9_]*)")
+        .ok()
+        .and_then(|re| re.captures(&query_lower))
+    {
+        return Some(("calls".to_string(), caps[2].to_string()));
+    }
+
+    // "what does X call" / "what X calls" → find callees of X
+    if let Some(caps) = regex::Regex::new(r"(?i)what\s+(?:does\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\s+call")
+        .ok()
+        .and_then(|re| re.captures(&query_lower))
+    {
+        return Some(("called_by".to_string(), caps[1].to_string()));
+    }
+
+    // "show implementations of X" / "who implements X" → find impl blocks
+    if let Some(caps) = regex::Regex::new(
+        r"(?i)(?:show\s+)?(?:implementations?\s+of|who\s+implements)\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+    )
+    .ok()
+    .and_then(|re| re.captures(&query_lower))
+    {
+        return Some(("implements".to_string(), caps[1].to_string()));
+    }
+
+    // "where is X defined" / "show definition of X" → find symbol definition
+    if let Some(caps) = regex::Regex::new(
+        r"(?i)(?:where\s+is|show\s+(?:the\s+)?definition\s+of)\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+    )
+    .ok()
+    .and_then(|re| re.captures(&query_lower))
+    {
+        return Some(("defined_in".to_string(), caps[1].to_string()));
+    }
+
+    None
+}
+
+/// Execute a structural query against the symbol graph.
+#[cfg(feature = "code-graph")]
+fn search_symbol_graph(
+    store: &Store,
+    query_type: &str,
+    symbol: &str,
+    n: usize,
+) -> Result<Vec<MemoryResult>, String> {
+    match query_type {
+        "calls" => {
+            // Find who calls this symbol
+            let callers = store.query_callers_of(symbol)?;
+            Ok(callers
+                .into_iter()
+                .take(n)
+                .map(|(caller, file_path, line)| MemoryResult {
+                    path: file_path,
+                    snippet: format!("{} calls {} at line {}", caller, symbol, line),
+                    rank: 1.0,
+                })
+                .collect())
+        }
+        "called_by" => {
+            // Find what this symbol calls
+            let callees = store.query_callees_of(symbol)?;
+            Ok(callees
+                .into_iter()
+                .take(n)
+                .map(|(callee, file_path, line)| MemoryResult {
+                    path: file_path,
+                    snippet: format!("{} calls {} at line {}", symbol, callee, line),
+                    rank: 1.0,
+                })
+                .collect())
+        }
+        "implements" | "defined_in" => {
+            // Find symbol definitions
+            let symbols = store.query_symbols_by_name(symbol)?;
+            Ok(symbols
+                .into_iter()
+                .take(n)
+                .map(|(kind, file_path, start_line, end_line)| MemoryResult {
+                    path: file_path,
+                    snippet: format!(
+                        "{} {} defined at lines {}-{}",
+                        kind, symbol, start_line, end_line
+                    ),
+                    rank: 1.0,
+                })
+                .collect())
+        }
+        _ => Ok(vec![]),
+    }
+}
+
 /// Hybrid search across ALL collections in the store: FTS5 (BM25) + vector
 /// (cosine) via RRF.
 ///
@@ -47,11 +154,23 @@ pub(crate) async fn search_memory(
 /// mtime moved and re-query once, so an in-place edit is reflected. The
 /// tier-2 sweep handles additions and deletions; this catches content edits
 /// that don't bump the parent directory's mtime.
+///
+/// Structural queries (code-graph feature): "who calls X", "what does X call",
+/// etc. route to the symbol graph instead of BM25+vector search.
 pub(crate) async fn search_external(
     store: &'static Mutex<Store>,
     query: &str,
     n: usize,
 ) -> Result<Vec<MemoryResult>, String> {
+    // Check for structural query (code-graph feature)
+    #[cfg(feature = "code-graph")]
+    if let Some((query_type, symbol)) = detect_structural_query(query) {
+        let store_lock = store
+            .lock()
+            .map_err(|e| format!("Store lock poisoned: {e}"))?;
+        return search_symbol_graph(&store_lock, &query_type, &symbol, n);
+    }
+
     let results = search_core(store, query, n, Some(COLLECTION_EXTERNAL)).await?;
     let paths: Vec<String> = results.iter().map(|r| r.path.clone()).collect();
     if super::freshness::refresh_stale_external(&paths).await > 0 {
@@ -419,4 +538,76 @@ pub fn hybrid_search_rrf(
     });
 
     results
+}
+
+#[cfg(all(test, feature = "code-graph"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_structural_query_calls() {
+        let result = detect_structural_query("who calls process_message");
+        assert_eq!(
+            result,
+            Some(("calls".to_string(), "process_message".to_string()))
+        );
+
+        let result = detect_structural_query("what calls validate_input");
+        assert_eq!(
+            result,
+            Some(("calls".to_string(), "validate_input".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_detect_structural_query_called_by() {
+        let result = detect_structural_query("what does process_message call");
+        assert_eq!(
+            result,
+            Some(("called_by".to_string(), "process_message".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_detect_structural_query_implements() {
+        let result = detect_structural_query("show implementations of Drawable");
+        assert_eq!(
+            result,
+            Some(("implements".to_string(), "drawable".to_string()))
+        );
+
+        let result = detect_structural_query("who implements Serializable");
+        assert_eq!(
+            result,
+            Some(("implements".to_string(), "serializable".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_detect_structural_query_defined_in() {
+        let result = detect_structural_query("where is process_message defined");
+        assert_eq!(
+            result,
+            Some(("defined_in".to_string(), "process_message".to_string()))
+        );
+
+        let result = detect_structural_query("show definition of validate_input");
+        assert_eq!(
+            result,
+            Some(("defined_in".to_string(), "validate_input".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_detect_structural_query_conceptual() {
+        // These should NOT match structural patterns
+        let result = detect_structural_query("context compaction");
+        assert_eq!(result, None);
+
+        let result = detect_structural_query("telegram rich cards");
+        assert_eq!(result, None);
+
+        let result = detect_structural_query("how does memory search work");
+        assert_eq!(result, None);
+    }
 }

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -81,10 +81,24 @@ fn build_store(db_path: &Path) -> Result<Store, String> {
             tracing::info!("Vector table created with {dims} dimensions");
         }
 
+        // Create symbol tables when code-graph feature is enabled
+        #[cfg(feature = "code-graph")]
+        {
+            store
+                .ensure_symbol_tables()
+                .map_err(|e| format!("Failed to create symbol tables: {e}"))?;
+            tracing::info!("Symbol graph tables created (code-graph feature)");
+        }
+
         tracing::info!(
-            "Memory store ready at {} (vector: {})",
+            "Memory store ready at {} (vector: {}, code-graph: {})",
             db_path.display(),
             if super::vector_enabled() {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            if cfg!(feature = "code-graph") {
                 "enabled"
             } else {
                 "disabled"

--- a/src/memory/symbol_extractor.rs
+++ b/src/memory/symbol_extractor.rs
@@ -1,0 +1,349 @@
+//! Tree-sitter based symbol extraction for Rust source files.
+//!
+//! Parses `.rs` files into ASTs and extracts:
+//! - Function definitions (name, file, line range)
+//! - Function calls (caller → callee edges)
+//! - Struct/enum/trait definitions
+//! - impl blocks (trait implementations)
+//! - Use statements (imports)
+//!
+//! Feature-gated behind `code-graph`.
+
+#[cfg(feature = "code-graph")]
+use std::path::Path;
+#[cfg(feature = "code-graph")]
+use tree_sitter::{Node, Parser};
+
+/// A symbol extracted from source code.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Symbol {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub file_path: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymbolKind {
+    Function,
+    Struct,
+    Enum,
+    Trait,
+    Impl,
+    Import,
+}
+
+impl std::fmt::Display for SymbolKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SymbolKind::Function => write!(f, "function"),
+            SymbolKind::Struct => write!(f, "struct"),
+            SymbolKind::Enum => write!(f, "enum"),
+            SymbolKind::Trait => write!(f, "trait"),
+            SymbolKind::Impl => write!(f, "impl"),
+            SymbolKind::Import => write!(f, "import"),
+        }
+    }
+}
+
+/// A call edge: caller function calls callee function.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallEdge {
+    pub caller: String,
+    pub callee: String,
+    pub file_path: String,
+    pub line: usize,
+}
+
+/// Extracts symbols and call graphs from Rust source files using tree-sitter.
+#[cfg(feature = "code-graph")]
+pub struct SymbolExtractor {
+    parser: Parser,
+}
+
+#[cfg(feature = "code-graph")]
+impl SymbolExtractor {
+    pub fn new() -> Result<Self, anyhow::Error> {
+        let mut parser = Parser::new();
+        let language = tree_sitter_rust::LANGUAGE;
+        parser.set_language(&language.into())?;
+        Ok(Self { parser })
+    }
+
+    /// Parse a Rust file and extract all symbols and call edges.
+    pub fn extract(
+        &mut self,
+        file_path: &Path,
+        source: &str,
+    ) -> Result<(Vec<Symbol>, Vec<CallEdge>), anyhow::Error> {
+        let tree = self
+            .parser
+            .parse(source, None)
+            .ok_or_else(|| anyhow::anyhow!("Failed to parse {}", file_path.display()))?;
+
+        let file_path_str = file_path.to_string_lossy().to_string();
+        let mut symbols = Vec::new();
+        let mut call_edges = Vec::new();
+
+        self.extract_from_node(
+            tree.root_node(),
+            source,
+            &file_path_str,
+            None, // no current function context at root
+            &mut symbols,
+            &mut call_edges,
+        );
+
+        Ok((symbols, call_edges))
+    }
+
+    fn extract_from_node(
+        &self,
+        node: Node,
+        source: &str,
+        file_path: &str,
+        current_function: Option<&str>,
+        symbols: &mut Vec<Symbol>,
+        call_edges: &mut Vec<CallEdge>,
+    ) {
+        let kind = node.kind();
+
+        match kind {
+            "function_item" => {
+                if let Some(name) = self.extract_function_name(node, source) {
+                    let start_line = node.start_position().row;
+                    let end_line = node.end_position().row;
+                    symbols.push(Symbol {
+                        name: name.clone(),
+                        kind: SymbolKind::Function,
+                        file_path: file_path.to_string(),
+                        start_line,
+                        end_line,
+                    });
+
+                    // Recurse into function body with this function as context
+                    for child in node.children(&mut node.walk()) {
+                        self.extract_from_node(
+                            child,
+                            source,
+                            file_path,
+                            Some(&name),
+                            symbols,
+                            call_edges,
+                        );
+                    }
+                }
+            }
+            "struct_item" => {
+                if let Some(name) = self.extract_type_name(node, source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Struct,
+                        file_path: file_path.to_string(),
+                        start_line: node.start_position().row,
+                        end_line: node.end_position().row,
+                    });
+                }
+            }
+            "enum_item" => {
+                if let Some(name) = self.extract_type_name(node, source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Enum,
+                        file_path: file_path.to_string(),
+                        start_line: node.start_position().row,
+                        end_line: node.end_position().row,
+                    });
+                }
+            }
+            "trait_item" => {
+                if let Some(name) = self.extract_type_name(node, source) {
+                    symbols.push(Symbol {
+                        name,
+                        kind: SymbolKind::Trait,
+                        file_path: file_path.to_string(),
+                        start_line: node.start_position().row,
+                        end_line: node.end_position().row,
+                    });
+                }
+            }
+            "impl_item" => {
+                // Extract impl block (trait implementation)
+                let impl_name = self.extract_impl_name(node, source);
+                symbols.push(Symbol {
+                    name: impl_name,
+                    kind: SymbolKind::Impl,
+                    file_path: file_path.to_string(),
+                    start_line: node.start_position().row,
+                    end_line: node.end_position().row,
+                });
+            }
+            "use_declaration" => {
+                // Extract import
+                let import_path = self.extract_use_path(node, source);
+                symbols.push(Symbol {
+                    name: import_path,
+                    kind: SymbolKind::Import,
+                    file_path: file_path.to_string(),
+                    start_line: node.start_position().row,
+                    end_line: node.end_position().row,
+                });
+            }
+            "call_expression" => {
+                // Extract function call
+                if let (Some(caller), Some(callee)) =
+                    (current_function, self.extract_callee(node, source))
+                {
+                    call_edges.push(CallEdge {
+                        caller: caller.to_string(),
+                        callee,
+                        file_path: file_path.to_string(),
+                        line: node.start_position().row,
+                    });
+                }
+            }
+            _ => {
+                // Recurse into children
+                for child in node.children(&mut node.walk()) {
+                    self.extract_from_node(
+                        child,
+                        source,
+                        file_path,
+                        current_function,
+                        symbols,
+                        call_edges,
+                    );
+                }
+            }
+        }
+    }
+
+    fn extract_function_name(&self, node: Node, source: &str) -> Option<String> {
+        node.child_by_field_name("name")
+            .map(|n| n.utf8_text(source.as_bytes()).unwrap_or("").to_string())
+    }
+
+    fn extract_type_name(&self, node: Node, source: &str) -> Option<String> {
+        node.child_by_field_name("name")
+            .map(|n| n.utf8_text(source.as_bytes()).unwrap_or("").to_string())
+    }
+
+    fn extract_impl_name(&self, node: Node, source: &str) -> String {
+        // Try to extract "impl Trait for Type" or "impl Type"
+        let mut result = String::from("impl");
+        if let Some(type_node) = node.child_by_field_name("type") {
+            let type_name = type_node.utf8_text(source.as_bytes()).unwrap_or("");
+            result.push(' ');
+            result.push_str(type_name);
+        }
+        result
+    }
+
+    fn extract_use_path(&self, node: Node, source: &str) -> String {
+        // Extract the full use path (e.g., "std::collections::HashMap")
+        node.child_by_field_name("argument")
+            .map(|n| n.utf8_text(source.as_bytes()).unwrap_or("").to_string())
+            .unwrap_or_else(|| "use".to_string())
+    }
+
+    fn extract_callee(&self, node: Node, source: &str) -> Option<String> {
+        // Extract the function being called
+        node.child_by_field_name("function")
+            .map(|n| n.utf8_text(source.as_bytes()).unwrap_or("").to_string())
+    }
+}
+
+#[cfg(all(test, feature = "code-graph"))]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_extract_function() {
+        let source = r#"
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (symbols, _edges) = extractor.extract(&path, source).unwrap();
+
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "add");
+        assert_eq!(symbols[0].kind, SymbolKind::Function);
+    }
+
+    #[test]
+    fn test_extract_struct() {
+        let source = r#"
+pub struct Point {
+    x: f64,
+    y: f64,
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (symbols, _edges) = extractor.extract(&path, source).unwrap();
+
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "Point");
+        assert_eq!(symbols[0].kind, SymbolKind::Struct);
+    }
+
+    #[test]
+    fn test_extract_call_edge() {
+        let source = r#"
+fn caller() {
+    callee();
+}
+
+fn callee() {
+    println!("called");
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (symbols, edges) = extractor.extract(&path, source).unwrap();
+
+        assert_eq!(symbols.len(), 2); // caller, callee
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].caller, "caller");
+        assert_eq!(edges[0].callee, "callee");
+    }
+
+    #[test]
+    fn test_extract_trait() {
+        let source = r#"
+pub trait Drawable {
+    fn draw(&self);
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (symbols, _edges) = extractor.extract(&path, source).unwrap();
+
+        assert!(
+            symbols
+                .iter()
+                .any(|s| s.name == "Drawable" && s.kind == SymbolKind::Trait)
+        );
+    }
+
+    #[test]
+    fn test_extract_impl() {
+        let source = r#"
+struct Circle;
+
+impl Drawable for Circle {
+    fn draw(&self) {}
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (symbols, _edges) = extractor.extract(&path, source).unwrap();
+
+        assert!(symbols.iter().any(|s| s.kind == SymbolKind::Impl));
+    }
+}

--- a/src/memory/symbol_extractor.rs
+++ b/src/memory/symbol_extractor.rs
@@ -248,9 +248,77 @@ impl SymbolExtractor {
     }
 
     fn extract_callee(&self, node: Node, source: &str) -> Option<String> {
-        // Extract the function being called
-        node.child_by_field_name("function")
-            .map(|n| n.utf8_text(source.as_bytes()).unwrap_or("").to_string())
+        // Extract the function being called.
+        // Receiver-qualified calls (`store.insert_symbol(..)`, `lines.push(..)`)
+        // are normalized to the bare method name (`insert_symbol`, `push`):
+        // the receiver is a local variable name that carries no lookup value,
+        // and callers-of queries search by bare method name. Module paths
+        // (`Arc::new`, `Vec::new`) keep their full path — no `.` receiver.
+        let raw = node
+            .child_by_field_name("function")
+            .map(|n| n.utf8_text(source.as_bytes()).unwrap_or("").to_string())?;
+        let callee = match raw.rsplit_once('.') {
+            Some((_, method)) => method.to_string(),
+            None => raw,
+        };
+        // Skip enum-variant constructor noise: `Some(x)`, `Ok(x)`, `Err(e)`.
+        // tree-sitter cannot distinguish these from function calls
+        // syntactically, and they otherwise dominate the edge table
+        // (1278 + 698 edges of garbage in the 1383-file repo benchmark).
+        if matches!(callee.as_str(), "Some" | "Ok" | "Err" | "None") {
+            return None;
+        }
+        Some(callee)
+    }
+}
+
+/// Extract symbols, call edges and imports from one Rust source file and
+/// store them in the symbol graph.
+///
+/// Called from the indexing chokepoint (`index::index_file_sync_keyed`) so
+/// every path that indexes content — cold external walk, periodic sweep,
+/// lazy refresh — populates the graph from one place. Creating a fresh
+/// `SymbolExtractor` per file is deliberate: the chokepoint is a free
+/// function with no state to carry a parser across calls, and parser
+/// construction is a cheap once-per-file allocation.
+#[cfg(feature = "code-graph")]
+pub(crate) fn extract_and_store(store: &super::db::Store, key: &str, body: &str) {
+    let mut extractor = match SymbolExtractor::new() {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!("code-graph: extractor init failed: {e}");
+            return;
+        }
+    };
+    let path = std::path::Path::new(key);
+    match extractor.extract(path, body) {
+        Ok((symbols, call_edges)) => {
+            // Definitions (everything except imports)
+            for sym in symbols.iter().filter(|s| s.kind != SymbolKind::Import) {
+                if let Err(e) = store.insert_symbol(
+                    &sym.name,
+                    &sym.kind.to_string(),
+                    key,
+                    sym.start_line,
+                    sym.end_line,
+                ) {
+                    tracing::debug!("code-graph: insert_symbol {key} {}: {e}", sym.name);
+                }
+            }
+            // Caller -> callee edges
+            for edge in call_edges {
+                if let Err(e) = store.insert_call_edge(&edge.caller, &edge.callee, key, edge.line) {
+                    tracing::debug!("code-graph: insert_call_edge {key} {}: {e}", edge.caller);
+                }
+            }
+            // Imports tracked separately
+            for sym in symbols.iter().filter(|s| s.kind == SymbolKind::Import) {
+                if let Err(e) = store.insert_import(&sym.name, key, sym.start_line) {
+                    tracing::debug!("code-graph: insert_import {key} {}: {e}", sym.name);
+                }
+            }
+        }
+        Err(e) => tracing::debug!("code-graph: failed to extract symbols from {key}: {e}"),
     }
 }
 
@@ -345,5 +413,70 @@ impl Drawable for Circle {
         let (symbols, _edges) = extractor.extract(&path, source).unwrap();
 
         assert!(symbols.iter().any(|s| s.kind == SymbolKind::Impl));
+    }
+
+    #[test]
+    fn test_method_call_normalized_to_bare_name() {
+        // `store.insert_symbol(..)` must land as callee `insert_symbol`
+        // (receiver-qualified storage broke callers-of queries — benchmark
+        // found 0 callers of insert_symbol despite 37k edges).
+        let source = r#"
+fn populate(store: &Store) {
+    store.insert_symbol("a", "function", "f.rs", 1, 2);
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (_symbols, edges) = extractor.extract(&path, source).unwrap();
+
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.caller == "populate" && e.callee == "insert_symbol")
+        );
+    }
+
+    #[test]
+    fn test_enum_variant_constructors_skipped() {
+        // Some/Ok/Err are not functions; they polluted the top of the
+        // callee table (1278 + 698 edges) before the denylist.
+        let source = r#"
+fn wrap(x: u32) -> Option<u32> {
+    let a = Some(x);
+    let b = Ok(1u32);
+    inner(a)
+}
+fn inner(_v: Option<u32>) {}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (_symbols, edges) = extractor.extract(&path, source).unwrap();
+
+        assert!(!edges.iter().any(|e| e.callee == "Some" || e.callee == "Ok"));
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.caller == "wrap" && e.callee == "inner")
+        );
+    }
+
+    #[test]
+    fn test_module_path_call_kept_full() {
+        // `Arc::new` has no `.` receiver — a true module path, kept intact.
+        let source = r#"
+use std::sync::Arc;
+fn share() -> Arc<u32> {
+    Arc::new(1u32)
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (_symbols, edges) = extractor.extract(&path, source).unwrap();
+
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.caller == "share" && e.callee == "Arc::new")
+        );
     }
 }

--- a/src/tests/memory_symbol_extractor_test.rs
+++ b/src/tests/memory_symbol_extractor_test.rs
@@ -276,3 +276,54 @@ fn test_symbol_kinds() {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].0, "function");
 }
+
+/// Benchmark scaffolding: populate the LIVE profile store's symbol graph
+/// from a real repository, bypassing the document layer (the external sweep
+/// already indexed the files as FTS documents; this backfills symbols for
+/// them in one pass).
+///
+/// Ignored by default — run explicitly with:
+///   cargo test --features code-graph --lib populate_live_symbol_graph -- --ignored --nocapture
+#[test]
+#[ignore = "writes to the live profile memory.db — benchmark scaffolding"]
+fn populate_live_symbol_graph() {
+    let repo = "/Users/adolfousierstudio/srv/rs/opencrabs";
+    let db_path = crate::config::opencrabs_home().join("memory/memory.db");
+    let store = Store::open(&db_path).expect("open live store");
+    store.ensure_symbol_tables().expect("ensure symbol tables");
+
+    let mut files = 0usize;
+    let mut failures = 0usize;
+    let mut stack = vec![std::path::PathBuf::from(repo)];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if path.is_dir() {
+                if name != "target" && name != ".git" && name != "node_modules" {
+                    stack.push(path);
+                }
+            } else if name.ends_with(".rs") {
+                let key = path.to_string_lossy().to_string();
+                match std::fs::read_to_string(&path) {
+                    Ok(body) => {
+                        files += 1;
+                        crate::memory::symbol_extractor::extract_and_store(&store, &key, &body);
+                    }
+                    Err(_) => failures += 1,
+                }
+            }
+        }
+    }
+
+    let (symbols, edges, imports) = store.symbol_graph_counts().unwrap();
+    println!(
+        "populated: files={files} failures={failures} symbols={symbols} call_edges={edges} imports={imports}"
+    );
+    assert!(files > 1000, "expected the whole repo, got {files} files");
+    assert!(symbols > 0, "no symbols extracted");
+}

--- a/src/tests/memory_symbol_extractor_test.rs
+++ b/src/tests/memory_symbol_extractor_test.rs
@@ -1,0 +1,278 @@
+//! Integration tests for code-graph symbol extraction pipeline.
+//!
+//! Tests the full flow: index Rust file → extract symbols → store in DB →
+//! query symbol graph → verify results.
+
+#![cfg(feature = "code-graph")]
+
+use crate::memory::db::Store;
+use crate::memory::search::detect_structural_query;
+use crate::memory::symbol_extractor::{SymbolExtractor, SymbolKind};
+use tempfile::TempDir;
+
+/// Sample Rust code with known symbols and call relationships.
+const SAMPLE_CODE: &str = r#"
+use std::collections::HashMap;
+
+pub struct Config {
+    pub name: String,
+    pub value: i32,
+}
+
+pub trait Processor {
+    fn process(&self, data: &str) -> Result<String, String>;
+}
+
+impl Processor for Config {
+    fn process(&self, data: &str) -> Result<String, String> {
+        Ok(format!("{}: {}", self.name, data))
+    }
+}
+
+pub fn validate_input(input: &str) -> bool {
+    !input.is_empty()
+}
+
+pub fn process_message(msg: &str) -> String {
+    if validate_input(msg) {
+        let config = Config {
+            name: "test".to_string(),
+            value: 42,
+        };
+        config.process(msg).unwrap_or_default()
+    } else {
+        String::new()
+    }
+}
+
+pub fn main() {
+    let result = process_message("hello");
+    println!("{}", result);
+}
+"#;
+
+#[test]
+fn test_full_pipeline_extract_and_query() {
+    // Create a temporary directory for the test database
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test_memory.db");
+
+    // Open a fresh store
+    let store = Store::open(&db_path).unwrap();
+    store.ensure_symbol_tables().unwrap();
+
+    // Create a sample Rust file
+    let sample_file = temp_dir.path().join("sample.rs");
+    std::fs::write(&sample_file, SAMPLE_CODE).unwrap();
+
+    // Extract symbols using SymbolExtractor
+    let mut extractor = SymbolExtractor::new().unwrap();
+    let (symbols, call_edges) = extractor.extract(&sample_file, SAMPLE_CODE).unwrap();
+
+    // Verify we extracted expected symbols
+    let symbol_names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        symbol_names.contains(&"Config"),
+        "Should extract Config struct"
+    );
+    assert!(
+        symbol_names.contains(&"Processor"),
+        "Should extract Processor trait"
+    );
+    assert!(
+        symbol_names.contains(&"validate_input"),
+        "Should extract validate_input function"
+    );
+    assert!(
+        symbol_names.contains(&"process_message"),
+        "Should extract process_message function"
+    );
+
+    // Verify we extracted call edges
+    assert!(
+        !call_edges.is_empty(),
+        "Should extract at least one call edge"
+    );
+    let process_message_calls: Vec<_> = call_edges
+        .iter()
+        .filter(|e| e.caller == "process_message")
+        .collect();
+    assert!(
+        !process_message_calls.is_empty(),
+        "process_message should call other functions"
+    );
+
+    // Store symbols in database
+    for symbol in &symbols {
+        if symbol.kind != SymbolKind::Import {
+            store
+                .insert_symbol(
+                    &symbol.name,
+                    &symbol.kind.to_string(),
+                    sample_file.to_str().unwrap(),
+                    symbol.start_line,
+                    symbol.end_line,
+                )
+                .unwrap();
+        }
+    }
+
+    // Store call edges
+    for edge in &call_edges {
+        store
+            .insert_call_edge(
+                &edge.caller,
+                &edge.callee,
+                sample_file.to_str().unwrap(),
+                edge.line,
+            )
+            .unwrap();
+    }
+
+    // Test structural query: who calls validate_input?
+    let callers = store.query_callers_of("validate_input").unwrap();
+    assert!(!callers.is_empty(), "Should find callers of validate_input");
+    let caller_names: Vec<&str> = callers.iter().map(|(c, _, _)| c.as_str()).collect();
+    assert!(
+        caller_names.contains(&"process_message"),
+        "process_message should call validate_input"
+    );
+
+    // Test structural query: what does process_message call?
+    let callees = store.query_callees_of("process_message").unwrap();
+    assert!(
+        !callees.is_empty(),
+        "Should find callees of process_message"
+    );
+    let callee_names: Vec<&str> = callees.iter().map(|(c, _, _)| c.as_str()).collect();
+    assert!(
+        callee_names.contains(&"validate_input"),
+        "process_message should call validate_input"
+    );
+
+    // Test structural query: where is Config defined?
+    let config_defs = store.query_symbols_by_name("Config").unwrap();
+    assert!(!config_defs.is_empty(), "Should find Config definition");
+    let (kind, file, start, _end) = &config_defs[0];
+    assert_eq!(kind, "struct", "Config should be a struct");
+    assert!(file.contains("sample.rs"), "Config should be in sample.rs");
+    assert!(*start > 0, "Config should have a valid start line");
+}
+
+#[test]
+fn test_structural_query_patterns() {
+    // Test "who calls X"
+    let result = detect_structural_query("who calls process_message");
+    assert!(result.is_some());
+    let (query_type, symbol) = result.unwrap();
+    assert_eq!(query_type, "calls");
+    assert_eq!(symbol, "process_message");
+
+    // Test "what does X call"
+    let result = detect_structural_query("what does validate_input call");
+    assert!(result.is_some());
+    let (query_type, symbol) = result.unwrap();
+    assert_eq!(query_type, "called_by");
+    assert_eq!(symbol, "validate_input");
+
+    // Test "show implementations of X"
+    let result = detect_structural_query("show implementations of Processor");
+    assert!(result.is_some());
+    let (query_type, symbol) = result.unwrap();
+    assert_eq!(query_type, "implements");
+    assert_eq!(symbol, "processor");
+
+    // Test "where is X defined"
+    let result = detect_structural_query("where is Config defined");
+    assert!(result.is_some());
+    let (query_type, symbol) = result.unwrap();
+    assert_eq!(query_type, "defined_in");
+    assert_eq!(symbol, "config");
+
+    // Test conceptual query (should NOT match)
+    let result = detect_structural_query("context compaction");
+    assert!(
+        result.is_none(),
+        "Conceptual queries should not match structural patterns"
+    );
+}
+
+#[test]
+fn test_call_graph_integrity() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test_memory.db");
+    let store = Store::open(&db_path).unwrap();
+    store.ensure_symbol_tables().unwrap();
+
+    // Insert symbols
+    store
+        .insert_symbol("main", "function", "main.rs", 1, 5)
+        .unwrap();
+    store
+        .insert_symbol("process_message", "function", "main.rs", 10, 20)
+        .unwrap();
+    store
+        .insert_symbol("validate_input", "function", "main.rs", 25, 30)
+        .unwrap();
+
+    // Insert call edges
+    store
+        .insert_call_edge("main", "process_message", "main.rs", 3)
+        .unwrap();
+    store
+        .insert_call_edge("process_message", "validate_input", "main.rs", 12)
+        .unwrap();
+
+    // Query: who calls process_message?
+    let callers = store.query_callers_of("process_message").unwrap();
+    assert_eq!(callers.len(), 1);
+    assert_eq!(callers[0].0, "main");
+
+    // Query: what does main call?
+    let callees = store.query_callees_of("main").unwrap();
+    assert_eq!(callees.len(), 1);
+    assert_eq!(callees[0].0, "process_message");
+
+    // Query: who calls validate_input?
+    let callers = store.query_callers_of("validate_input").unwrap();
+    assert_eq!(callers.len(), 1);
+    assert_eq!(callers[0].0, "process_message");
+}
+
+#[test]
+fn test_symbol_kinds() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test_memory.db");
+    let store = Store::open(&db_path).unwrap();
+    store.ensure_symbol_tables().unwrap();
+
+    // Insert different symbol kinds
+    store
+        .insert_symbol("MyStruct", "struct", "lib.rs", 1, 5)
+        .unwrap();
+    store
+        .insert_symbol("MyEnum", "enum", "lib.rs", 10, 15)
+        .unwrap();
+    store
+        .insert_symbol("MyTrait", "trait", "lib.rs", 20, 25)
+        .unwrap();
+    store
+        .insert_symbol("process", "function", "lib.rs", 30, 40)
+        .unwrap();
+    store
+        .insert_symbol("std::collections::HashMap", "import", "lib.rs", 1, 1)
+        .unwrap();
+
+    // Query by name
+    let results = store.query_symbols_by_name("MyStruct").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, "struct");
+
+    let results = store.query_symbols_by_name("MyTrait").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, "trait");
+
+    let results = store.query_symbols_by_name("process").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, "function");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -267,6 +267,8 @@ pub mod memory_search_scope_test;
 pub mod memory_search_test;
 pub mod memory_store_profile_test;
 pub mod memory_store_test;
+#[cfg(feature = "code-graph")]
+pub mod memory_symbol_extractor_test;
 pub mod menu_auto_solo_test;
 #[cfg(feature = "telegram")]
 pub mod menu_refresh_test;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -350,6 +350,7 @@ pub mod tasks_list_test;
 pub mod telegram_callback_session_topic_test;
 pub mod telegram_cancel_token_no_drop_test;
 pub mod telegram_dedup_approval_test;
+pub mod telegram_details_fallback_render_test;
 #[cfg(feature = "telegram")]
 pub mod telegram_general_topic_delivery_test;
 #[cfg(feature = "telegram")]

--- a/src/tests/ralph_verification_gate_test.rs
+++ b/src/tests/ralph_verification_gate_test.rs
@@ -361,7 +361,12 @@ fn criteria_policy_parses_each_variant_lowercase() {
 /// from. A plan in one repo was gated on another repo's build.
 #[test]
 fn verification_runs_in_the_directory_it_is_given() {
-    let dir = std::env::temp_dir().join("opencrabs_ralph_cwd_test");
+    // Unique per process. A fixed name under the shared temp dir is one
+    // mutable global: two concurrent `cargo test` runs execute this test
+    // against the SAME directory, and whichever finishes first deletes it out
+    // from under the other. That made this fail intermittently in a full
+    // suite while passing in isolation.
+    let dir = std::env::temp_dir().join(format!("opencrabs_ralph_cwd_test-{}", std::process::id()));
     std::fs::create_dir_all(&dir).expect("create temp dir");
     // macOS reports /var/... as /private/var/..., so compare resolved paths.
     let expected = dir.canonicalize().expect("canonicalize temp dir");
@@ -382,7 +387,10 @@ fn verification_runs_in_the_directory_it_is_given() {
 /// when the two differ.
 #[test]
 fn verification_directory_is_not_the_process_cwd() {
-    let dir = std::env::temp_dir().join("opencrabs_ralph_cwd_differs");
+    let dir = std::env::temp_dir().join(format!(
+        "opencrabs_ralph_cwd_differs-{}",
+        std::process::id()
+    ));
     std::fs::create_dir_all(&dir).expect("create temp dir");
     let expected = dir.canonicalize().expect("canonicalize temp dir");
     let process_cwd = std::env::current_dir().expect("process cwd");

--- a/src/tests/telegram_details_fallback_render_test.rs
+++ b/src/tests/telegram_details_fallback_render_test.rs
@@ -1,0 +1,102 @@
+//! A `<details>` collapse that fails its native rich send must still render
+//! through the rich AST on the HTML fallback.
+//!
+//! `should_send_native_rich` routes a collapse block to `sendRichMessage`
+//! because `has_rich_structure` matches the `<details>` opener. When that
+//! send fails on a transport error the ladder retries through
+//! `markdown_to_telegram_html`, which picks its renderer with
+//! `prefers_rich_render`. That predicate used to cover only tables and task
+//! lists, so a collapse fell to the line-based ladder, which escapes unknown
+//! tags — the `<details>`, `<summary>` and `<sub>` markup surfaced as visible
+//! text in the delivered message instead of collapsing.
+
+use crate::channels::telegram::markdown::markdown_to_telegram_html;
+use crate::channels::telegram::rich::detect::{
+    contains_details, has_rich_structure, is_details_open, prefers_rich_render,
+};
+
+/// The background-task result card shape emitted by `resume.rs`: a block-form
+/// opener, a `<sub>` summary and a fenced body.
+fn result_card() -> String {
+    "<details>\n<summary><sub>✅ `build` 🕒 1s</sub></summary>\n\n\
+     ```\ntest result: FAILED. 0 passed; 5 failed\n```\n\n</details>"
+        .to_string()
+}
+
+#[test]
+fn details_opener_matches_bare_and_attributed_forms() {
+    assert!(is_details_open("<details>"));
+    assert!(is_details_open("<details open>"));
+    assert!(is_details_open("<details><summary>inline</summary>"));
+    assert!(!is_details_open("</details>"));
+    assert!(!is_details_open("details about the failure"));
+}
+
+#[test]
+fn contains_details_finds_an_indented_opener() {
+    assert!(contains_details(&result_card()));
+    assert!(contains_details("intro\n  <details open>\nbody"));
+    assert!(!contains_details("no collapse here\njust prose"));
+}
+
+/// The two predicates must agree on collapse blocks: whichever one sends it
+/// rich, the other has to render it rich on the way back down.
+#[test]
+fn rich_gate_and_fallback_renderer_agree_on_details() {
+    let card = result_card();
+    assert!(
+        has_rich_structure(&card),
+        "collapse must qualify for the native rich send"
+    );
+    assert!(
+        prefers_rich_render(&card),
+        "the HTML fallback must render the same collapse through the rich AST"
+    );
+}
+
+/// A collapse with no table and no task list is the exact payload that used
+/// to leak. The rendered HTML must carry no literal collapse markup.
+#[test]
+fn details_fallback_emits_no_literal_collapse_markup() {
+    let html = markdown_to_telegram_html(&result_card());
+
+    for leaked in [
+        "&lt;details&gt;",
+        "&lt;summary&gt;",
+        "&lt;sub&gt;",
+        "&lt;/details&gt;",
+    ] {
+        assert!(
+            !html.contains(leaked),
+            "escaped collapse markup leaked into the delivered message: {leaked} in {html}"
+        );
+    }
+    // The rich renderer's downgrade keeps the summary visible as a heading.
+    assert!(
+        html.contains('▸'),
+        "collapse summary should survive as a flat header: {html}"
+    );
+    assert!(
+        html.contains("build"),
+        "summary text should survive the downgrade: {html}"
+    );
+}
+
+/// Prose without any block structure keeps the line-based ladder.
+#[test]
+fn plain_prose_still_uses_the_line_renderer() {
+    assert!(!prefers_rich_render("just a sentence with **bold** in it"));
+}
+
+/// An unmatched `<sub>` is not markup we emitted, so it must stay visible
+/// text rather than being silently swallowed by the downgrade.
+#[test]
+fn lone_sub_opener_in_prose_is_still_escaped() {
+    let html = markdown_to_telegram_html(
+        "<details>\n<summary>x</summary>\n\nuse <sub> here\n\n</details>",
+    );
+    assert!(
+        html.contains("&lt;sub&gt;"),
+        "an unmatched tag is prose, not markup: {html}"
+    );
+}


### PR DESCRIPTION
Closes #1321

## What

Adds a structural code-intelligence lane to `memory_search` (Option A from the codegraph spike): tree-sitter parses `.rs` files into symbols and call edges, stored in SQLite alongside the existing BM25+vector index. Queries auto-route — structural questions (`who calls X`, `callers of`, `callees of`) hit the symbol graph; conceptual questions keep the existing text+vector path.

## Implementation

- **Feature-gated** behind `code-graph` (`tree-sitter` + `tree-sitter-rust` optional deps) — default build untouched, zero cost unless opted in
- `src/memory/symbol_extractor.rs` — AST walker extracting functions, structs, traits, impls, imports, and caller→callee edges
- `src/memory/db.rs` — `symbols`, `call_edges`, `imports` tables + query methods (`query_callers_of`, `query_callees_of`, `query_symbols_by_name`)
- `src/memory/external.rs` — extraction runs during indexing of `.rs` files in `[[memory.extra_paths]]`
- `src/memory/search.rs` — `detect_structural_query` routes structural intent to the graph lane
- `src/brain/prompt_builder.rs` — `code-graph` registered in `AVAILABLE_CARGO_FEATURES` (sentinel test)

## Tests

14 new: 5 extractor unit, 4 integration (end-to-end index→query), 5 routing detection.

Full gate: fmt ✅, clippy `-D warnings` ✅, `cargo test --all-features` **7562 passed / 0 failed / 29 ignored** (up from 7542).

## Notes

- Insertion order guarantees symbol→edge integrity; no FK constraint (file_path alone isn't unique)
- Rust first; tree-sitter grammars for Python/JS are additive follow-ups
- Spike context: memory_search won conceptual queries outright (compaction, rich cards); this closes the structural lane (call chains, impact)