### PR TITLE
fix(telegram): promote fence-bearing oversized host to answer slot instead of burying it as trailer (#58)

### DIFF
--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -2009,6 +2009,19 @@ pub(crate) fn folded_duplicates_final(folded: &str, final_text: &str) -> bool {
     overlap >= 20 && (norm_final.starts_with(&norm_folded) || norm_folded.starts_with(&norm_final))
 }
 
+/// A post-halt run larger than this is not a sign-off — it is a substantive
+/// answer misfiled by position (#58). Counted in chars, not bytes.
+pub(crate) const MAX_TRAILER_CHARS: usize = 600;
+
+/// #58 cap+reroute decision, split out pure so the threshold matrix is
+/// unit-testable without a loaded config (`should_render_mermaid` reads
+/// `Config::current()`). A mermaid fence in the trailer would ship as raw
+/// fence text — the fence→PNG conversion only runs on the final-answer
+/// send — and an oversized trailer is a second answer, not a sign-off.
+pub(crate) fn trailer_promotes_to_answer(has_mermaid: bool, char_count: usize) -> bool {
+    has_mermaid || char_count > MAX_TRAILER_CHARS
+}
+
 /// Settle the options-pending reclaim into `(final text, trailer)` (#31).
 ///
 /// `content` is the response.content text — with an option-surface halt the
@@ -2026,6 +2039,14 @@ pub(crate) fn folded_duplicates_final(folded: &str, final_text: &str) -> bool {
 /// - Keep-never-discard: when the popper found no trailer run but content
 ///   carries a non-duplicate leftover (the ack never folded into the flow),
 ///   the content text BECOMES the trailer instead of vanishing.
+/// - #58 cap+reroute (owner-approved Option A): a trailer carrying a
+///   mermaid fence or exceeding [`MAX_TRAILER_CHARS`] is substantive answer
+///   text misfiled by position, NOT a sign-off. It is promoted to the
+///   answer slot — the normal final-answer send renders its fence to PNG
+///   for free — and the host it displaces demotes to the trailer (nothing
+///   dies). Live miss 2026-09-01 04:21Z: a 2668-byte design answer rode
+///   after the buttons, its fence shipped as raw text, the pre-rendered
+///   PNG died in the render cache (#58).
 pub(crate) fn settle_options_reclaim(
     content: String,
     host: Option<String>,
@@ -2045,5 +2066,20 @@ pub(crate) fn settle_options_reclaim(
             _ => None,
         },
     };
+    // #58 cap+reroute (owner-approved Option A): reject a misfiled trailer —
+    // promote it to the answer, demote the displaced host to the trailer.
+    if let Some(t) = trailer.as_ref().filter(|t| {
+        trailer_promotes_to_answer(
+            super::rich::mermaid::should_render_mermaid(t),
+            t.chars().count(),
+        )
+    }) {
+        let demoted = if text.trim().is_empty() {
+            None
+        } else {
+            Some(text)
+        };
+        return (t.clone(), demoted);
+    }
     (text, trailer)
 }

--- a/src/tests/telegram_options_reclaim_test.rs
+++ b/src/tests/telegram_options_reclaim_test.rs
@@ -21,7 +21,8 @@
 //! an unfolded content leftover is promoted to the trailer).
 
 use crate::channels::telegram::flow::{
-    FlowEntry, pop_trailing_folded_texts, settle_options_reclaim,
+    FlowEntry, MAX_TRAILER_CHARS, pop_trailing_folded_texts, settle_options_reclaim,
+    trailer_promotes_to_answer,
 };
 
 #[test]
@@ -237,9 +238,67 @@ fn settle_no_host_uses_content() {
 }
 
 #[test]
+fn trailer_promotes_to_answer_matrix() {
+    // Pure threshold matrix (#58): a fence promotes at any size; no fence
+    // promotes only past MAX_TRAILER_CHARS; the cap itself does NOT
+    // promote (strictly greater — a run AT the cap is still a trailer).
+    assert!(trailer_promotes_to_answer(true, 10));
+    assert!(!trailer_promotes_to_answer(false, MAX_TRAILER_CHARS));
+    assert!(trailer_promotes_to_answer(false, MAX_TRAILER_CHARS + 1));
+}
+
+#[test]
 fn settle_no_host_no_trailer_is_stock() {
     // Plain shape: content only, no runs — the stock reclaim result.
     let (text, trailer) = settle_options_reclaim("the whole answer".into(), None, None);
     assert_eq!(text, "the whole answer");
     assert_eq!(trailer, None);
+}
+
+#[test]
+fn settle_oversized_trailer_promoted_to_answer() {
+    // The #58 incident shape, cap leg (config-independent — no fence): the
+    // post-halt run carries the whole substantive answer while the pre-Tool
+    // host is just the ack. Position said "trailer"; size says "answer".
+    // The big text takes the answer slot, the ack demotes to the trailer.
+    let big_answer = "word ".repeat(121);
+    assert!(big_answer.chars().count() > MAX_TRAILER_CHARS);
+    let (text, trailer) = settle_options_reclaim(
+        "unused content".into(),
+        Some("Got it — one moment.".into()),
+        Some(big_answer.clone()),
+    );
+    assert_eq!(text, big_answer, "oversized trailer promoted to the answer");
+    assert_eq!(
+        trailer.as_deref(),
+        Some("Got it — one moment."),
+        "displaced host demotes to trailer"
+    );
+}
+
+#[test]
+fn settle_small_trailer_stays_trailer() {
+    // #58 regression guard: a normal-sized fence-less sign-off must NOT be
+    // promoted — the rule fires on fences or oversize, nothing else.
+    let (text, trailer) = settle_options_reclaim(
+        "content".into(),
+        Some("the substantive answer".into()),
+        Some("all set — sign-off".into()),
+    );
+    assert_eq!(text, "the substantive answer");
+    assert_eq!(trailer.as_deref(), Some("all set — sign-off"));
+}
+
+#[test]
+fn settle_oversized_trailer_empty_host_drops_demote() {
+    // CLI-provider shape (content empty, nothing folded): promoting the
+    // oversized trailer leaves NOTHING to demote — the trailer slot dies
+    // rather than shipping an empty ack bubble after the buttons.
+    let big_answer = "word ".repeat(121);
+    let (text, trailer) = settle_options_reclaim(String::new(), None, Some(big_answer.clone()));
+    assert_eq!(text, big_answer);
+    assert_eq!(
+        trailer, None,
+        "empty host demotes to None, not an empty trailer"
+    );
 }


### PR DESCRIPTION
# Options-bubble trailer path bypasses mermaid media rendering — promote oversized or mermaid-bearing trailers to the answer

## Problem

When a turn emits a mermaid fence and halts on `suggest_options`, any post-halt text run is classified as the options-trailer **by position alone** — no size or sanity cap. Two failure modes compound:

1. A substantive post-halt answer (live case: a 2668-char design answer) ships as raw trailer text after the buttons, while a 352-char pre-tool fragment becomes the host bubble.
2. A mermaid fence inside that misfiled run renders as literal fence text — the fence→PNG conversion only runs on the final-answer send sites — so the pre-rendered PNG sits in the cache and is never sent. No error is logged anywhere.

## Fix

Cap+reroute in `settle_options_reclaim` (`src/channels/telegram/flow.rs`):

- `MAX_TRAILER_CHARS = 600` — a post-halt run larger than this is not a sign-off; it is a second answer misfiled by position.
- `trailer_promotes_to_answer(has_mermaid, char_count)` — pure threshold rule: a run carrying a mermaid fence (`should_render_mermaid`, same predicate the render path already uses) or exceeding the cap is promoted to the **answer slot**, where the normal final-answer send renders its fence to PNG for free. The displaced host demotes to the trailer (or dies empty); nothing is discarded.
- Composes with the existing `take_folded_final` reclaim unchanged.

The threshold rule is split into a pure function so the matrix is unit-testable without a loaded config (`should_render_mermaid` reads `Config::current()`).

## Tests

Acceptance tests in `src/tests/telegram_options_reclaim_test.rs`:

- `trailer_promotes_to_answer_matrix` — fence promotes at any size; fence-less promotes only strictly past the cap (a run AT the cap stays a trailer).
- `settle_oversized_trailer_promoted_to_answer` — the incident shape: big trailer takes the answer slot, ack host demotes to trailer.
- `settle_small_trailer_stays_trailer` — regression guard: normal-sized fence-less sign-offs are untouched.
- `settle_oversized_trailer_empty_host_drops_demote` — CLI-provider shape: empty host demotes to `None`, no empty ack bubble.

## Scope notes

- Deliberately out of scope: a mermaid render hook inside the options-bubble send surfaces themselves (the trailer path is now mitigated by avoidance — fence-bearing runs never ride the bubble). Tracked on the fork: https://github.com/leshchenko1979/opencrabs/issues/93 (host/demoted-host paths) and https://github.com/leshchenko1979/opencrabs/issues/92 (demoted-host re-check edge).
- Port of the fork-side fix (leshchenko1979/opencrabs commits `1b286c66`/`5888ff36`, merged to fork main as `6ba81845` + acceptance tests in `ad7b1246`); both files are byte-identical to fork `main`.

## Gate receipts

- CI gate (fmt/clippy/`cargo test --locked --profile ci --all-features`, flags verbatim from `ci.yml`): GREEN run 33891744543 on this head — https://github.com/leshchenko1979/opencrabs/actions/runs/33891744543

Original issue: https://github.com/leshchenko1979/opencrabs/issues/58
