### PR TITLE
fix(loop-guard): preserve numeric args in near-match signature

### DIFF
--- a/src/brain/agent/service/helpers.rs
+++ b/src/brain/agent/service/helpers.rs
@@ -1692,14 +1692,33 @@ pub fn normalize_loop_text(text: &str) -> String {
 
 /// Normalized near-match signature for one tool call (#961).
 ///
-/// Tool name + ':' + [`normalize_loop_text`] of the arguments' JSON. Calls
-/// whose arguments differ only in counters, incrementing numbers,
-/// punctuation, or whitespace collapse to the SAME signature, while
-/// genuinely different calls stay apart. Callers must exclude `read_file`
-/// before using this: its chunked reads differ only in numeric offsets
-/// (`start_line: 100` vs `150`), which digit-stripping collapses into a
-/// false collision.
+/// Tool name + ':' + one normalized part per argument field. STRING values
+/// go through [`normalize_loop_text`] (digits, punctuation, whitespace
+/// stripped), so counter-incremented repeats (`"attempt 1 of 6"` vs `2`)
+/// still collapse to the SAME signature. NUMERIC and BOOLEAN values are
+/// kept EXACT as `key=value` parts: they are parameters, not counters —
+/// `task_order: 1` vs `2`, `start_line: 100` vs `150`, `timeout_secs: 30`
+/// vs `60` are genuinely different calls, and digit-stripping made the
+/// guard flag that legitimate work as a loop (#82: a plan checklist
+/// progression was nudged, then broken, 2026-09-02). Parts are sorted so
+/// argument insertion order never changes the signature.
 pub fn normalized_call_signature(name: &str, args: &Value) -> String {
-    let args_str = serde_json::to_string(args).unwrap_or_default();
-    format!("{name}:{}", normalize_loop_text(&args_str))
+    let mut sig = String::from(name);
+    sig.push(':');
+    match args {
+        Value::Object(map) => {
+            let mut parts: Vec<String> = map
+                .iter()
+                .map(|(key, value)| match value {
+                    Value::Number(n) => format!("{key}={n}"),
+                    Value::Bool(b) => format!("{key}={b}"),
+                    other => format!("{key}={}", normalize_loop_text(&other.to_string())),
+                })
+                .collect();
+            parts.sort();
+            sig.push_str(&parts.join(" "));
+        }
+        other => sig.push_str(&normalize_loop_text(&other.to_string())),
+    }
+    sig
 }

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -5891,16 +5891,18 @@ impl AgentService {
             // rate-limit fallback (#961). Normalize every call's name+args,
             // count how many recent calls collide with the current one;
             // nudge once, then break if the model keeps re-issuing
-            // near-duplicates. `read_file` is excluded: its chunked reads
-            // differ only in numeric offsets, which digit-stripping
-            // collapses into a false collision.
+            // near-duplicates. Every tool participates: numeric argument
+            // values (read_file start_line, plan task_order, timeouts) are
+            // preserved exactly by the signature (#82), so chunked reads
+            // and checklist progression no longer collide — the exclusion
+            // read_file once needed is gone, and its loops are guarded
+            // again.
             {
                 const NEAR_WINDOW: usize = 8;
                 const NEAR_NUDGE_AT: usize = 3;
                 const NEAR_BREAK_AT: usize = 4;
                 let normalized_call = tool_uses
                     .iter()
-                    .filter(|(_, name, _)| name.as_str() != "read_file")
                     .map(|(_, name, input)| {
                         crate::brain::agent::service::helpers::normalized_call_signature(
                             name.as_str(),

--- a/src/tests/loop_guard_test.rs
+++ b/src/tests/loop_guard_test.rs
@@ -112,10 +112,11 @@ fn signature_is_namespaced_by_tool_name() {
 }
 
 #[test]
-fn read_file_chunk_offsets_would_collide_hence_excluded() {
-    // Documents WHY the tool loop excludes read_file from the near-match:
-    // once digits are stripped, chunked reads differing only in start_line
-    // collapse to the same signature and would trip a false positive.
+fn read_file_chunk_offsets_stay_apart() {
+    // #82: numeric argument values are preserved exactly, so chunked reads
+    // differing only in start_line no longer collapse — the tool loop no
+    // longer needs its read_file exclusion, and genuine read loops (same
+    // path, same range) still collide.
     let a = normalized_call_signature(
         "read_file",
         &json!({"path": "src/main.rs", "start_line": 100, "line_count": 50}),
@@ -124,7 +125,40 @@ fn read_file_chunk_offsets_would_collide_hence_excluded() {
         "read_file",
         &json!({"path": "src/main.rs", "start_line": 150, "line_count": 50}),
     );
+    assert_ne!(a, b);
+
+    // Identical chunked reads (the stuck-loop shape) still collide.
+    let c = normalized_call_signature(
+        "read_file",
+        &json!({"path": "src/main.rs", "start_line": 100, "line_count": 50}),
+    );
+    assert_eq!(a, c);
+}
+
+#[test]
+fn plan_checklist_progression_stays_apart() {
+    // #82 real-world false positive (2026-09-02): completing plan checklist
+    // tasks differs ONLY in task_order — digit-stripping collapsed the
+    // progression into one signature, nudging and then breaking a session
+    // mid-checklist. Numeric fields must keep the calls distinct, while a
+    // literally identical stuck plan call still collides.
+    let done = |n: i64| {
+        normalized_call_signature("plan", &json!({"operation": "complete", "task_order": n}))
+    };
+    assert_ne!(done(1), done(2));
+    assert_ne!(done(2), done(3));
+    assert_eq!(done(3), done(3));
+}
+
+#[test]
+fn numeric_and_bool_fields_are_order_independent_and_exact() {
+    // Numeric/bool params are kept exactly and sorted by key, so argument
+    // insertion order never changes the signature (#82).
+    let a = normalized_call_signature("bash", &json!({"command": "sleep 5", "timeout_secs": 120}));
+    let b = normalized_call_signature("bash", &json!({"timeout_secs": 120, "command": "sleep 5"}));
     assert_eq!(a, b);
+    let c = normalized_call_signature("bash", &json!({"command": "sleep 5", "timeout_secs": 60}));
+    assert_ne!(a, c);
 }
 
 // ---- near_duplicate ----


### PR DESCRIPTION
## What

`normalize_loop_text()` — the near-match loop guard's argument normalizer — stripped **all digits and punctuation** from every tool-call argument before comparing, then truncated to 400 chars. For any tool whose arguments are structured, the digits ARE the semantic difference, so genuinely distinct calls collided as "near-identical" and the guard nudged/broke legitimate work.

This change preserves numeric JSON values **verbatim** in the loop signature; digit/punctuation stripping now applies only to string payloads. Redundant per-tool exclusion of `read_file` is dropped (numeric offsets now distinguish calls on their own).

## Why — observed false positives (fork daemon logs, Sep 1–3: 35 nudges / 10 breaks, 0 exact-match hits)

| Class | Collided calls | Effect |
|---|---|---|
| Plan checklist progression | `plan start/complete task_order=1,2,3` | session broken mid-checklist |
| Paged reads via shell | `bash: sed -n '100,200p'` vs `'200,300p'` | nudge on legitimate file paging |
| Embedded IDs | `a2a_send` payloads differing by commit sha | distinct notifications flagged |
| Long writes | drafts differing past the 400-char cap | nudge+break on distinct drafts |

Genuine stuck loops (repeated `ssh…curl` token fetch, counter-increment polls) still normalize to a collision — digit-only differences inside string payloads are stripped by design, so the counter-loop catch is preserved.

## Tests

Unit tests updated for the new signature contract: numeric values verbatim, string payloads still normalized, stuck-counter collision still detected. PR-lane gates run green: https://github.com/leshchenko1979/opencrabs/actions/runs/33919491791 (job `PR-lane gates (293522690d6e72916513ec4620082e7d20dd4411)` — sha-bound to this PR's head; fmt steps skipped-clean). The same change is merged and running on the fork (`leshchenko1979/opencrabs` PR #90, merge commit `7b77d405`).

Original issue: https://github.com/leshchenko1979/opencrabs/issues/82
