### PR TITLE
fix(tui): theme picker triad compliance — clippy + clamp no-op

### DIFF
--- a/src/tui/render/theme_picker.rs
+++ b/src/tui/render/theme_picker.rs
@@ -134,8 +134,14 @@ impl ThemePickerState {
         } else {
             return PickerAction::None;
         };
+        let prev = self.selected;
         self.move_selection(step);
         self.scroll_into_view(visible_rows.max(1));
+        if self.selected == prev {
+            // Movement clamped at the list edge (or no valid row in that
+            // direction): selection unchanged, no preview re-emit.
+            return PickerAction::None;
+        }
         match self.items.get(self.selected).and_then(|i| i.theme) {
             Some(t) => PickerAction::Preview(t),
             None => PickerAction::None,

--- a/src/tui/render/theme_picker.rs
+++ b/src/tui/render/theme_picker.rs
@@ -76,6 +76,9 @@ impl ThemePickerState {
         }
     }
 
+    /// True when the highlighted row is a rejected (non-selectable) theme.
+    /// Reserved for the pending status-line work; kept visible to clippy.
+    #[allow(dead_code)]
     fn selected_is_rejected(&self) -> bool {
         self.items.get(self.selected).is_some_and(|i| i.theme.is_none())
     }
@@ -261,6 +264,18 @@ pub fn draw(f: &mut Frame, area: Rect, state: &ThemePickerState) {
     f.render_widget(hints, rows[1]);
 }
 
+/// Fixed-size popup centered in `area`, clamped to fit.
+fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let x = area.width.saturating_sub(width) / 2;
+    let y = area.height.saturating_sub(height) / 2;
+    Rect {
+        x: area.x + x,
+        y: area.y + y,
+        width: width.min(area.width),
+        height: height.min(area.height),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -411,17 +426,5 @@ mod tests {
         assert_eq!(s.selected, 3);
         assert!(s.selected >= s.scroll_offset);
         assert!(s.selected < s.scroll_offset + 2);
-    }
-}
-
-/// Fixed-size popup centered in `area`, clamped to fit.
-fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
-    let x = area.width.saturating_sub(width) / 2;
-    let y = area.height.saturating_sub(height) / 2;
-    Rect {
-        x: area.x + x,
-        y: area.y + y,
-        width: width.min(area.width),
-        height: height.min(area.height),
     }
 }


### PR DESCRIPTION
Two independent defects in `src/tui/render/theme_picker.rs`, both introduced by #1371 (`49c399e9`), both proven RED on pristine `main` (`3f880c5e`, zero-diff gate: run 33953528244):

1. **Clippy `-D warnings`** (breaks any battery-gated CI): `selected_is_rejected` dead code + `centered_rect` defined after `mod tests` (items-after-test-module). Fix: `#[allow(dead_code)]` (repo idiom — zero `#[expect]` uses in-tree) + verbatim move of `centered_rect` above the test module.

2. **`movement_clamps_at_list_ends` fails**: `handle_key` re-emits `Preview` after any movement key, even when `move_selection` clamped and the selection did not change — contradicting the test's own `expect_noop` contract at both list ends. Fix: return `None` when the selection didn't move. All sibling movement tests still pass (actual moves → `Preview`, clamps → `None`).

No behavior change beyond the clamp no-op the existing test already specifies. Verified GREEN on this branch: run 33954033732 (fmt + clippy + full battery).

Original issue: https://github.com/leshchenko1979/opencrabs/issues/99