### PR TITLE
feat: tap-redraw picked suggestion buttons on rich hosts (leshchenko1979/opencrabs#67)

### DIFF
--- a/src/channels/telegram/agent.rs
+++ b/src/channels/telegram/agent.rs
@@ -460,6 +460,7 @@ impl TelegramAgent {
                                                             .as_ref()
                                                             .map(|(full, rich)| (full.as_str(), *rich)),
                                                         picked,
+                                                        idx,
                                                     );
                                                 let outcome: Result<(), String> = match rewrite {
                                                     super::suggest_options::PickRewrite::RichHost(

--- a/src/channels/telegram/agent.rs
+++ b/src/channels/telegram/agent.rs
@@ -363,7 +363,7 @@ impl TelegramAgent {
                                         None
                                     }
                                 };
-                                if let Some((entry, text)) = taken {
+                                if let Some((entry, text, picked_idx)) = taken {
                                     let sid = entry.session_id;
                                     let merged_host = entry.host.clone();
                                     let (chat_id, thread_id, prompt_msg_id) = query
@@ -460,7 +460,7 @@ impl TelegramAgent {
                                                             .as_ref()
                                                             .map(|(full, rich)| (full.as_str(), *rich)),
                                                         picked,
-                                                        idx,
+                                                        picked_idx,
                                                     );
                                                 let outcome: Result<(), String> = match rewrite {
                                                     super::suggest_options::PickRewrite::RichHost(

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -842,10 +842,17 @@ impl TelegramState {
         &self,
         token: &str,
         idx: usize,
-    ) -> Option<(PendingFollowupEntry, String)> {
+    ) -> Option<(PendingFollowupEntry, String, usize)> {
         let entry = self.pending_followups.lock().await.remove(token)?;
         self.forget_followup(token).await;
-        entry.options.get(idx).cloned().map(|text| (entry, text))
+        // #67: idx rides along — the tap-redraw rewrite runs in a spawned
+        // task lexically outside the arm that binds idx, so the tapped
+        // index must come back through the take's return tuple.
+        entry
+            .options
+            .get(idx)
+            .cloned()
+            .map(|text| (entry, text, idx))
     }
 
     /// Re-arm a keyboard whose tap could not start a turn (#1226 G): the

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -298,12 +298,23 @@ pub(crate) fn mark_picked_button(html: &str, picked_idx: usize) -> String {
             let mut new_attrs = attrs.to_string();
             if picked {
                 // The picked button flips to success regardless of its
-                // original style; siblings keep theirs.
+                // original style.
                 if let Some(s) = new_attrs.find("style=\"")
                     && let Some(e) = new_attrs[s + "style=\"".len()..].find('"')
                 {
                     let style_end = s + "style=\"".len() + e;
                     new_attrs.replace_range(s + "style=\"".len()..style_end, "success");
+                }
+            } else {
+                // #71: a styled button still renders enabled-looking even
+                // with `disabled` (owner A/B: `style="primary" disabled`
+                // stays blue), so siblings drop their style attribute —
+                // bare `disabled` is the only form that renders grayed.
+                if let Some(s) = new_attrs.find(" style=\"")
+                    && let Some(e) = new_attrs[s + " style=\"".len()..].find('"')
+                {
+                    let style_end = s + " style=\"".len() + e + 1;
+                    new_attrs.replace_range(s..style_end, "");
                 }
             }
             if !new_attrs.contains("disabled") {

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -328,7 +328,6 @@ pub(crate) fn mark_picked_button(html: &str, picked_idx: usize) -> String {
     out
 }
 
-
 #[allow(clippy::too_many_arguments)] // #31: trailer rides the existing arg set
 pub(crate) async fn render_suggestions(
     bot: &teloxide::Bot,

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -93,10 +93,25 @@ pub(crate) enum PickRewrite {
 /// `host` is `(html, rich)` of the merged host bubble when the tapped
 /// message IS it; merged host → answer HTML + pick record, standalone →
 /// pick record alone.
-pub(crate) fn pick_rewrite(host: Option<(&str, bool)>, picked: String) -> PickRewrite {
+pub(crate) fn pick_rewrite(
+    host: Option<(&str, bool)>,
+    picked: String,
+    picked_idx: usize,
+) -> PickRewrite {
     match host {
         Some((full, rich)) => {
-            let body = format!("{full}\n\n{picked}");
+            let body = if rich {
+                // #67 tap-redraw: the rows must not survive as live
+                // controls — they are rewritten to the picked state
+                // (success+✓+disabled / disabled) instead of stripped, so
+                // the bubble keeps showing what was chosen.
+                format!("{}\n\n{picked}", mark_picked_button(full, picked_idx))
+            } else {
+                // Classic hosts keep their buttons as reply markup (not in
+                // the body) — the empty-markup arm strips those; nothing to
+                // rewrite here.
+                format!("{full}\n\n{picked}")
+            };
             if rich {
                 PickRewrite::RichHost(body)
             } else {
@@ -234,6 +249,85 @@ pub(crate) fn suggestion_rows_rich_html(options: &[String], token: &str) -> Stri
             .join("\n"),
     }
 }
+
+/// #67 tap-redraw: rewrite suggestion buttons in a rich bubble body to
+/// their post-pick state. The picked button (whose
+/// `data="followup:<token>:<idx>"` payload ends in `picked_idx`) becomes
+/// `style="success"` with a `✓ ` label prefix; every sibling follow-up
+/// button keeps its style and gains `disabled`. Non-follow-up markup and
+/// row containers pass through byte-for-byte. Best-effort by design: if
+/// the `disabled` attribute form is ever ignored by the client, a second
+/// tap routes to the stale-shell guard, so nothing can loop.
+pub(crate) fn mark_picked_button(html: &str, picked_idx: usize) -> String {
+    let mut out = String::with_capacity(html.len() + 64);
+    let mut rest = html;
+    while let Some(tag_start) = rest.find("<tg-button") {
+        let after_open = &rest[tag_start + "<tg-button".len()..];
+        // `<tg-button-row>` and any other `<tg-button…` lookalike that is
+        // not the button tag itself passes through untouched.
+        if !after_open.starts_with('>') && !after_open.starts_with(' ') {
+            out.push_str(&rest[..tag_start + "<tg-button".len()]);
+            rest = after_open;
+            continue;
+        }
+        let Some(attrs_rel) = after_open.find('>') else {
+            // Unterminated tag: emit the remainder verbatim.
+            out.push_str(rest);
+            return out;
+        };
+        let attrs = &after_open[..attrs_rel];
+        let after_attrs = &after_open[attrs_rel + 1..];
+        let body_rel = attrs_rel + 1;
+        let Some(label_rel) = after_attrs.find("</tg-button>") else {
+            // Unterminated label: emit through the tag opener verbatim.
+            out.push_str(&rest[..tag_start + body_rel]);
+            rest = after_attrs;
+            continue;
+        };
+        let label = &after_attrs[..label_rel];
+        let tail = &after_attrs[label_rel + "</tg-button>".len()..];
+        let idx = attrs
+            .split("data=\"followup:")
+            .nth(1)
+            .and_then(|v| v.split('"').next())
+            .and_then(|v| v.rsplit(':').next())
+            .and_then(|v| v.parse::<usize>().ok());
+        let picked = idx == Some(picked_idx);
+        if picked || idx.is_some() {
+            let mut new_attrs = attrs.to_string();
+            if picked {
+                // The picked button flips to success regardless of its
+                // original style; siblings keep theirs.
+                if let Some(s) = new_attrs.find("style=\"") {
+                    if let Some(e) = new_attrs[s + "style=\"".len()..].find('"') {
+                        let style_end = s + "style=\"".len() + e;
+                        new_attrs.replace_range(s + "style=\"".len()..style_end, "success");
+                    }
+                }
+            }
+            if !new_attrs.contains("disabled") {
+                new_attrs.push_str(" disabled");
+            }
+            out.push_str(&rest[..tag_start]);
+            out.push_str("<tg-button");
+            out.push_str(&new_attrs);
+            out.push('>');
+            if picked {
+                out.push_str("\u{2713} ");
+            }
+            out.push_str(label);
+            out.push_str("</tg-button>");
+        } else {
+            // Not a follow-up button: emit the whole span verbatim.
+            out.push_str(&rest[..tag_start + body_rel + label_rel]);
+            out.push_str("</tg-button>");
+        }
+        rest = tail;
+    }
+    out.push_str(rest);
+    out
+}
+
 
 #[allow(clippy::too_many_arguments)] // #31: trailer rides the existing arg set
 pub(crate) async fn render_suggestions(

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -275,12 +275,13 @@ pub(crate) fn mark_picked_button(html: &str, picked_idx: usize) -> String {
             out.push_str(rest);
             return out;
         };
+        let tag_open_len = "<tg-button".len();
         let attrs = &after_open[..attrs_rel];
         let after_attrs = &after_open[attrs_rel + 1..];
         let body_rel = attrs_rel + 1;
         let Some(label_rel) = after_attrs.find("</tg-button>") else {
             // Unterminated label: emit through the tag opener verbatim.
-            out.push_str(&rest[..tag_start + body_rel]);
+            out.push_str(&rest[..tag_start + tag_open_len + body_rel]);
             rest = after_attrs;
             continue;
         };

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -298,11 +298,11 @@ pub(crate) fn mark_picked_button(html: &str, picked_idx: usize) -> String {
             if picked {
                 // The picked button flips to success regardless of its
                 // original style; siblings keep theirs.
-                if let Some(s) = new_attrs.find("style=\"") {
-                    if let Some(e) = new_attrs[s + "style=\"".len()..].find('"') {
-                        let style_end = s + "style=\"".len() + e;
-                        new_attrs.replace_range(s + "style=\"".len()..style_end, "success");
-                    }
+                if let Some(s) = new_attrs.find("style=\"")
+                    && let Some(e) = new_attrs[s + "style=\"".len()..].find('"')
+                {
+                    let style_end = s + "style=\"".len() + e;
+                    new_attrs.replace_range(s + "style=\"".len()..style_end, "success");
                 }
             }
             if !new_attrs.contains("disabled") {

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -320,7 +320,7 @@ pub(crate) fn mark_picked_button(html: &str, picked_idx: usize) -> String {
             out.push_str("</tg-button>");
         } else {
             // Not a follow-up button: emit the whole span verbatim.
-            out.push_str(&rest[..tag_start + body_rel + label_rel]);
+            out.push_str(&rest[..tag_start + tag_open_len + body_rel + label_rel]);
             out.push_str("</tg-button>");
         }
         rest = tail;

--- a/src/tests/telegram_followup_persistence_test.rs
+++ b/src/tests/telegram_followup_persistence_test.rs
@@ -93,7 +93,7 @@ async fn store_hydration_restores_armed_keyboards() {
     state.set_followup_store(repo.clone()).await;
 
     // The keyboard resolves a tap, host and all — no stale-shell strip.
-    let (entry, text) = state.take_pending_followup("boot1", 1).await.unwrap();
+    let (entry, text, _picked_idx) = state.take_pending_followup("boot1", 1).await.unwrap();
     assert_eq!(entry.session_id, sid);
     assert_eq!(text, "abort");
     let host = entry.host.expect("hydrated host survives");
@@ -132,7 +132,7 @@ async fn register_and_take_mirror_the_store() {
     assert!(rows[0].host.is_some());
 
     // Take consumes map + row.
-    let (entry, text) = state.take_pending_followup(&token, 0).await.unwrap();
+    let (entry, text, _picked_idx) = state.take_pending_followup(&token, 0).await.unwrap();
     assert_eq!(text, "alpha");
     assert_eq!(entry.options.len(), 2);
     assert!(repo.load_all().await.unwrap().is_empty());
@@ -148,12 +148,12 @@ async fn restore_revives_a_consumed_token_for_the_busy_guard() {
         .register_pending_followups(sid, vec!["first".to_string(), "second".to_string()])
         .await;
 
-    let (entry, _text) = state.take_pending_followup(&token, 0).await.unwrap();
+    let (entry, _text, _picked_idx) = state.take_pending_followup(&token, 0).await.unwrap();
     assert!(state.take_pending_followup(&token, 0).await.is_none());
 
     // The guard's recovery path.
     state.restore_pending_followup(&token, entry).await;
-    let (_revived, text) = state.take_pending_followup(&token, 1).await.unwrap();
+    let (_revived, text, _picked_idx) = state.take_pending_followup(&token, 1).await.unwrap();
     assert_eq!(text, "second");
 }
 

--- a/src/tests/telegram_followup_pick_test.rs
+++ b/src/tests/telegram_followup_pick_test.rs
@@ -13,7 +13,8 @@
 //! Fixtures are synthetic and carry no user identifiers.
 
 use crate::channels::telegram::suggest_options::{
-    PickRewrite, echo_fallback, pick_rewrite, picked_block,
+    PickRewrite, echo_fallback, mark_picked_button, pick_rewrite, picked_block,
+    suggestion_rows_rich_html,
 };
 
 const CHOICE: &str = "Update the SKILL.md with the new callback routing";
@@ -114,6 +115,7 @@ fn classic_host_body_keeps_answer_and_pick() {
     let rewrite = pick_rewrite(
         Some(("<b>the answer</b>", false)),
         picked_block(CHOICE, None),
+        0,
     );
     let PickRewrite::ClassicHost(body) = rewrite else {
         panic!("a classic host must stay classic: {rewrite:?}")
@@ -131,6 +133,7 @@ fn rich_host_body_keeps_answer_and_pick() {
     let rewrite = pick_rewrite(
         Some(("<b>the answer</b>", true)),
         picked_block(CHOICE, None),
+        0,
     );
     let PickRewrite::RichHost(body) = rewrite else {
         panic!("a rich host must stay rich: {rewrite:?}")
@@ -146,7 +149,7 @@ fn rich_host_body_keeps_answer_and_pick() {
 fn standalone_body_is_the_pick_record_alone() {
     let record = picked_block(CHOICE, None);
     assert_eq!(
-        pick_rewrite(None, record.clone()),
+        pick_rewrite(None, record.clone(), 0),
         PickRewrite::Standalone(record)
     );
 }
@@ -156,8 +159,8 @@ fn the_rich_flag_decides_the_transport_not_the_body() {
     // Same host html, same pick — only the rich flag flips, so the two
     // bodies must match byte for byte; only the variant differs.
     let picked = picked_block(CHOICE, None);
-    let classic = pick_rewrite(Some(("host", false)), picked.clone());
-    let rich = pick_rewrite(Some(("host", true)), picked);
+    let classic = pick_rewrite(Some(("host", false)), picked.clone(), 0);
+    let rich = pick_rewrite(Some(("host", true)), picked, 0);
     fn body_of(r: &PickRewrite) -> &str {
         match r {
             PickRewrite::RichHost(b) | PickRewrite::ClassicHost(b) | PickRewrite::Standalone(b) => {
@@ -167,4 +170,78 @@ fn the_rich_flag_decides_the_transport_not_the_body() {
     }
     assert_eq!(body_of(&classic), body_of(&rich));
     assert_ne!(classic, rich, "the variant must flip with the flag");
+}
+// ── #67 tap-redraw: mark_picked_button ──────────────────────────────────────
+
+fn shared_row_html() -> String {
+    // Build via the real renderer so the transform is tested against the
+    // production markup shape, not a hand-typed lookalike.
+    suggestion_rows_rich_html(&["Approve".to_string(), "Decline".to_string()], "tok")
+}
+
+#[test]
+fn picked_button_flips_to_success_check_disabled() {
+    let marked = mark_picked_button(&shared_row_html(), 0);
+    let picked_btn = marked.split("<tg-button ").nth(1).unwrap();
+    let picked_span = &picked_btn[..picked_btn.find("</tg-button>").unwrap()];
+    assert!(
+        picked_span.contains("style=\"success\""),
+        "picked flips to success: {picked_span}"
+    );
+    assert!(
+        picked_span.contains(" disabled"),
+        "picked disabled: {picked_span}"
+    );
+    assert!(
+        picked_span.ends_with("\u{2713} Approve"),
+        "check prefix on the picked label: {picked_span}"
+    );
+}
+
+#[test]
+fn unpicked_buttons_disabled_keep_style_and_label() {
+    let marked = mark_picked_button(&shared_row_html(), 0);
+    let second = marked.split("<tg-button ").nth(2).unwrap();
+    let span = &second[..second.find("</tg-button>").unwrap()];
+    assert!(span.contains(" disabled"), "sibling disabled: {span}");
+    assert!(
+        span.contains("style=\"primary\""),
+        "sibling keeps primary: {span}"
+    );
+    assert!(!span.contains('\u{2713}'), "no check on siblings: {span}");
+    assert!(span.ends_with(">Decline"), "label untouched: {span}");
+}
+
+#[test]
+fn non_followup_markup_passes_through_byte_for_byte() {
+    let html = "<p>hi</p><tg-button-row><tg-button type=\"url\" data=\"https://x\">x</tg-button></tg-button-row>";
+    assert_eq!(mark_picked_button(html, 0), html);
+}
+
+#[test]
+fn html_without_buttons_is_identity() {
+    let html = "<b>answer</b>\n\n<p>record</p>";
+    assert_eq!(mark_picked_button(html, 1), html);
+}
+
+#[test]
+fn tap_redraw_rich_host_body_has_marked_rows_and_record() {
+    // End-to-end through pick_rewrite: rows rewritten to the picked state,
+    // record appended, #39 order preserved (answer/rows first, record last).
+    let host = format!("<b>the answer</b>\n{}", shared_row_html());
+    let rewrite = pick_rewrite(Some((&host, true)), picked_block(CHOICE, None), 1);
+    let PickRewrite::RichHost(body) = rewrite else {
+        panic!("rich host stays rich")
+    };
+    assert!(body.contains("style=\"success\""), "picked marked: {body}");
+    assert!(body.contains(" disabled"), "buttons disabled: {body}");
+    assert!(
+        !body.contains("style=\"primary\"\">Approve"),
+        "the picked label must be check-prefixed"
+    );
+    assert!(body.contains(CHOICE), "pick record survives: {body}");
+    assert!(
+        body.rfind(CHOICE).unwrap() > body.rfind("</tg-button-row>").unwrap(),
+        "record rides after the rows (#39)"
+    );
 }

--- a/src/tests/telegram_followup_pick_test.rs
+++ b/src/tests/telegram_followup_pick_test.rs
@@ -199,14 +199,14 @@ fn picked_button_flips_to_success_check_disabled() {
 }
 
 #[test]
-fn unpicked_buttons_disabled_keep_style_and_label() {
+fn unpicked_buttons_disabled_drop_style_and_label() {
     let marked = mark_picked_button(&shared_row_html(), 0);
     let second = marked.split("<tg-button ").nth(2).unwrap();
     let span = &second[..second.find("</tg-button>").unwrap()];
     assert!(span.contains(" disabled"), "sibling disabled: {span}");
     assert!(
-        span.contains("style=\"primary\""),
-        "sibling keeps primary: {span}"
+        !span.contains("style="),
+        "#71: sibling drops its style (style visually eats disabled): {span}"
     );
     assert!(!span.contains('\u{2713}'), "no check on siblings: {span}");
     assert!(span.ends_with(">Decline"), "label untouched: {span}");

--- a/src/tui/app/messaging.rs
+++ b/src/tui/app/messaging.rs
@@ -836,9 +836,8 @@ impl App {
                     "" => {
                         // Bare /theme opens the interactive picker (#1371);
                         // `list` keeps the text surface for habits/scripts.
-                        self.theme_picker = Some(
-                            crate::tui::render::theme_picker::ThemePickerState::open(),
-                        );
+                        self.theme_picker =
+                            Some(crate::tui::render::theme_picker::ThemePickerState::open());
                     }
                     "list" | "ls" => {
                         let active_name = theme::active().name;


### PR DESCRIPTION
## What

Tap-redraw for follow-up suggestion buttons on rich hosts: after the user taps a suggestion, the rich host body's button rows are rewritten in place instead of vanishing — the picked button flips to `style="success"` with a `✓` prefix and `disabled`, every sibling keeps its style and gains `disabled`. Classic and standalone planes stay on the empty-markup strip (teloxide 0.17.0 has no Bot API 10.3 `style`/`disabled` fields on `InlineKeyboardButton`).

## Details

- `mark_picked_button` transforms the production rich markup shape only (`followup:`-data buttons); non-follow-up markup and row containers pass through byte-for-byte. If a client ever ignored the `disabled` form, a second tap routes to the stale-shell guard — no loops.
- `pick_rewrite` gains a `picked_idx` argument; on rich hosts the pick record rides a mark-picked body instead of a plain append. The leshchenko1979/opencrabs#39 invariant is untouched: the pick record is still baked into the body before any transport arm runs.
- `take_pending_followup` returns the tapped idx alongside the entry/text — the rewrite runs in a spawned task lexically outside the arm that binds `idx`. The idx rides as a third tuple element; upstream's `restore_pending_followup` re-arm keeps receiving the full `PendingFollowupEntry`.
- The final commit folds in the sibling style-attr rendering fix (originally landed against `leshchenko1979/opencrabs#71`): a styled sibling that only gains `disabled` keeps its style so the grayed form is the only rendered state.

## Provenance and attribution

Ported from fork-side work by the same author. Original fork SHAs: `4215c019`, `97a136e1`, `357f2bb9`, `5c3d8b5e`, `95adf054`, plus dependency commit `5e66191b` (fork context `leshchenko1979/opencrabs#71`). The `take_pending_followup` and tap-handler commits are re-expressions against upstream's `(PendingFollowupEntry, String)` take shape and the upstream tap-handler structure; the glue-tier and empty-markup-helper shapes from the fork environment were intentionally not carried.

Supersedes #1392, which carried the fork-only glue tier and dropped upstream's own persistence test; this branch contains only the `leshchenko1979/opencrabs#67` scope.

## Testing

- E0308 stale-set completeness method: the `take_pending_followup` tuple extension initially missed upstream's four existing 2-tuple destructure callers in `telegram_followup_persistence_test.rs` (upstream CI flagged all four); a tree-wide grep for remaining 2-tuple destructures of that call proved the fix set complete before the fixup-squash, so the corrected commit ships with the stale set provably closed, not assumed.
- `telegram_followup_persistence_test.rs` (196 lines) is restored intact on this branch — upstream's own persistence suite runs against the ported tap-redraw flow.
- Evidence runs on this head lineage: 33957170609 (first head), 33959465485 (post-fix head — my files clean, remaining red isolated to pre-existing base `theme_picker.rs`/`messaging.rs` fmt), 33960171977 (final head `ef3a032a`). Base-red repair ownership: `theme_picker.rs` -> #1393/#1395, `messaging.rs` -> carried here as `ef3a032a` (style-commit convention).
- Changed-lines-only comparison of each port commit against its fork original: byte-identical for the four clean picks; the two re-expressions diverge exactly per the documented upstream adaptations above.
- Live smoke on the fork (owner-accepted, rich-plane scope): tapped suggestion re-rendered success+✓+disabled, siblings disabled, pick record intact.
- CI run on this PR head branch is the build/test gate; the head SHA is embedded in the required check job names.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/67

