### PR TITLE
fix(telegram): warn! on mermaid.ink render failure — non-200 attempts were log-invisible

### DIFF
--- a/src/channels/telegram/rich/mermaid.rs
+++ b/src/channels/telegram/rich/mermaid.rs
@@ -243,6 +243,14 @@ pub(crate) async fn prevalidate(source: &str) -> MermaidResult {
     // Not a usable image: surface the renderer's own error text (mermaid.ink
     // returns a plain-text parse error) so the failure block is legible.
     let body = resp.text().await.unwrap_or_default();
+    // Failure telemetry (leshchenko1979/opencrabs#64): the success leg logs
+    // `render ok`; without a matching warn here a non-200 is invisible in
+    // the daemon log and incidents get argued from absence.
+    tracing::warn!(
+        status,
+        note = %error_note(status, &body),
+        "mermaid.ink render failed"
+    );
     MermaidResult::Failed(error_note(status, &body))
 }
 


### PR DESCRIPTION
## Problem

The mermaid.ink render path logged the success leg (`render ok; delivering bytes`) but the failure leg logged **nothing**. A transient 5xx degrade to the raw-fence block was unprovable from the daemon log alone — during a 2026-09-01 incident a cross-lane report quoted a failure line that existed in no tree, because no real failure line was ever emitted.

## Fix

One `tracing::warn!` before the render-failure classification: HTTP status plus the error-note body. Parse rejections (4xx) also warn — the preflight consumes them, but the render attempt still leaves a receipt in the log.

Single-file, single-log-line change (+8 lines); no behavior change to the render pipeline, observability only.

## Provenance / conflict note

Cherry-picked from a fork-side commit onto upstream `main`. The original hunk carried fork-only context (a `classify_render_failure`/`preflight_parse_errors` refactor that belongs to a separate fork issue) — those lines were dropped; only the warn! telemetry lines are kept here. CI on this branch ran against exactly this tree and is green.

Fork issue: leshchenko1979/opencrabs#64