### PR TITLE
fix(memory): recurse into nested call expressions and impl items in symbol extractor

### DIFF
--- a/src/memory/symbol_extractor.rs
+++ b/src/memory/symbol_extractor.rs
@@ -169,7 +169,11 @@ impl SymbolExtractor {
                 }
             }
             "impl_item" => {
-                // Extract impl block (trait implementation)
+                // Extract impl block (trait implementation), then recurse:
+                // impl bodies contain `function_item` methods, and stopping
+                // here made every impl method in the codebase invisible to the
+                // symbols table (#1325 — `insert_symbol`, `query_callers_of`
+                // had edges but no symbol rows).
                 let impl_name = self.extract_impl_name(node, source);
                 symbols.push(Symbol {
                     name: impl_name,
@@ -178,6 +182,16 @@ impl SymbolExtractor {
                     start_line: node.start_position().row,
                     end_line: node.end_position().row,
                 });
+                for child in node.children(&mut node.walk()) {
+                    self.extract_from_node(
+                        child,
+                        source,
+                        file_path,
+                        current_function,
+                        symbols,
+                        call_edges,
+                    );
+                }
             }
             "use_declaration" => {
                 // Extract import
@@ -191,7 +205,11 @@ impl SymbolExtractor {
                 });
             }
             "call_expression" => {
-                // Extract function call
+                // Extract function call, then recurse: calls nest inside other
+                // calls' subtrees (receiver `.await.context()` chains, call
+                // arguments, method chains) and each nested call is its own
+                // edge (#1325 — `retry_db_operation(..).await.context(..)`
+                // dropped the inner edge when this arm stopped after handling).
                 if let (Some(caller), Some(callee)) =
                     (current_function, self.extract_callee(node, source))
                 {
@@ -201,6 +219,16 @@ impl SymbolExtractor {
                         file_path: file_path.to_string(),
                         line: node.start_position().row,
                     });
+                }
+                for child in node.children(&mut node.walk()) {
+                    self.extract_from_node(
+                        child,
+                        source,
+                        file_path,
+                        current_function,
+                        symbols,
+                        call_edges,
+                    );
                 }
             }
             _ => {
@@ -477,6 +505,90 @@ fn share() -> Arc<u32> {
             edges
                 .iter()
                 .any(|e| e.caller == "share" && e.callee == "Arc::new")
+        );
+    }
+
+    #[test]
+    fn test_await_context_chain_inner_call_extracted() {
+        // #1325: `retry_db_operation(..).await.context(..)` — the inner call
+        // sits inside the outer `.context` call's subtree (receiver
+        // await_expression). The call_expression arm must recurse after
+        // handling, or the inner edge is dropped. Generics in the signature
+        // are incidental; the nesting is the bug.
+        let source = r#"
+async fn retry_db_anyhow<F, Fut, T>(operation: F, config: &DbRetryConfig) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    retry_db_operation(operation, config)
+        .await
+        .context("Database operation failed after retries")
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (_symbols, edges) = extractor.extract(&path, source).unwrap();
+
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.caller == "retry_db_anyhow" && e.callee == "retry_db_operation"),
+            "inner call of an .await.context() chain must produce its edge, got: {edges:?}"
+        );
+        assert!(edges.iter().any(|e| e.callee == "context"));
+    }
+
+    #[test]
+    fn test_nested_call_in_arguments_extracted() {
+        // #1325 (same class): `wrap(inner())` — inner call lives in the outer
+        // call's argument subtree.
+        let source = r#"
+fn outer() -> u32 {
+    wrap(inner())
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (_symbols, edges) = extractor.extract(&path, source).unwrap();
+
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.caller == "outer" && e.callee == "wrap")
+        );
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.caller == "outer" && e.callee == "inner")
+        );
+    }
+
+    #[test]
+    fn test_impl_method_symbol_and_calls_extracted() {
+        // #1325 (found while fixing): impl_item handled-and-stopped, so impl
+        // methods had no symbol rows and their bodies no call edges.
+        let source = r#"
+struct Store;
+
+impl Store {
+    fn query_all(&self) -> Vec<u32> {
+        self.load()
+    }
+}
+"#;
+        let mut extractor = SymbolExtractor::new().unwrap();
+        let path = PathBuf::from("test.rs");
+        let (symbols, edges) = extractor.extract(&path, source).unwrap();
+
+        assert!(
+            symbols.iter().any(|s| s.name == "query_all"),
+            "impl method must appear in symbols, got: {symbols:?}"
+        );
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.caller == "query_all" && e.callee == "load")
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1325.

The symbol extractor's tree walk had a handle-and-stop defect in two node arms: `call_expression` and `impl_item` pushed their extraction and never recursed into children. Any symbol or call edge nested inside another expression's subtree was silently dropped.

## Root cause

Two walk arms were terminal instead of recursive:

- `call_expression` recorded its own edge, then stopped — so a call nested anywhere inside another call's subtree was never visited: receiver awaits (`retry_db_operation(...).await.context(...)`), calls in arguments (`foo(bar())`), method chains.
- `impl_item` recorded the impl block, then stopped — so every `impl` method in the codebase was missing from the symbols table entirely.

The `_` fallback arm recursed correctly; only the handled arms forgot to.

## Fix

Recurse after handle, same pattern as `function_item`:

- `call_expression`: push edge, then walk children with the same caller context
- `impl_item`: record impl, then walk children (methods) so each method_item extracts as a symbol and gets its own caller context

## Impact (bigger than the issue title)

- The graph was missing **every impl method** — verified live: `insert_symbol`, `query_callers_of` had zero symbols before this fix
- Nested call edges (await chains, calls-as-arguments) now extracted
- Benchmark Q2 caller recall: 4/5 → 5/5 (`retry_db_operation` call inside `.await.context()` in `db/retry.rs:155` now captured)

## Tests

3 new regression tests in `symbol_extractor`:
- nested call in arguments extracted
- nested call in await/context chain extracted
- impl methods extracted as symbols

Extractor suite: 11 passed, 0 failed. Full gate on the branch.
