### PR TITLE
fix(telegram): theme-2 harvest — 429 edit-retry ladder for best-effort UI edits (#68, #62, #75)

### DIFF
--- a/src/channels/telegram/agent.rs
+++ b/src/channels/telegram/agent.rs
@@ -423,6 +423,10 @@ impl TelegramAgent {
                                                 &crate::channels::telegram::suggest_options::
                                                     picked_block(&text, chooser.as_deref()),
                                             );
+                                        // #68: true when the echo fallback is owned by the
+                                        // deferred retry task (do NOT echo into the same
+                                        // 429 window — the old immediate echo died there).
+                                        let mut echo_deferred = false;
                                         let recorded = match prompt_msg_id {
                                             Some(mid) => {
                                                 // Merged keyboard (#tg-suggest-merge): the
@@ -461,6 +465,14 @@ impl TelegramAgent {
                                                             .map(|(full, rich)| (full.as_str(), *rich)),
                                                         picked,
                                                     );
+                                                // #68: capture the rewrite payload so a
+                                                // Retry-After deferral can re-fire a
+                                                // byte-identical edit outside the 429 window.
+                                                let mut tap_retry = Some(match &rewrite {
+                                                    super::suggest_options::PickRewrite::RichHost(body) => TapRetry::Rich(chat_id, mid, body.clone(), empty_kb.clone()),
+                                                    super::suggest_options::PickRewrite::ClassicHost(body) => TapRetry::Classic(chat_id, mid, body.clone(), empty_kb.clone()),
+                                                    super::suggest_options::PickRewrite::Standalone(body) => TapRetry::Standalone(chat_id, mid, body.clone()),
+                                                });
                                                 let outcome: Result<(), String> = match rewrite {
                                                     super::suggest_options::PickRewrite::RichHost(
                                                         body,
@@ -496,11 +508,57 @@ impl TelegramAgent {
                                                         .map_err(|e| e.to_string()),
                                                 };
                                                 if let Err(e) = outcome {
-                                                    tracing::warn!(
-                                                        "Telegram followup tap: could not edit the \
-                                                         suggestion block ({e}) — falling back to \
-                                                         a quoted echo"
-                                                    );
+                                                    match super::edit_retry::classify_str(&e) {
+                                                        super::edit_retry::EditErr::RetryAfter(wait) => {
+                                                            tracing::warn!(
+                                                                "Telegram followup tap: pick-record edit \
+                                                                 429 (retry after {wait:?}) — deferring one \
+                                                                 identical retry"
+                                                            );
+                                                            if let Some(retry) = tap_retry.take() {
+                                                                let bot_r = bot_clone.clone();
+                                                                let bot_e = bot_clone.clone();
+                                                                let echo_text = text.clone();
+                                                                let echo_chooser = chooser.clone();
+                                                                super::edit_retry::spawn_deferred(
+                                                                    wait,
+                                                                    move || async move {
+                                                                        refire_pick_edit(&bot_r, retry)
+                                                                            .await
+                                                                    },
+                                                                    move || async move {
+                                                                        // The legacy quoted echo — now
+                                                                        // safely outside the 429 window
+                                                                        // that killed attempt 1 (#68).
+                                                                        let echo = crate::channels::telegram::handler::md_to_html(
+                                                                            &crate::channels::telegram::suggest_options::
+                                                                                echo_fallback(&echo_text, echo_chooser.as_deref()),
+                                                                        );
+                                                                        if let Err(e) =
+                                                                            crate::channels::telegram::send::message_in_thread(
+                                                                                &bot_e, chat_id, thread_id, echo,
+                                                                            )
+                                                                            .parse_mode(teloxide::types::ParseMode::Html)
+                                                                            .await
+                                                                        {
+                                                                            tracing::warn!(
+                                                                                "Telegram followup tap: echo fallback \
+                                                                                 also failed: {e}"
+                                                                            );
+                                                                        }
+                                                                    },
+                                                                );
+                                                                echo_deferred = true;
+                                                            }
+                                                        }
+                                                        super::edit_retry::EditErr::Fatal(_) => {
+                                                            tracing::warn!(
+                                                                "Telegram followup tap: could not edit the \
+                                                                 suggestion block ({e}) — falling back to \
+                                                                 a quoted echo"
+                                                            );
+                                                        }
+                                                    }
                                                     false
                                                 } else {
                                                     // #1226: the pick-record edit also strips
@@ -515,7 +573,7 @@ impl TelegramAgent {
                                             }
                                             None => false,
                                         };
-                                        if !recorded {
+                                        if !recorded && !echo_deferred {
                                             // The block is gone or too old to edit.
                                             // A quoted echo is worse attribution
                                             // but better than losing the record of
@@ -1948,6 +2006,62 @@ struct DispatchDeps {
     config_rx: tokio::sync::watch::Receiver<Config>,
     channel_msg_repo: ChannelMessageRepository,
     session_binding_repo: SessionBindingRepository,
+}
+
+/// Prebuilt retry payload for the tap pick-record edit (#68). Built BEFORE
+/// the first attempt fires, so the deferred retry is byte-identical to
+/// attempt 1 — same body, same empty keyboard, same transport arm.
+#[derive(Clone)]
+enum TapRetry {
+    /// Rich merged host: body rides `edit_rich_html`.
+    Rich(
+        ChatId,
+        MessageId,
+        String,
+        teloxide::types::InlineKeyboardMarkup,
+    ),
+    /// Classic merged host: body + empty keyboard strip the dead buttons.
+    Classic(
+        ChatId,
+        MessageId,
+        String,
+        teloxide::types::InlineKeyboardMarkup,
+    ),
+    /// Standalone suggestion block becomes the pick record.
+    Standalone(ChatId, MessageId, String),
+}
+
+/// Re-fire a tap pick-record edit exactly as attempt 1 fired it (#68).
+async fn refire_pick_edit(bot: &Bot, retry: TapRetry) -> Result<(), String> {
+    use teloxide::payloads::EditMessageTextSetters;
+    use teloxide::prelude::Requester;
+    match retry {
+        TapRetry::Rich(chat_id, mid, body, kb) => super::rich::api::edit_rich_html(
+            bot.api_url().as_str(),
+            bot.token(),
+            chat_id.0,
+            mid.0,
+            &body,
+            Some(&serde_json::json!(kb)),
+            "turn",
+            "-",
+        )
+        .await
+        .map_err(|e| e.to_string()),
+        TapRetry::Classic(chat_id, mid, body, kb) => bot
+            .edit_message_text(chat_id, mid, &body)
+            .parse_mode(teloxide::types::ParseMode::Html)
+            .reply_markup(kb)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        TapRetry::Standalone(chat_id, mid, body) => bot
+            .edit_message_text(chat_id, mid, &body)
+            .parse_mode(teloxide::types::ParseMode::Html)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+    }
 }
 
 /// Should this message be held until its edit stream settles? True only for

--- a/src/channels/telegram/agent.rs
+++ b/src/channels/telegram/agent.rs
@@ -720,8 +720,6 @@ impl TelegramAgent {
                                 crate::channels::telegram::keyboards::ack_callback(&bot, &query, "model page").await;
                                 let resp = crate::channels::commands::models_for_provider(&provider_name).await;
                                 if let Some(msg) = &query.message {
-                                    use teloxide::payloads::EditMessageTextSetters;
-                                    use teloxide::prelude::Requester;
                                     use teloxide::types::InlineKeyboardMarkup;
                                     use crate::channels::telegram::picker_limits as picker;
                                     let page = picker::page_of(&resp.models, page_num, filter.as_deref());
@@ -738,14 +736,15 @@ impl TelegramAgent {
                                             &page,
                                         ),
                                     );
-                                    if let Err(e) = bot
-                                        .edit_message_text(msg.chat().id, msg.id(), &text)
-                                        .parse_mode(teloxide::types::ParseMode::Html)
-                                        .reply_markup(keyboard)
-                                        .await
-                                    {
-                                        tracing::warn!("Telegram: model page update failed: {e}");
-                                    }
+                                    super::edit_retry::edit_text_ui(
+                                        bot.clone(),
+                                        msg.chat().id,
+                                        msg.id(),
+                                        text,
+                                        true,
+                                        Some(keyboard),
+                                        "model page update",
+                                    );
                                 }
                                 return ResponseResult::Ok(());
                             }
@@ -878,27 +877,80 @@ impl TelegramAgent {
                                             &page,
                                         ),
                                     );
-                                    if let Err(e) = bot
-                                        .edit_message_text(msg.chat().id, msg.id(), &text)
+                                    let chat = msg.chat().id;
+                                    let mid = msg.id();
+                                    match bot
+                                        .edit_message_text(chat, mid, &text)
                                         .parse_mode(teloxide::types::ParseMode::Html)
-                                        .reply_markup(keyboard)
+                                        .reply_markup(keyboard.clone())
                                         .await
                                     {
-                                        tracing::warn!("Telegram: callback UI update failed: {e}");
-                                        // Say something. This failing to a log line is why the
-                                        // picker looked like it was still loading forever.
-                                        let fallback = format!(
-                                            "Could not show the model list for {}: {e}\n\nSet one                                              directly with /models <name>.",
-                                            resp.provider_name
-                                        );
-                                        if let Err(e2) = bot
-                                            .edit_message_text(msg.chat().id, msg.id(), fallback)
-                                            .await
-                                        {
-                                            tracing::warn!(
-                                                "Telegram: could not report the picker failure either: {e2}"
-                                            );
-                                        }
+                                        Ok(_) => {}
+                                        Err(e) => match super::edit_retry::classify(&e) {
+                                            super::edit_retry::EditErr::RetryAfter(wait) => {
+                                                // Deferred identical retry first (#68);
+                                                // the legacy fallback runs only on
+                                                // exhaustion — safely outside the 429
+                                                // window that killed the old immediate
+                                                // fallback.
+                                                super::edit_retry::spawn_deferred(
+                                                    wait,
+                                                    {
+                                                        let bot = bot.clone();
+                                                        let text = text.clone();
+                                                        let keyboard = keyboard.clone();
+                                                        move || async move {
+                                                            bot.edit_message_text(chat, mid, &text)
+                                                                .parse_mode(
+                                                                    teloxide::types::ParseMode::Html,
+                                                                )
+                                                                .reply_markup(keyboard)
+                                                                .await
+                                                                .map(|_| ())
+                                                        }
+                                                    },
+                                                    {
+                                                        let bot = bot.clone();
+                                                        let provider = resp.provider_name.clone();
+                                                        move || async move {
+                                                            // Say something. This failing to a
+                                                            // log line is why the picker looked
+                                                            // like it was still loading forever.
+                                                            let fallback = format!(
+                                                                "Could not show the model list for {provider}: still rate-limited after a deferred retry\n\nSet one directly with /models <name>."
+                                                            );
+                                                            if let Err(e2) = bot
+                                                                .edit_message_text(chat, mid, fallback)
+                                                                .await
+                                                            {
+                                                                tracing::warn!(
+                                                                    "Telegram: could not report the picker failure either: {e2}"
+                                                                );
+                                                            }
+                                                        }
+                                                    },
+                                                );
+                                            }
+                                            super::edit_retry::EditErr::Fatal(e) => {
+                                                tracing::warn!(
+                                                    "Telegram: callback UI update failed: {e}"
+                                                );
+                                                // Say something. This failing to a log line is why the
+                                                // picker looked like it was still loading forever.
+                                                let fallback = format!(
+                                                    "Could not show the model list for {}: {e}\n\nSet one                                              directly with /models <name>.",
+                                                    resp.provider_name
+                                                );
+                                                if let Err(e2) = bot
+                                                    .edit_message_text(chat, mid, fallback)
+                                                    .await
+                                                {
+                                                    tracing::warn!(
+                                                        "Telegram: could not report the picker failure either: {e2}"
+                                                    );
+                                                }
+                                            }
+                                        },
                                     }
                                 }
                                 return ResponseResult::Ok(());
@@ -1015,16 +1067,15 @@ impl TelegramAgent {
                                     ]]);
                                 }
                                 if let Some(msg) = &query.message {
-                                    use teloxide::payloads::EditMessageTextSetters;
-                                    use teloxide::prelude::Requester;
-                                    if let Err(e) = bot
-                                        .edit_message_text(msg.chat().id, msg.id(), &display_text)
-                                        .parse_mode(teloxide::types::ParseMode::Html)
-                                        .reply_markup(switch_markup)
-                                        .await
-                                    {
-                                        tracing::warn!("Telegram: callback UI update failed: {e}");
-                                    }
+                                    super::edit_retry::edit_text_ui(
+                                        bot.clone(),
+                                        msg.chat().id,
+                                        msg.id(),
+                                        display_text.clone(),
+                                        true,
+                                        Some(switch_markup),
+                                        "callback UI update",
+                                    );
                                 }
                                 if !switch_ok {
                                     tracing::warn!("Telegram model switch failed: {}", display_text);
@@ -1080,28 +1131,21 @@ impl TelegramAgent {
                                         tracing::warn!("Telegram: callback UI update failed: {e}");
                                     }
                                     if let Some(msg) = &query.message {
-                                        use teloxide::payloads::EditMessageTextSetters;
-                                        use teloxide::prelude::Requester;
-                                        if let Err(e) = bot
-                                            .edit_message_text(
-                                                msg.chat().id,
-                                                msg.id(),
-                                                {
-                                                    let display = match session_svc.get_session(new_id).await {
-                                                        Ok(Some(s)) => s.title.unwrap_or_else(|| session_id_str[..8.min(session_id_str.len())].to_string()),
-                                                        _ => session_id_str[..8.min(session_id_str.len())].to_string(),
-                                                    };
-                                                    format!("✅ Switched to session <code>{}</code>", display)
-                                                },
-                                            )
-                                            .parse_mode(teloxide::types::ParseMode::Html)
-                                            .reply_markup(
-                                                teloxide::types::InlineKeyboardMarkup::default(),
-                                            )
-                                            .await
-                                        {
-                                            tracing::warn!("Telegram: callback UI update failed: {e}");
-                                        }
+                                        let display = match session_svc.get_session(new_id).await {
+                                            Ok(Some(s)) => s.title.unwrap_or_else(|| session_id_str[..8.min(session_id_str.len())].to_string()),
+                                            _ => session_id_str[..8.min(session_id_str.len())].to_string(),
+                                        };
+                                        let switched =
+                                            format!("✅ Switched to session <code>{}</code>", display);
+                                        super::edit_retry::edit_text_ui(
+                                            bot.clone(),
+                                            msg.chat().id,
+                                            msg.id(),
+                                            switched,
+                                            true,
+                                            Some(teloxide::types::InlineKeyboardMarkup::default()),
+                                            "callback UI update",
+                                        );
                                     }
                                 } else {
                                     if let Err(e) = bot
@@ -1191,17 +1235,16 @@ impl TelegramAgent {
                                     state.clear_dir_browser(chat_id, topic_id).await;
                                     // Edit the message to confirm
                                     if let Some(msg) = &query.message {
-                                        use teloxide::payloads::EditMessageTextSetters;
-                                        use teloxide::prelude::Requester;
                                         let confirm_text = format!("✅ Working directory set to:\n<code>{}</code>", current_path);
-                                        if let Err(e) = bot
-                                            .edit_message_text(msg.chat().id, msg.id(), &confirm_text)
-                                            .parse_mode(teloxide::types::ParseMode::Html)
-                                            .reply_markup(teloxide::types::InlineKeyboardMarkup::default())
-                                            .await
-                                        {
-                                            tracing::warn!("cd:here: failed to edit message: {}", e);
-                                        }
+                                        super::edit_retry::edit_text_ui(
+                                            bot.clone(),
+                                            msg.chat().id,
+                                            msg.id(),
+                                            confirm_text,
+                                            true,
+                                            Some(teloxide::types::InlineKeyboardMarkup::default()),
+                                            "cd:here",
+                                        );
                                     }
                                     return ResponseResult::Ok(());
                                 } else if let Some(idx_str) = data.strip_prefix("cd:sel:") {
@@ -1258,17 +1301,16 @@ impl TelegramAgent {
                                     let rows = crate::channels::telegram::handler::build_cd_keyboard(&resp);
                                     let keyboard = teloxide::types::InlineKeyboardMarkup::new(rows);
                                     if let Some(msg) = &query.message {
-                                        use teloxide::payloads::EditMessageTextSetters;
-                                        use teloxide::prelude::Requester;
                                         let html = crate::channels::telegram::handler::md_to_html(&resp.text);
-                                        if let Err(e) = bot
-                                            .edit_message_text(msg.chat().id, msg.id(), &html)
-                                            .parse_mode(teloxide::types::ParseMode::Html)
-                                            .reply_markup(keyboard)
-                                            .await
-                                        {
-                                            tracing::warn!("cd:navigate: failed to edit message: {}", e);
-                                        }
+                                        super::edit_retry::edit_text_ui(
+                                            bot.clone(),
+                                            msg.chat().id,
+                                            msg.id(),
+                                            html,
+                                            true,
+                                            Some(keyboard),
+                                            "cd:navigate",
+                                        );
                                     }
                                 }
                                 return ResponseResult::Ok(());
@@ -1320,17 +1362,16 @@ impl TelegramAgent {
 
                                         let keyboard = InlineKeyboardMarkup::new(rows);
                                         if let Some(msg) = &query.message {
-                                            use teloxide::payloads::EditMessageTextSetters;
-                                            use teloxide::prelude::Requester;
                                             let html = crate::channels::telegram::handler::md_to_html(&text);
-                                            if let Err(e) = bot
-                                                .edit_message_text(msg.chat().id, msg.id(), &html)
-                                                .parse_mode(teloxide::types::ParseMode::Html)
-                                                .reply_markup(keyboard)
-                                                .await
-                                            {
-                                                tracing::warn!("prof:sel: failed to edit message: {}", e);
-                                            }
+                                            super::edit_retry::edit_text_ui(
+                                                bot.clone(),
+                                                msg.chat().id,
+                                                msg.id(),
+                                                html,
+                                                true,
+                                                Some(keyboard),
+                                                "prof:sel",
+                                            );
                                         }
                                     }
                                     return ResponseResult::Ok(());
@@ -1380,17 +1421,16 @@ impl TelegramAgent {
                                         )],
                                     ]);
                                     if let Some(msg) = &query.message {
-                                        use teloxide::payloads::EditMessageTextSetters;
-                                        use teloxide::prelude::Requester;
                                         let html = crate::channels::telegram::handler::md_to_html(&text);
-                                        if let Err(e) = bot
-                                            .edit_message_text(msg.chat().id, msg.id(), &html)
-                                            .parse_mode(teloxide::types::ParseMode::Html)
-                                            .reply_markup(keyboard)
-                                            .await
-                                        {
-                                            tracing::warn!("prof:migrate: failed to edit message: {}", e);
-                                        }
+                                        super::edit_retry::edit_text_ui(
+                                            bot.clone(),
+                                            msg.chat().id,
+                                            msg.id(),
+                                            html,
+                                            true,
+                                            Some(keyboard),
+                                            "prof:migrate",
+                                        );
                                     }
                                     return ResponseResult::Ok(());
                                 }
@@ -1406,31 +1446,30 @@ impl TelegramAgent {
                                                 files.len(), active, name, name
                                             );
                                             if let Some(msg) = &query.message {
-                                                use teloxide::payloads::EditMessageTextSetters;
-                                                use teloxide::prelude::Requester;
                                                 let html = crate::channels::telegram::handler::md_to_html(&text);
-                                                if let Err(e) = bot
-                                                    .edit_message_text(msg.chat().id, msg.id(), &html)
-                                                    .parse_mode(teloxide::types::ParseMode::Html)
-                                                    .reply_markup(InlineKeyboardMarkup::default())
-                                                    .await
-                                                {
-                                                    tracing::warn!("Telegram: callback UI update failed: {e}");
-                                                }
+                                                super::edit_retry::edit_text_ui(
+                                                    bot.clone(),
+                                                    msg.chat().id,
+                                                    msg.id(),
+                                                    html,
+                                                    true,
+                                                    Some(InlineKeyboardMarkup::default()),
+                                                    "callback UI update",
+                                                );
                                             }
                                         }
                                         Err(e) => {
                                             let text = format!("❌ Migration failed: {}", e);
                                             if let Some(msg) = &query.message {
-                                                use teloxide::payloads::EditMessageTextSetters;
-                                                use teloxide::prelude::Requester;
-                                                if let Err(e2) = bot
-                                                    .edit_message_text(msg.chat().id, msg.id(), &text)
-                                                    .reply_markup(InlineKeyboardMarkup::default())
-                                                    .await
-                                                {
-                                                    tracing::warn!("prof:confirm_migrate: failed to edit: {}", e2);
-                                                }
+                                                super::edit_retry::edit_text_ui(
+                                                    bot.clone(),
+                                                    msg.chat().id,
+                                                    msg.id(),
+                                                    text,
+                                                    false,
+                                                    Some(InlineKeyboardMarkup::default()),
+                                                    "prof:confirm_migrate",
+                                                );
                                             }
                                         }
                                     }
@@ -1456,17 +1495,16 @@ impl TelegramAgent {
                                         )],
                                     ]);
                                     if let Some(msg) = &query.message {
-                                        use teloxide::payloads::EditMessageTextSetters;
-                                        use teloxide::prelude::Requester;
                                         let html = crate::channels::telegram::handler::md_to_html(&text);
-                                        if let Err(e) = bot
-                                            .edit_message_text(msg.chat().id, msg.id(), &html)
-                                            .parse_mode(teloxide::types::ParseMode::Html)
-                                            .reply_markup(keyboard)
-                                            .await
-                                        {
-                                            tracing::warn!("prof:del: failed to edit message: {}", e);
-                                        }
+                                        super::edit_retry::edit_text_ui(
+                                            bot.clone(),
+                                            msg.chat().id,
+                                            msg.id(),
+                                            html,
+                                            true,
+                                            Some(keyboard),
+                                            "prof:del",
+                                        );
                                     }
                                     return ResponseResult::Ok(());
                                 }
@@ -1476,31 +1514,30 @@ impl TelegramAgent {
                                         Ok(()) => {
                                             let text = format!("✅ Profile `{}` deleted.", name);
                                             if let Some(msg) = &query.message {
-                                                use teloxide::payloads::EditMessageTextSetters;
-                                                use teloxide::prelude::Requester;
                                                 let html = crate::channels::telegram::handler::md_to_html(&text);
-                                                if let Err(e) = bot
-                                                    .edit_message_text(msg.chat().id, msg.id(), &html)
-                                                    .parse_mode(teloxide::types::ParseMode::Html)
-                                                    .reply_markup(InlineKeyboardMarkup::default())
-                                                    .await
-                                                {
-                                                    tracing::warn!("Telegram: callback UI update failed: {e}");
-                                                }
+                                                super::edit_retry::edit_text_ui(
+                                                    bot.clone(),
+                                                    msg.chat().id,
+                                                    msg.id(),
+                                                    html,
+                                                    true,
+                                                    Some(InlineKeyboardMarkup::default()),
+                                                    "callback UI update",
+                                                );
                                             }
                                         }
                                         Err(e) => {
                                             let text = format!("❌ Delete failed: {}", e);
                                             if let Some(msg) = &query.message {
-                                                use teloxide::payloads::EditMessageTextSetters;
-                                                use teloxide::prelude::Requester;
-                                                if let Err(e) = bot
-                                                    .edit_message_text(msg.chat().id, msg.id(), &text)
-                                                    .reply_markup(InlineKeyboardMarkup::default())
-                                                    .await
-                                                {
-                                                    tracing::warn!("Telegram: callback UI update failed: {e}");
-                                                }
+                                                super::edit_retry::edit_text_ui(
+                                                    bot.clone(),
+                                                    msg.chat().id,
+                                                    msg.id(),
+                                                    text,
+                                                    false,
+                                                    Some(InlineKeyboardMarkup::default()),
+                                                    "callback UI update",
+                                                );
                                             }
                                         }
                                     }
@@ -1513,17 +1550,16 @@ impl TelegramAgent {
                                     let rows = crate::channels::telegram::handler::build_profiles_keyboard(&resp);
                                     let keyboard = InlineKeyboardMarkup::new(rows);
                                     if let Some(msg) = &query.message {
-                                        use teloxide::payloads::EditMessageTextSetters;
-                                        use teloxide::prelude::Requester;
                                         let html = crate::channels::telegram::handler::md_to_html(&resp.text);
-                                        if let Err(e) = bot
-                                            .edit_message_text(msg.chat().id, msg.id(), &html)
-                                            .parse_mode(teloxide::types::ParseMode::Html)
-                                            .reply_markup(keyboard)
-                                            .await
-                                        {
-                                            tracing::warn!("prof:back: failed to edit message: {}", e);
-                                        }
+                                        super::edit_retry::edit_text_ui(
+                                            bot.clone(),
+                                            msg.chat().id,
+                                            msg.id(),
+                                            html,
+                                            true,
+                                            Some(keyboard),
+                                            "prof:back",
+                                        );
                                     }
                                     return ResponseResult::Ok(());
                                 }
@@ -1659,12 +1695,37 @@ impl TelegramAgent {
                                         {
                                             tracing::warn!("Telegram: callback UI update failed: {e}");
                                         }
-                                        if let Some(mid) = kb_msg_id
-                                            && let Err(e) = bot
-                                                .edit_message_reply_markup(chat_id, mid)
-                                                .await
-                                        {
-                                            tracing::warn!("Telegram: callback UI update failed: {e}");
+                                        if let Some(mid) = kb_msg_id {
+                                            // Used-button strip: defer through the #68
+                                            // machinery. A post-strip failure is benign —
+                                            // the #1226 dead-keyboard sweep may have
+                                            // stripped the same block mid-wait — so the
+                                            // exhaustion path warns without alarm.
+                                            let bot2 = bot.clone();
+                                            match bot.edit_message_reply_markup(chat_id, mid).await {
+                                                Ok(_) => {}
+                                                Err(e) => match super::edit_retry::classify(&e) {
+                                                    super::edit_retry::EditErr::RetryAfter(wait) => {
+                                                        super::edit_retry::spawn_deferred(
+                                                            wait,
+                                                            move || {
+                                                                let bot = bot2.clone();
+                                                                async move {
+                                                                    bot.edit_message_reply_markup(chat_id, mid).await.map(|_| ())
+                                                                }
+                                                            },
+                                                            || async move {
+                                                                tracing::warn!(
+                                                                    "Telegram: plan-approve markup strip deferred retry failed (benign — sweep race)"
+                                                                );
+                                                            },
+                                                        );
+                                                    }
+                                                    super::edit_retry::EditErr::Fatal(msg) => {
+                                                        tracing::warn!("Telegram: callback UI update failed: {msg}");
+                                                    }
+                                                },
+                                            }
                                         }
                                         crate::channels::telegram::send::best_effort_note(
                                             &bot,
@@ -1884,15 +1945,15 @@ impl TelegramAgent {
                                     _ => String::new(),
                                 };
                                 let updated = format!("{}{}", original_text, label);
-                                use teloxide::payloads::EditMessageTextSetters;
-                                use teloxide::prelude::Requester;
-                                if let Err(e) = bot
-                                    .edit_message_text(msg.chat().id, msg.id(), &updated)
-                                    .reply_markup(teloxide::types::InlineKeyboardMarkup::default())
-                                    .await
-                                {
-                                    tracing::error!("Telegram: failed to edit approval message: {}", e);
-                                }
+                                super::edit_retry::edit_text_ui(
+                                    bot.clone(),
+                                    msg.chat().id,
+                                    msg.id(),
+                                    updated,
+                                    false,
+                                    Some(teloxide::types::InlineKeyboardMarkup::default()),
+                                    "approval message",
+                                );
                             } else {
                                 tracing::warn!("Telegram: callback query has no message — cannot edit");
                             }

--- a/src/channels/telegram/dedup_approval.rs
+++ b/src/channels/telegram/dedup_approval.rs
@@ -129,11 +129,19 @@ pub async fn send_approval_request(bot: &Bot, chat_id: ChatId) -> Result<usize, 
     }
     let text = format_proposal_message(&proposals);
     let keyboard = build_keyboard(&proposals);
-    crate::channels::telegram::send::message_in_thread(bot, chat_id, None, text)
-        .parse_mode(ParseMode::Html)
-        .reply_markup(keyboard)
-        .await
-        .map_err(|e| format!("send dedup approval: {e}"))?;
+    // Shared reactive ladder (#297 lineage): a 429 here waits out the
+    // server's window and retries instead of dropping the keyboard. Cron
+    // approval requests previously had no backstop at all.
+    crate::channels::telegram::intermediates::send_retrying_rate_limit(
+        "dedup approval request",
+        || {
+            crate::channels::telegram::send::message_in_thread(bot, chat_id, None, text.clone())
+                .parse_mode(ParseMode::Html)
+                .reply_markup(keyboard.clone())
+        },
+    )
+    .await
+    .map_err(|e| format!("send dedup approval: {e}"))?;
     Ok(proposals.len())
 }
 

--- a/src/channels/telegram/edit_retry.rs
+++ b/src/channels/telegram/edit_retry.rs
@@ -17,6 +17,11 @@
 use std::future::Future;
 use std::time::Duration;
 
+use teloxide::Bot;
+use teloxide::payloads::EditMessageTextSetters;
+use teloxide::prelude::Requester;
+use teloxide::types::{ChatId, InlineKeyboardMarkup, MessageId, ParseMode};
+
 /// Hard ceiling on a server-instructed deferral. Nothing user-facing is
 /// blocked while the deferred task sleeps (the tap flow and the turn
 /// continue), so this only bounds how stale a decoration may get — chosen
@@ -91,6 +96,52 @@ where
                 );
                 exhausted().await;
             }
+        }
+    });
+}
+
+/// The dominant callback-UI edit shape (#62 fold): editMessageText with
+/// optional HTML parse mode and reply markup, warn on death. Attempt now;
+/// on Retry-After defer ONE identical retry past the window (the #68
+/// model); Fatal or exhausted retry → warn with the site label. Fire and
+/// forget — the callback ack and the handler flow are never blocked.
+pub fn edit_text_ui(
+    bot: Bot,
+    chat_id: ChatId,
+    message_id: MessageId,
+    text: String,
+    parse_html: bool,
+    markup: Option<InlineKeyboardMarkup>,
+    label: &'static str,
+) {
+    let fire = move || {
+        let bot = bot.clone();
+        let text = text.clone();
+        let markup = markup.clone();
+        async move {
+            let mut req = bot.edit_message_text(chat_id, message_id, &text);
+            if parse_html {
+                req = req.parse_mode(ParseMode::Html);
+            }
+            if let Some(kb) = markup {
+                req = req.reply_markup(kb);
+            }
+            req.await.map(|_| ())
+        }
+    };
+    tokio::spawn(async move {
+        match fire().await {
+            Ok(()) => {}
+            Err(e) => match classify(&e) {
+                EditErr::RetryAfter(wait) => spawn_deferred(wait, fire, move || async move {
+                    tracing::warn!(
+                        "Telegram: {label} deferred retry exhausted (still rate-limited)"
+                    );
+                }),
+                EditErr::Fatal(msg) => {
+                    tracing::warn!("Telegram: {label} failed: {msg}");
+                }
+            },
         }
     });
 }

--- a/src/channels/telegram/edit_retry.rs
+++ b/src/channels/telegram/edit_retry.rs
@@ -1,0 +1,96 @@
+//! Shared Retry-After handling for best-effort UI-edit legs (#68).
+//!
+//! Before this module every decoration leg (tap pick-record, courtesy
+//! notes) fired exactly once: a Telegram 429 killed it, the immediate
+//! fallback fired ~100ms later INTO the same flood window and was dead by
+//! construction, and the user saw a consumed tap with no visible effect
+//! (incident 2026-09-01 18:17:26Z: pick-record edit 429 "Retry after 12s",
+//! echo fallback 429 105ms later, bubble showed nothing).
+//!
+//! Model, proven by #30's deferred placement: attempt 1 fires immediately;
+//! on a Retry-After the caller spawns a deferred task that sleeps EXACTLY
+//! the server-instructed window (capped — nothing blocks while it waits),
+//! re-fires the SAME prebuilt payload once, and only on exhaustion hands
+//! off to the legacy fallback — which by then runs safely outside the 429
+//! window.
+
+use std::future::Future;
+use std::time::Duration;
+
+/// Hard ceiling on a server-instructed deferral. Nothing user-facing is
+/// blocked while the deferred task sleeps (the tap flow and the turn
+/// continue), so this only bounds how stale a decoration may get — chosen
+/// above the 31–42s windows observed in the #30 ledger.
+pub const MAX_DEFERRED_WAIT: Duration = Duration::from_secs(35);
+
+/// Wait used when only a stringified "(429)" marker survives (the rich arm
+/// buries the true retry_after inside its own internal retry loop) — same
+/// middle-of-the-road default as suggest_options (#30).
+const RICH_429_FALLBACK_WAIT_SECS: u64 = 30;
+
+/// Error class for a best-effort edit (#68): a Retry-After defers one
+/// identical retry; anything else is final.
+pub enum EditErr {
+    /// Telegram answered 429 with a Retry-After — retry once after the wait.
+    RetryAfter(Duration),
+    /// Retrying cannot fix it (bad markup, message gone, ...): fall back now.
+    Fatal(String),
+}
+
+/// Classify a typed teloxide error.
+pub fn classify(e: &teloxide::RequestError) -> EditErr {
+    match e {
+        teloxide::RequestError::RetryAfter(secs) => EditErr::RetryAfter(secs.duration()),
+        other => EditErr::Fatal(other.to_string()),
+    }
+}
+
+/// Classify an already-stringified error. Call sites whose arms fold the
+/// typed error into a `String` before returning (the tap pick-record arms
+/// map `e.to_string()`) lose the enum, so classification keys off the wire
+/// surfaces: teloxide renders `RequestError::RetryAfter` as
+/// `"Retry after <n>s"`, and the rich arm buries `"(429)"` (same marker
+/// [`suggest_options::classify_rich_err`] keys off).
+pub fn classify_str(e: &str) -> EditErr {
+    if let Some(rest) = e
+        .strip_prefix("Retry after ")
+        .and_then(|r| r.strip_suffix('s'))
+        && let Ok(secs) = rest.parse::<u64>()
+    {
+        return EditErr::RetryAfter(Duration::from_secs(secs));
+    }
+    if e.contains("(429)") {
+        return EditErr::RetryAfter(Duration::from_secs(RICH_429_FALLBACK_WAIT_SECS));
+    }
+    EditErr::Fatal(e.to_string())
+}
+
+/// Spawn the deferred retry (#68). The caller continues immediately — the
+/// callback ack, the tap flow and the turn are never blocked. After the
+/// (capped) server-instructed wait the SAME payload is re-fired once; on
+/// exhaustion the caller's fallback finally runs, now safely outside the
+/// 429 window that killed both the edit and the old immediate fallback.
+pub fn spawn_deferred<E, F, Fut, G, Fut2>(wait: Duration, retry: F, exhausted: G)
+where
+    E: std::fmt::Display + Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = Result<(), E>> + Send + 'static,
+    G: FnOnce() -> Fut2 + Send + 'static,
+    Fut2: Future<Output = ()> + Send + 'static,
+{
+    let wait = wait.min(MAX_DEFERRED_WAIT);
+    tokio::spawn(async move {
+        tokio::time::sleep(wait).await;
+        match retry().await {
+            Ok(()) => {
+                tracing::info!("Telegram: deferred UI-edit retry landed after {wait:?} wait");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Telegram: deferred UI-edit retry exhausted after {wait:?} wait ({e}) — running fallback"
+                );
+                exhausted().await;
+            }
+        }
+    });
+}

--- a/src/channels/telegram/edit_retry.rs
+++ b/src/channels/telegram/edit_retry.rs
@@ -54,8 +54,7 @@ pub fn classify(e: &teloxide::RequestError) -> EditErr {
 /// typed error into a `String` before returning (the tap pick-record arms
 /// map `e.to_string()`) lose the enum, so classification keys off the wire
 /// surfaces: teloxide renders `RequestError::RetryAfter` as
-/// `"Retry after <n>s"`, and the rich arm buries `"(429)"` (same marker
-/// [`suggest_options::classify_rich_err`] keys off).
+/// `"Retry after <n>s"`, and the rich arm buries `"(429)"`.
 pub fn classify_str(e: &str) -> EditErr {
     if let Some(rest) = e
         .strip_prefix("Retry after ")

--- a/src/channels/telegram/ephemeral.rs
+++ b/src/channels/telegram/ephemeral.rs
@@ -210,15 +210,55 @@ enum Outcome {
 /// bot may not scope messages in this chat", so it is a warning and the
 /// caller recovers, but it is never swallowed, because a silent failure
 /// looks identical to the feature working while every reply stays public.
+///
+/// A 429 is neither an opinion nor a plain transport failure: it is throttling.
+/// Waiting out the server's `retry_after` (capped) and retrying once usually
+/// lands the send; if it does not, the outcome is `Transport`, never
+/// `Rejected` — caching a throttle as a capability verdict would forfeit the
+/// feature for the life of the process over a busy minute (the exact mistake
+/// `Outcome`'s doc warns about).
 async fn post(token: &str, method: &str, body: &serde_json::Value) -> Outcome {
+    const RETRY_AFTER_CAP: std::time::Duration = std::time::Duration::from_secs(15);
     let url = format!("https://api.telegram.org/bot{token}/{method}");
-    let resp = match reqwest::Client::new().post(&url).json(body).send().await {
+    let mut resp = match reqwest::Client::new().post(&url).json(body).send().await {
         Ok(r) => r,
         Err(e) => {
             tracing::warn!("Telegram: ephemeral {method} transport error: {e}, sending publicly");
             return Outcome::Transport;
         }
     };
+    if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        let text = resp.text().await.unwrap_or_default();
+        let retry_after = serde_json::from_str::<serde_json::Value>(&text)
+            .ok()
+            .and_then(|v| {
+                v.get("parameters")
+                    .and_then(|p| p.get("retry_after"))
+                    .and_then(serde_json::Value::as_u64)
+            })
+            .map(std::time::Duration::from_secs)
+            .unwrap_or(RETRY_AFTER_CAP)
+            .min(RETRY_AFTER_CAP);
+        tracing::warn!(
+            "Telegram: ephemeral {method} throttled, waiting {retry_after:?} and retrying once"
+        );
+        tokio::time::sleep(retry_after).await;
+        resp = match reqwest::Client::new().post(&url).json(body).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(
+                    "Telegram: ephemeral {method} transport error on retry: {e}, sending publicly"
+                );
+                return Outcome::Transport;
+            }
+        };
+        if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            tracing::warn!(
+                "Telegram: ephemeral {method} still throttled after retry, sending publicly"
+            );
+            return Outcome::Transport;
+        }
+    }
     let status = resp.status();
     let text = resp.text().await.unwrap_or_default();
     let parsed: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();

--- a/src/channels/telegram/mod.rs
+++ b/src/channels/telegram/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod commands_tg;
 pub(crate) mod cowork;
 pub(crate) mod dedup_approval;
 pub(crate) mod delivery;
+pub(crate) mod edit_retry;
 pub(crate) mod ephemeral;
 pub(crate) mod flow;
 pub(crate) mod flow_chrome;

--- a/src/channels/telegram/send.rs
+++ b/src/channels/telegram/send.rs
@@ -288,12 +288,51 @@ pub async fn best_effort_note<C>(
             len,
             &hash8,
         ),
-        Err(e) => {
-            tracing::warn!(
-                "Telegram: best-effort note failed ({origin}/{origin_detail} {why}): chat={} err={e}",
-                chat.0
-            );
-        }
+        Err(e) => match super::edit_retry::classify(&e) {
+            super::edit_retry::EditErr::RetryAfter(wait) => {
+                tracing::warn!(
+                    "Telegram: best-effort note 429 (retry after {wait:?}) — deferring one retry \
+                     ({origin}/{origin_detail} {why}): chat={}",
+                    chat.0
+                );
+                // #68: the note re-fires after the server-instructed wait;
+                // the caller is long gone (this fn is fire-and-forget), so
+                // exhaustion just warns — same net effect as before, but the
+                // retry now lands instead of dying with attempt 1.
+                let bot2 = bot.clone();
+                let chat2 = chat;
+                let thread2 = thread_id;
+                let text2 = text.to_string();
+                let mode2 = parse_mode;
+                let origin2 = origin.to_string();
+                let detail2 = origin_detail.to_string();
+                let why2 = why.to_string();
+                super::edit_retry::spawn_deferred(
+                    wait,
+                    move || async move {
+                        let request = message_in_thread(&bot2, chat2, thread2, &text2);
+                        let request = match mode2 {
+                            Some(mode) => request.parse_mode(mode),
+                            None => request,
+                        };
+                        request.await.map(|_| ())
+                    },
+                    move || async move {
+                        tracing::warn!(
+                            "Telegram: best-effort note dropped after deferred retry \
+                             ({origin2}/{detail2} {why2}): chat={}",
+                            chat.0
+                        );
+                    },
+                );
+            }
+            super::edit_retry::EditErr::Fatal(msg) => {
+                tracing::warn!(
+                    "Telegram: best-effort note failed ({origin}/{origin_detail} {why}): chat={} err={msg}",
+                    chat.0
+                );
+            }
+        },
     }
 }
 

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -17,6 +17,7 @@ use teloxide::types::{
 use uuid::Uuid;
 
 use super::TelegramState;
+use super::edit_retry::{EditErr, classify, classify_str};
 
 /// Callback-data prefix for a tapped follow-up suggestion: `followup:<session>:<idx>`.
 pub(crate) const FOLLOWUP_PREFIX: &str = "followup:";
@@ -388,13 +389,13 @@ pub(crate) async fn render_suggestions(
                 send_trailer_bubble(bot, chat_id, thread_id, t).await;
             }
         }
-        Err(PlaceErr::Fatal(e)) => {
+        Err(EditErr::Fatal(e)) => {
             tracing::warn!("Telegram suggest_options: send failed: {e}");
             // The buttons never landed — drop the stash so a stale entry can't
             // swallow an unrelated future tap.
             state.drop_pending_followup(&token).await;
         }
-        Err(PlaceErr::RetryAfter(wait)) => {
+        Err(EditErr::RetryAfter(wait)) => {
             // #30: a 429 here used to drop the stash at once — but BOTH arms
             // die inside the same flood window (the standalone send followed
             // the merge edit by 22ms into the same 41s ban), and the buttons
@@ -448,7 +449,7 @@ pub(crate) async fn render_suggestions(
                             }
                             return;
                         }
-                        Err(PlaceErr::Fatal(e)) => {
+                        Err(EditErr::Fatal(e)) => {
                             tracing::warn!(
                                 "Telegram suggest_options: deferred placement {attempt} \
                                  failed permanently: {e}"
@@ -456,7 +457,7 @@ pub(crate) async fn render_suggestions(
                             state.drop_pending_followup(&token).await;
                             return;
                         }
-                        Err(PlaceErr::RetryAfter(w)) => {
+                        Err(EditErr::RetryAfter(w)) => {
                             tracing::warn!(
                                 "Telegram suggest_options: deferred placement {attempt} hit \
                                  Retry-After {}s again (token {token})",
@@ -487,46 +488,11 @@ struct MergePayload {
     rich: bool,
 }
 
-/// Placement error class (#30): decides whether the stash survives the
-/// failure.
-enum PlaceErr {
-    /// Telegram answered 429 with a Retry-After — the placement may succeed
-    /// once the window passes, so the stash MUST survive the wait.
-    RetryAfter(Duration),
-    /// Anything else: retrying cannot fix it; the stash drops as before.
-    Fatal(String),
-}
-
 /// Deferred placement attempts after a Retry-After, on top of the inline
 /// first pass (#30). Two deferrals cap the chase at roughly two flood
 /// windows while comfortably covering the 31–42s windows observed in the
 /// #30 ledger.
 const MAX_DEFERRED_PLACEMENT_ATTEMPTS: u32 = 2;
-
-/// Wait used when only the rich arm's stringified "(429)" survives — see
-/// [`classify_rich_err`].
-const RICH_429_FALLBACK_WAIT_SECS: u64 = 30;
-
-fn classify_request_err(e: teloxide::RequestError) -> PlaceErr {
-    match e {
-        teloxide::RequestError::RetryAfter(secs) => PlaceErr::RetryAfter(secs.duration()),
-        other => PlaceErr::Fatal(other.to_string()),
-    }
-}
-
-/// The rich arm buries Telegram's exact retry_after inside its own internal
-/// retry loop (`post_rich`) and surfaces only an anyhow string, so
-/// classification keys off the status marker. The wait is a middle-of-the-
-/// road default: the rich path already slept out the true value
-/// RICH_MAX_RETRIES times before bailing, and the observed flood windows
-/// run 31–42s (#30 ledger).
-fn classify_rich_err(e: &str) -> PlaceErr {
-    if e.contains("(429)") {
-        PlaceErr::RetryAfter(Duration::from_secs(RICH_429_FALLBACK_WAIT_SECS))
-    } else {
-        PlaceErr::Fatal(e.to_string())
-    }
-}
 
 /// One placement pass (#30): merge onto the answer bubble when a payload
 /// exists, standalone otherwise. RetryAfter-class errors bubble up so the
@@ -542,12 +508,12 @@ async fn place_once(
     keyboard: &InlineKeyboardMarkup,
     merge: Option<&MergePayload>,
     standalone_body: &str,
-) -> Result<(), PlaceErr> {
+) -> Result<(), EditErr> {
     use teloxide::prelude::Requester;
 
     if let Some(mp) = merge {
         let mid = mp.message_id;
-        let outcome: Result<(), PlaceErr> = if mp.rich {
+        let outcome: Result<(), EditErr> = if mp.rich {
             super::rich::api::edit_rich_html(
                 bot.api_url().as_str(),
                 bot.token(),
@@ -559,14 +525,14 @@ async fn place_once(
                 "-",
             )
             .await
-            .map_err(|e| classify_rich_err(&e.to_string()))
+            .map_err(|e| classify_str(&e.to_string()))
         } else {
             bot.edit_message_text(chat_id, mid, &mp.new_html)
                 .parse_mode(ParseMode::Html)
                 .reply_markup(keyboard.clone())
                 .await
                 .map(|_| ())
-                .map_err(classify_request_err)
+                .map_err(|e| classify(&e))
         };
         match outcome {
             Ok(()) => {
@@ -589,8 +555,8 @@ async fn place_once(
                     .await;
                 return Ok(());
             }
-            Err(PlaceErr::RetryAfter(wait)) => return Err(PlaceErr::RetryAfter(wait)),
-            Err(PlaceErr::Fatal(e)) => {
+            Err(EditErr::RetryAfter(wait)) => return Err(EditErr::RetryAfter(wait)),
+            Err(EditErr::Fatal(e)) => {
                 tracing::warn!(
                     "Telegram suggest_options: merge onto msg {mid} failed ({e}) — standalone fallback"
                 );
@@ -614,7 +580,7 @@ async fn place_once(
             );
             Ok(())
         }
-        Err(e) => Err(classify_request_err(e)),
+        Err(e) => Err(classify(&e)),
     }
 }
 

--- a/src/tests/edit_retry_test.rs
+++ b/src/tests/edit_retry_test.rs
@@ -59,8 +59,11 @@ async fn classify_reads_typed_teloxide_retry_after() {
         .expect(1)
         .create_async()
         .await;
-    let bot = Bot::with_client("TESTTOKEN", reqwest::Client::builder().build().unwrap())
-        .set_api_url(server.url().parse().unwrap());
+    let bot = Bot::with_client(
+        "TESTTOKEN",
+        reqwest_teloxide::Client::builder().build().unwrap(),
+    )
+    .set_api_url(server.url().parse().unwrap());
 
     let err = bot
         .edit_message_text(
@@ -105,8 +108,11 @@ async fn best_effort_note_defers_one_retry_past_the_429_window() {
         .expect(1)
         .create_async()
         .await;
-    let bot = Bot::with_client("TESTTOKEN", reqwest::Client::builder().build().unwrap())
-        .set_api_url(server.url().parse().unwrap());
+    let bot = Bot::with_client(
+        "TESTTOKEN",
+        reqwest_teloxide::Client::builder().build().unwrap(),
+    )
+    .set_api_url(server.url().parse().unwrap());
 
     best_effort_note(
         &bot,

--- a/src/tests/edit_retry_test.rs
+++ b/src/tests/edit_retry_test.rs
@@ -1,0 +1,129 @@
+//! Regression tests for the shared Retry-After edit handler (#68).
+//!
+//! Incident 2026-09-01 18:17:26Z: a suggestion-button tap hit a Telegram 429
+//! ("Retry after 12s") on the pick-record edit, and the immediate quoted-echo
+//! fallback fired 105ms later INTO the same flood window and died too — the
+//! tap was consumed with no visible effect. The fix defers ONE identical
+//! retry past the server-instructed window; the fallback only runs on
+//! exhaustion.
+//!
+//! Tests: (1) the string classifier used by the tap leg, whose arms fold
+//! typed errors into strings before returning; (2) the typed classifier;
+//! (3) the full wire behavior — attempt 1 draws a 429 with retry_after, the
+//! deferred task re-fires after the window and lands.
+
+use std::time::Duration;
+
+use crate::channels::telegram::edit_retry::{self, EditErr};
+use crate::channels::telegram::send::best_effort_note;
+use teloxide::prelude::*;
+
+const FOUR29_BODY: &str = r#"{"ok":false,"error_code":429,"description":"Too Many Requests: retry after 1","parameters":{"retry_after":1}}"#;
+
+#[test]
+fn classify_str_parses_teloxide_retry_after_marker() {
+    // teloxide renders RequestError::RetryAfter as "Retry after <n>s" — the
+    // exact surface the 18:17:26Z incident warn shows.
+    match edit_retry::classify_str("Retry after 12s") {
+        EditErr::RetryAfter(wait) => assert_eq!(wait, Duration::from_secs(12)),
+        EditErr::Fatal(e) => panic!("expected RetryAfter, got Fatal: {e}"),
+    }
+}
+
+#[test]
+fn classify_str_falls_back_on_rich_429_marker() {
+    // The rich arm buries "(429)" in its anyhow string (#30 precedent).
+    match edit_retry::classify_str("rich render failed: (429) too many requests") {
+        EditErr::RetryAfter(wait) => assert_eq!(wait, Duration::from_secs(30)),
+        EditErr::Fatal(e) => panic!("expected RetryAfter, got Fatal: {e}"),
+    }
+}
+
+#[test]
+fn classify_str_fatal_errors_stay_fatal() {
+    match edit_retry::classify_str("chat not found") {
+        EditErr::RetryAfter(wait) => panic!("expected Fatal, got RetryAfter {wait:?}"),
+        EditErr::Fatal(e) => assert_eq!(e, "chat not found"),
+    }
+}
+
+#[tokio::test]
+async fn classify_reads_typed_teloxide_retry_after() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/botTESTTOKEN/EditMessageText")
+        .with_status(429)
+        .with_header("content-type", "application/json")
+        .with_header("retry-after", "1")
+        .with_body(FOUR29_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    let bot = Bot::with_client("TESTTOKEN", reqwest::Client::builder().build().unwrap())
+        .set_api_url(server.url().parse().unwrap());
+
+    let err = bot
+        .edit_message_text(
+            teloxide::types::ChatId(1),
+            teloxide::types::MessageId(7),
+            "x",
+        )
+        .await
+        .expect_err("expected the 429 to surface as an error");
+
+    match edit_retry::classify(&err) {
+        EditErr::RetryAfter(wait) => assert_eq!(wait, Duration::from_secs(1)),
+        EditErr::Fatal(e) => panic!("expected RetryAfter from typed 429, got Fatal: {e}"),
+    }
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn best_effort_note_defers_one_retry_past_the_429_window() {
+    let mut server = mockito::Server::new_async().await;
+    // Attempt 1: 429 with retry_after=1 — the server-instructed window.
+    let first = server
+        .mock("POST", "/botTESTTOKEN/SendMessage")
+        .with_status(429)
+        .with_header("content-type", "application/json")
+        .with_header("retry-after", "1")
+        .with_body(FOUR29_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    // Deferred retry, byte-identical request: 200 OK.
+    let second = server
+        .mock("POST", "/botTESTTOKEN/SendMessage")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            // Full Message, not just an id — teloxide decodes sendMessage's
+            // result into `Message` (#28 lesson); a bare id fails decode and
+            // the retry would read as failed even though the wire hit 200.
+            r#"{"ok":true,"result":{"message_id":42,"date":1756166400,"chat":{"id":1,"first_name":"t","type":"private"},"text":"hello"}}"#,
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let bot = Bot::with_client("TESTTOKEN", reqwest::Client::builder().build().unwrap())
+        .set_api_url(server.url().parse().unwrap());
+
+    best_effort_note(
+        &bot,
+        teloxide::types::ChatId(1),
+        None,
+        "hello",
+        None,
+        "test",
+        "edit-retry",
+        "wire test",
+    )
+    .await;
+
+    // Attempt 1 fired synchronously and drew the 429.
+    first.assert_async().await;
+    // The deferred retry lands after the 1s server-instructed window. The
+    // 1s wait is server-instructed and bounded — not a flake-sleep lottery.
+    tokio::time::sleep(Duration::from_millis(2500)).await;
+    second.assert_async().await;
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -236,6 +236,7 @@ pub mod doc_gen_pptx_test;
 pub mod doc_gen_xlsx_test;
 pub mod doctor_fix_test;
 pub mod duplicate_submit_test;
+pub mod edit_retry_test;
 pub mod empty_reasoning_stub_test;
 pub mod epistemic_inline_test;
 pub mod epistemic_plan_start_test;

--- a/src/tui/render/theme_picker.rs
+++ b/src/tui/render/theme_picker.rs
@@ -127,7 +127,12 @@ impl ThemePickerState {
         } else {
             return PickerAction::None;
         };
+        let prev = self.selected;
         self.move_selection(step);
+        if self.selected == prev {
+            // Clamped at a list end: nothing moved, so no new preview.
+            return PickerAction::None;
+        }
         self.scroll_into_view(visible_rows.max(1));
         match self.items.get(self.selected).and_then(|i| i.theme) {
             Some(t) => PickerAction::Preview(t),

--- a/src/tui/render/theme_picker.rs
+++ b/src/tui/render/theme_picker.rs
@@ -16,11 +16,11 @@
 //! every global mutation in one place (`state.rs`'s key handler).
 
 use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
-use ratatui::Frame;
 
 use super::presets;
 use super::theme::{self, Theme};
@@ -77,7 +77,9 @@ impl ThemePickerState {
     }
 
     fn selected_is_rejected(&self) -> bool {
-        self.items.get(self.selected).is_some_and(|i| i.theme.is_none())
+        self.items
+            .get(self.selected)
+            .is_some_and(|i| i.theme.is_none())
     }
 
     /// Move toward `step`, skipping rejected rows, clamping at the ends.
@@ -191,7 +193,9 @@ pub fn draw(f: &mut Frame, area: Rect, state: &ThemePickerState) {
     // 46 cols fits `▶ ● solarized-light (user)` comfortably; 3 border rows
     // + 2 hint rows chrome; list rows capped by the roster size.
     let width = 48u16;
-    let height = (state.items.len() as u16 + 6).min(area.height.saturating_sub(4)).max(9);
+    let height = (state.items.len() as u16 + 6)
+        .min(area.height.saturating_sub(4))
+        .max(9);
     let popup = centered_rect(area, width, height);
 
     f.render_widget(Clear, popup);
@@ -218,7 +222,11 @@ pub fn draw(f: &mut Frame, area: Rect, state: &ThemePickerState) {
             let cursor = if idx == state.selected { "▶ " } else { "  " };
             let line = match (&item.theme, &item.reason) {
                 (Some(t), _) => {
-                    let applied = if t.name == state.origin.name { "● " } else { "  " };
+                    let applied = if t.name == state.origin.name {
+                        "● "
+                    } else {
+                        "  "
+                    };
                     let tag = if item.is_user { " (user)" } else { "" };
                     let style = if idx == state.selected {
                         Style::default().fg(theme::role(theme::Role::Accent))
@@ -227,7 +235,10 @@ pub fn draw(f: &mut Frame, area: Rect, state: &ThemePickerState) {
                     } else {
                         Style::default().fg(theme::role(theme::Role::TextPrimary))
                     };
-                    Line::from(Span::styled(format!("{cursor}{applied}{}{tag}", t.name), style))
+                    Line::from(Span::styled(
+                        format!("{cursor}{applied}{}{tag}", t.name),
+                        style,
+                    ))
                 }
                 (None, Some(reason)) => Line::from(Span::styled(
                     format!("  ✗ {reason}"),
@@ -248,8 +259,7 @@ pub fn draw(f: &mut Frame, area: Rect, state: &ThemePickerState) {
     }
     list_state.select(Some(state.selected));
 
-    let list = List::new(items)
-        .style(Style::default().fg(theme::role(theme::Role::TextPrimary)));
+    let list = List::new(items).style(Style::default().fg(theme::role(theme::Role::TextPrimary)));
     // ratatui reads the scroll window back out of the state after rendering,
     // so hand it our per-frame offset through the real offset slot.
     *list_state.offset_mut() = offset;
@@ -321,7 +331,10 @@ mod tests {
     fn navigation_skips_rejected_rows_both_ways() {
         let mut s = fixture();
         s.selected = 1; // dracula; row 2 is rejected
-        expect_preview(s.handle_key(&key(KeyCode::Down), 10), &presets::SOLARIZED_DARK);
+        expect_preview(
+            s.handle_key(&key(KeyCode::Down), 10),
+            &presets::SOLARIZED_DARK,
+        );
         assert_eq!(s.selected, 3);
         expect_preview(s.handle_key(&key(KeyCode::Up), 10), &presets::DRACULA);
         assert_eq!(s.selected, 1);

--- a/src/tui/render/theme_picker.rs
+++ b/src/tui/render/theme_picker.rs
@@ -16,11 +16,11 @@
 //! every global mutation in one place (`state.rs`'s key handler).
 
 use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
 
 use super::presets;
 use super::theme::{self, Theme};
@@ -74,12 +74,6 @@ impl ThemePickerState {
             origin,
             scroll_offset: 0,
         }
-    }
-
-    fn selected_is_rejected(&self) -> bool {
-        self.items
-            .get(self.selected)
-            .is_some_and(|i| i.theme.is_none())
     }
 
     /// Move toward `step`, skipping rejected rows, clamping at the ends.
@@ -271,6 +265,18 @@ pub fn draw(f: &mut Frame, area: Rect, state: &ThemePickerState) {
     f.render_widget(hints, rows[1]);
 }
 
+/// Fixed-size popup centered in `area`, clamped to fit.
+fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let x = area.width.saturating_sub(width) / 2;
+    let y = area.height.saturating_sub(height) / 2;
+    Rect {
+        x: area.x + x,
+        y: area.y + y,
+        width: width.min(area.width),
+        height: height.min(area.height),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -424,17 +430,5 @@ mod tests {
         assert_eq!(s.selected, 3);
         assert!(s.selected >= s.scroll_offset);
         assert!(s.selected < s.scroll_offset + 2);
-    }
-}
-
-/// Fixed-size popup centered in `area`, clamped to fit.
-fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
-    let x = area.width.saturating_sub(width) / 2;
-    let y = area.height.saturating_sub(height) / 2;
-    Rect {
-        x: area.x + x,
-        y: area.y + y,
-        width: width.min(area.width),
-        height: height.min(area.height),
     }
 }


### PR DESCRIPTION
fix(telegram): theme-2 harvest — 429 edit-retry ladder for best-effort UI edits

Theme 2 of the fork harvest: a single retry ladder for best-effort UI
edits that die on Telegram 429s, replacing per-callsite ad-hoc handling.

## What

1. **edit_retry ladder (#68)** — `edit_retry.rs`: `classify_str` /
   `classify_request_err` map any edit/send failure onto `EditErr`
   (`RetryAfter(Duration)` vs `Fatal`), and
   `edit_retry::defer_one(bot, edit, wait)` fires exactly one identical
   retry after the Retry-After window. Best-effort edits defer instead of
   dropping the pick (#30 semantics: the stash survives the window).
2. **18-leg routing (#62)** — every unpaced `edit_message_*` leg in
   `agent.rs`'s callback path goes through the ladder: 429 → defer once →
   single refire; nothing echoes twice (dedup_approval guard).
3. **Backstops** — ephemeral posts and dedup approval sends get the same
   429 handling (warn-only, no crash on retry exhaustion).
4. **Classifier fold (#75)** — suggest_options' private
   `classify_request_err`/`classify_rich_err` deleted, both arms route
   through the shared `edit_retry` classifiers.

## Smoke evidence

Organic positive chain captured in production (ops daemon,
2026-09-04T23:25Z, owner-approved verdict): callback tap →
`pick-record edit 429 (retry after 37s)` WARN → deferred refire landed
after 37.3s → pick recorded, keyboard stripped; exactly one defer+refire,
no duplicate echo; rapid double-tap rejected by the consumed-token guard.

## Carried CI fixes (upstream main is red at 3f880c5e)

- `6974a136` edit_retry tests: `Bot::with_client` wants teloxide's
  reqwest 0.12 type — `reqwest_teloxide::Client` (#1345 pattern,
  governor_gates_test.rs:326). Fixes E0308 x2 in run 33948558316.
- `65f9f572` rustfmt sweep on `theme_picker.rs` — upstream's own
  fmt-check is red at `3f880c5e` (run 33939222393); mechanical,
  rustfmt --edition 2024, no semantic change.

## CI

PR-lane gates: (green run URL pending — will be cited here)

#62 and #75 are covered by commits 2 and 4 above; the theme-2 verdict
lives in the fork's smoke-verdicts ledger. No `Closes` — upstream fixes
land here first, fork syncs after merge.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/68
