### PR TITLE
Fix: parse or strip tool-call JSON returned as text; persist no parser warning into compaction

### DIFF
--- a/src/brain/agent/service/helpers.rs
+++ b/src/brain/agent/service/helpers.rs
@@ -1133,6 +1133,14 @@ impl AgentService {
             None
         };
 
+        // Streaming leak flag (fork #66, ex-upstream adolfousier/opencrabs#1260):
+        // text was already emitted to display as deltas, so there is no
+        // retro-strip here — the flag lets the tool loop attempt one
+        // corrective retry and otherwise fail clean instead of accepting
+        // the residue as a final answer.
+        let tool_text_leak =
+            crate::brain::provider::json_repair::content_has_unrecovered_tool_text(&content_blocks);
+
         Ok((
             LLMResponse {
                 id,
@@ -1155,6 +1163,7 @@ impl AgentService {
                     ..Default::default()
                 },
                 streaming_active_secs,
+                tool_text_leak,
             },
             reasoning,
         ))

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -5548,7 +5548,7 @@ impl AgentService {
                         "provider-integrity",
                         Some("leak persisted after corrective retry; failing clean"),
                     );
-                    return Err(crate::brain::provider::ProviderError::StreamError(msg));
+                    return Err(AgentError::Provider(crate::brain::provider::ProviderError::StreamError(msg)));
                 }
 
                 // ── Mid-sentence truncation retry ────────────────────────

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -7219,6 +7219,7 @@ impl AgentService {
                     // per-iteration LLMResponses; this top-level
                     // synthesis is for content/usage handoff only.
                     streaming_active_secs: None,
+                    tool_text_leak: false,
                 }
             }
             None => {

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -1490,6 +1490,12 @@ impl AgentService {
         // ladder.
         #[cfg_attr(not(feature = "telegram"), allow(unused))]
         let mut mermaid_regen_retries: u32 = 0;
+        // Tool-text leak (leshchenko1979/opencrabs#66, ex-upstream
+        // adolfousier/opencrabs#1260): the provider stripped unrecoverable
+        // tool-call JSON and set tool_text_leak. One corrective retry with a
+        // structured-calls nudge; a second leak fails the turn clean instead
+        // of delivering raw internals as the final answer.
+        let mut tool_text_leak_retry_used: bool = false;
         // One-shot nudge for the browser screenshot-spam pattern detected
         // by the semantic-loop check below the per-iteration tool dispatch.
         // Reset per turn; fires at most once.
@@ -5496,6 +5502,53 @@ impl AgentService {
                             );
                         }
                     }
+                }
+
+                // ── Tool-text leak: corrective retry, then fail clean ───
+                // (fork #66, ex-upstream adolfousier/opencrabs#1260) The
+                // provider flagged unrecoverable tool-call JSON as text.
+                // With tools available, give the model ONE structured-calls
+                // nudge; if it leaks again, fail the turn clean — never
+                // deliver raw internals as the final answer. Compaction-style
+                // requests without tools never reach this loop, and the
+                // parse layer already stripped the JSON from content.
+                if response.tool_text_leak && self.tool_registry.count() > 0 {
+                    if !tool_text_leak_retry_used {
+                        tool_text_leak_retry_used = true;
+                        tracing::warn!(
+                            "Tool-call JSON leaked as text — one corrective retry with \
+                             structured-calls nudge (iteration {})",
+                            iteration,
+                        );
+                        self.record_provider_feedback(
+                            session_id,
+                            "tool_text_leak_retry",
+                            "provider-integrity",
+                            Some("model returned tool requests as text; corrective retry"),
+                        );
+                        context.add_message(Message::user(
+                            "[System: Your previous response contained tool-call JSON as plain \
+                             text instead of executable calls. You have access to tools — invoke \
+                             them ONLY through the structured function-call API, never as text \
+                             or JSON in your reply. Re-issue your response using real tool_use \
+                             calls; if no tool is needed, answer in plain prose without any \
+                             JSON.]"
+                                .to_string(),
+                        ));
+                        continue;
+                    }
+                    let msg = "Model returned tool requests as text and recovery failed \
+                               after one retry — try a model with native function calling \
+                               (e.g. Claude, GPT-4, Gemini)."
+                        .to_string();
+                    tracing::warn!("Tool-text leak retry exhausted — failing clean: {}", msg);
+                    self.record_provider_feedback(
+                        session_id,
+                        "tool_text_leak_fail",
+                        "provider-integrity",
+                        Some("leak persisted after corrective retry; failing clean"),
+                    );
+                    return Err(crate::brain::provider::ProviderError::StreamError(msg));
                 }
 
                 // ── Mid-sentence truncation retry ────────────────────────

--- a/src/brain/provider/anthropic.rs
+++ b/src/brain/provider/anthropic.rs
@@ -189,6 +189,7 @@ impl AnthropicProvider {
             usage: response.usage,
             // Non-streaming path — active streaming time only meaningful for stream_complete.
             streaming_active_secs: None,
+            tool_text_leak: false,
         }
     }
 

--- a/src/brain/provider/claude_cli.rs
+++ b/src/brain/provider/claude_cli.rs
@@ -721,6 +721,7 @@ impl Provider for ClaudeCliProvider {
             usage,
             // CLI subprocess output is parsed in one shot, not streamed.
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/brain/provider/codex_cli.rs
+++ b/src/brain/provider/codex_cli.rs
@@ -320,6 +320,7 @@ impl Provider for CodexCliProvider {
             usage,
             // CLI subprocess output is parsed in one shot, not streamed.
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/brain/provider/command_code_cli.rs
+++ b/src/brain/provider/command_code_cli.rs
@@ -276,6 +276,7 @@ impl Provider for CommandCodeCliProvider {
             stop_reason,
             usage,
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/brain/provider/custom_openai_compatible.rs
+++ b/src/brain/provider/custom_openai_compatible.rs
@@ -3168,26 +3168,40 @@ impl OpenAIProvider {
             }
         }
 
-        // Detect models that dump tool JSON as text instead of structured calls
-        let has_tool_text = content_blocks.iter().any(|b| {
-            if let ContentBlock::Text { text } = b {
-                (text.contains("\"function\"") && text.contains("\"arguments\""))
-                    || (text.contains("tool_call") && text.contains("\"name\""))
-                    || (text.contains("```json") && text.contains("\"command\""))
-            } else {
-                false
-            }
-        });
+        // Detect models that dump tool JSON as text instead of structured
+        // calls. Tightened detector (fork #66, ex-upstream
+        // adolfousier/opencrabs#1260): only a parseable call-shaped JSON
+        // object outside code fences counts — prose about tools no longer
+        // false-positives. On detection the raw JSON is STRIPPED from the
+        // content and `tool_text_leak` is set on the response for the tool
+        // loop's corrective retry. No ⚠️ warning block is appended: parser
+        // artifacts must never ride as content (they used to be persisted
+        // verbatim into compaction summaries / memory files).
         let has_structured_tools = content_blocks
             .iter()
             .any(|b| matches!(b, ContentBlock::ToolUse { .. }));
-        if has_tool_text && !has_structured_tools {
-            tracing::warn!(
-                "Model returned tool call JSON as text — likely does not support function calling"
-            );
-            content_blocks.push(ContentBlock::Text {
-                text: "\n\n⚠️ **This model does not support function calling.** Tool requests were returned as text instead of executable calls. Consider switching to a model that supports tool use (e.g. Claude, GPT-4, Gemini).".to_string(),
-            });
+        let mut tool_text_leak = false;
+        if !has_structured_tools {
+            for block in content_blocks.iter_mut() {
+                if let ContentBlock::Text { text } = block {
+                    let (cleaned, stripped) = super::json_repair::strip_call_shaped_json(text);
+                    if stripped {
+                        tracing::warn!(
+                            "Model returned tool call JSON as text — unrecoverable, \
+                             stripped from content (likely weak function-calling support)"
+                        );
+                        *text = cleaned;
+                        tool_text_leak = true;
+                    }
+                }
+            }
+            if tool_text_leak {
+                // Drop text blocks emptied by the strip.
+                content_blocks.retain(|b| match b {
+                    ContentBlock::Text { text } => !text.trim().is_empty(),
+                    _ => true,
+                });
+            }
         }
 
         // Map finish_reason to StopReason
@@ -3214,6 +3228,7 @@ impl OpenAIProvider {
             },
             // Non-streaming parse path — streaming responses go through helpers.rs.
             streaming_active_secs: None,
+            tool_text_leak,
         }
     }
 

--- a/src/brain/provider/gemini.rs
+++ b/src/brain/provider/gemini.rs
@@ -344,6 +344,7 @@ impl GeminiProvider {
             },
             // Non-streaming path — active streaming time only meaningful for stream_complete.
             streaming_active_secs: None,
+            tool_text_leak: false,
         }
     }
 

--- a/src/brain/provider/json_repair.rs
+++ b/src/brain/provider/json_repair.rs
@@ -186,3 +186,176 @@ pub fn try_repair(raw: &str) -> Option<String> {
 
     Some(out)
 }
+
+// ── Call-shaped JSON detection (tool-text leak defense) ─────────────────
+// fork #66, ex-upstream adolfousier/opencrabs#1260.
+//
+// When a model with weak function-calling support "invokes" a tool, it
+// dumps the call as raw JSON text instead of a structured tool_calls
+// field. The rescue layer (extract_text_tool_calls) converts known shapes;
+// what SURVIVES rescue is unparseable or unknown-shape residue that used
+// to ride to the user as the final answer.
+//
+// The detector here replaces the old keyword heuristic ("contains
+// \"function\" && contains \"arguments\"") which false-positived on prose
+// ABOUT tool calls. Rules:
+//   1. Only a PARSEABLE JSON object counts (keyword hits on broken JSON in
+//      prose no longer fire the leak path).
+//   2. The object must be call-shaped: name+arguments, bare command, or
+//      OpenAI-legacy function{name,arguments}.
+//   3. Fenced ```json code blocks are EXCLUDED — they are display
+//      artifacts of discussion (agents routinely explain tool-call JSON
+//      in fenced examples). The rescue layer above still converts known
+//      fenced shapes to real calls before detection runs.
+//   4. Unfenced parseable call-shaped objects are treated as genuine
+//      leaked invocations: stripped from content, flagged for retry.
+
+use super::types::ContentBlock;
+
+/// Byte ranges of fenced code blocks (``` ... ```) in `text`.
+/// An unterminated fence swallows the rest of the text.
+fn fenced_code_ranges(text: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut in_fence = false;
+    let mut fence_start = 0usize;
+    let mut offset = 0usize;
+    for line in text.split_inclusive('\n') {
+        if line.trim_start().starts_with("```") {
+            if in_fence {
+                ranges.push((fence_start, offset + line.len()));
+                in_fence = false;
+            } else {
+                in_fence = true;
+                fence_start = offset;
+            }
+        }
+        offset += line.len();
+    }
+    if in_fence {
+        ranges.push((fence_start, offset));
+    }
+    ranges
+}
+
+/// Does `candidate` parse as a JSON object with tool-invocation shape?
+fn is_call_shaped_json(candidate: &str) -> bool {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(candidate) else {
+        return false;
+    };
+    let Some(obj) = v.as_object() else {
+        return false;
+    };
+    // Shape 1: {"name": "...", "arguments": {...}}
+    if obj.get("name").is_some_and(|n| n.is_string()) && obj.contains_key("arguments") {
+        return true;
+    }
+    // Shape 2: bare execution object {"command": ...}
+    if obj.contains_key("command") {
+        return true;
+    }
+    // Shape 3: OpenAI legacy {"function": {"name": ..., "arguments": ...}}
+    if let Some(f) = obj.get("function")
+        && f.get("name").is_some_and(|n| n.is_string())
+        && f.get("arguments").is_some()
+    {
+        return true;
+    }
+    false
+}
+
+/// Find spans of UNFENCED, parseable, call-shaped JSON objects in `text`.
+/// Outermost matching objects are returned; their nested content is not
+/// re-scanned (an outer span covers its inner keys).
+pub fn find_call_shaped_json_spans(text: &str) -> Vec<(usize, usize)> {
+    let fenced = fenced_code_ranges(text);
+    let bytes = text.as_bytes();
+    let mut spans = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            // String-aware scan to the matching close brace.
+            let mut depth = 0i32;
+            let mut in_string = false;
+            let mut escape = false;
+            let mut j = i;
+            let mut closed = false;
+            while j < bytes.len() {
+                let b = bytes[j];
+                if in_string {
+                    if escape {
+                        escape = false;
+                    } else if b == b'\\' {
+                        escape = true;
+                    } else if b == b'"' {
+                        in_string = false;
+                    }
+                } else {
+                    match b {
+                        b'"' => in_string = true,
+                        b'{' => depth += 1,
+                        b'}' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                closed = true;
+                                break;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                j += 1;
+            }
+            if closed {
+                let end = j + 1;
+                let in_fence = fenced.iter().any(|(s, e)| i >= *s && j < *e);
+                if !in_fence && is_call_shaped_json(&text[i..end]) {
+                    spans.push((i, end));
+                    i = end; // skip past the matched object
+                    continue;
+                }
+            }
+            // Unbalanced or not call-shaped: step forward so nested
+            // objects still get scanned.
+        }
+        i += 1;
+    }
+    spans
+}
+
+/// Remove call-shaped JSON spans from `text`. Returns the cleaned text and
+/// whether anything was stripped. Overlaps (nested matches inside an
+/// already-removed outer span) are consumed by the outermost span.
+pub fn strip_call_shaped_json(text: &str) -> (String, bool) {
+    let mut spans = find_call_shaped_json_spans(text);
+    if spans.is_empty() {
+        return (text.to_string(), false);
+    }
+    spans.sort_unstable();
+    let mut out = String::with_capacity(text.len());
+    let mut last_end = 0usize;
+    for (s, e) in spans {
+        if s < last_end {
+            continue;
+        }
+        out.push_str(&text[last_end..s]);
+        last_end = e;
+    }
+    out.push_str(&text[last_end..]);
+    (out.trim().to_string(), true)
+}
+
+/// Leak predicate over final content blocks: true when the response has NO
+/// structured ToolUse blocks but its text contains unfenced call-shaped
+/// JSON — i.e. the model tried to invoke tools as text and rescue failed.
+pub fn content_has_unrecovered_tool_text(blocks: &[ContentBlock]) -> bool {
+    if blocks
+        .iter()
+        .any(|b| matches!(b, ContentBlock::ToolUse { .. }))
+    {
+        return false;
+    }
+    blocks.iter().any(|b| match b {
+        ContentBlock::Text { text } => !find_call_shaped_json_spans(text).is_empty(),
+        _ => false,
+    })
+}

--- a/src/brain/provider/opencode_cli.rs
+++ b/src/brain/provider/opencode_cli.rs
@@ -305,6 +305,7 @@ impl Provider for OpenCodeCliProvider {
             // CLI subprocess output is parsed in one shot, not streamed —
             // no per-token timing to measure here.
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/brain/provider/types.rs
+++ b/src/brain/provider/types.rs
@@ -243,6 +243,14 @@ pub struct LLMResponse {
     /// this; non-streaming `parse_response` sites leave it `None`.
     #[serde(default)]
     pub streaming_active_secs: Option<f64>,
+    /// True when the provider detected tool-call JSON dumped as plain text
+    /// and could not recover it into structured ToolUse blocks (rescue
+    /// failed). Raw call-shaped JSON is stripped from `content` at the
+    /// parse boundary; the tool loop uses this flag for one corrective
+    /// retry, then fails clean instead of delivering the residue.
+    /// (fork #66, ex-upstream adolfousier/opencrabs#1260)
+    #[serde(default)]
+    pub tool_text_leak: bool,
 }
 
 /// Reason why the model stopped generating

--- a/src/eval/replay.rs
+++ b/src/eval/replay.rs
@@ -105,6 +105,7 @@ impl ReplayProvider {
                 stop_reason: Some(StopReason::EndTurn),
                 usage: TokenUsage::default(),
                 streaming_active_secs: None,
+                tool_text_leak: false,
             };
         };
         *cursor += 1;
@@ -144,6 +145,7 @@ impl ReplayProvider {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         }
     }
 }

--- a/src/tests/agent_service_mocks.rs
+++ b/src/tests/agent_service_mocks.rs
@@ -33,6 +33,7 @@ impl Provider for MockProvider {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 
@@ -136,6 +137,7 @@ impl Provider for MockProviderWithTools {
                     ..Default::default()
                 },
                 streaming_active_secs: None,
+                tool_text_leak: false,
             })
         } else {
             Ok(LLMResponse {
@@ -151,6 +153,7 @@ impl Provider for MockProviderWithTools {
                     ..Default::default()
                 },
                 streaming_active_secs: None,
+                tool_text_leak: false,
             })
         }
     }
@@ -361,6 +364,7 @@ impl Provider for MockProviderWithModel {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 
@@ -466,6 +470,7 @@ impl Provider for MockProviderWithNamedTool {
                     ..Default::default()
                 },
                 streaming_active_secs: None,
+                tool_text_leak: false,
             })
         } else {
             Ok(LLMResponse {
@@ -481,6 +486,7 @@ impl Provider for MockProviderWithNamedTool {
                     ..Default::default()
                 },
                 streaming_active_secs: None,
+                tool_text_leak: false,
             })
         }
     }
@@ -618,6 +624,7 @@ impl Provider for MockProviderWithTwoToolCalls {
                     ..Default::default()
                 },
                 streaming_active_secs: None,
+                tool_text_leak: false,
             })
         } else {
             Ok(LLMResponse {
@@ -633,6 +640,7 @@ impl Provider for MockProviderWithTwoToolCalls {
                     ..Default::default()
                 },
                 streaming_active_secs: None,
+                tool_text_leak: false,
             })
         }
     }

--- a/src/tests/agent_streaming_usage_test.rs
+++ b/src/tests/agent_streaming_usage_test.rs
@@ -47,6 +47,7 @@ impl Provider for MockDeferredUsageProvider {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 
@@ -163,6 +164,7 @@ impl Provider for MockInlineUsageProvider {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 
@@ -342,6 +344,7 @@ async fn test_deferred_usage_with_tool_calls() {
                         ..Default::default()
                     },
                     streaming_active_secs: None,
+                    tool_text_leak: false,
                 })
             } else {
                 Ok(LLMResponse {
@@ -357,6 +360,7 @@ async fn test_deferred_usage_with_tool_calls() {
                         ..Default::default()
                     },
                     streaming_active_secs: None,
+                    tool_text_leak: false,
                 })
             }
         }

--- a/src/tests/auto_title_e2e_test.rs
+++ b/src/tests/auto_title_e2e_test.rs
@@ -68,6 +68,7 @@ impl Provider for AutoTitleMockProvider {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 
@@ -402,6 +403,7 @@ impl Provider for ThinkingOnlyTitleProvider {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/tests/cli_arg_too_long_test.rs
+++ b/src/tests/cli_arg_too_long_test.rs
@@ -55,6 +55,7 @@ impl Provider for ArgTooLongMockProvider {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 
@@ -176,6 +177,7 @@ impl Provider for ContextLengthMockProvider {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/tests/compaction_fallback_chain_test.rs
+++ b/src/tests/compaction_fallback_chain_test.rs
@@ -120,6 +120,7 @@ impl Provider for CountingMock {
                 stop_reason: None,
                 usage: TokenUsage::default(),
                 streaming_active_secs: None,
+                tool_text_leak: false,
             }),
             Behaviour::QuotaExhausted => Err(ProviderError::RateLimitExceeded(
                 "Insufficient balance or no resource package. Please recharge.".to_string(),

--- a/src/tests/error_scenarios_test.rs
+++ b/src/tests/error_scenarios_test.rs
@@ -330,6 +330,7 @@ impl Provider for WorkingMockProvider {
             usage: TokenUsage {
                 input_tokens: 10,
                 output_tokens: 20, ..Default::default() },
+            tool_text_leak: false,
         })
     }
 

--- a/src/tests/fallback_cli_tool_ownership_test.rs
+++ b/src/tests/fallback_cli_tool_ownership_test.rs
@@ -81,6 +81,7 @@ impl Provider for OwnershipMock {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/tests/fallback_provenance_test.rs
+++ b/src/tests/fallback_provenance_test.rs
@@ -53,6 +53,7 @@ impl Provider for NamedMock {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/tests/fallback_swap_model_report_test.rs
+++ b/src/tests/fallback_swap_model_report_test.rs
@@ -69,6 +69,7 @@ impl Provider for ModelAwareMock {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/tests/fallback_vision_test.rs
+++ b/src/tests/fallback_vision_test.rs
@@ -171,6 +171,7 @@ mod fallback_runtime {
                         ..Default::default()
                     },
                     streaming_active_secs: None,
+                    tool_text_leak: false,
                 })
             }
         }

--- a/src/tests/goal_judge_test.rs
+++ b/src/tests/goal_judge_test.rs
@@ -105,6 +105,7 @@ fn make_response(text: &str, stop: StopReason) -> LLMResponse {
         stop_reason: Some(stop),
         usage: TokenUsage::default(),
         streaming_active_secs: None,
+        tool_text_leak: false,
     }
 }
 

--- a/src/tests/integration_test.rs
+++ b/src/tests/integration_test.rs
@@ -64,6 +64,7 @@ impl Provider for MockProvider {
             usage: TokenUsage {
                 input_tokens: 10,
                 output_tokens: 20, ..Default::default() },
+            tool_text_leak: false,
         })
     }
 

--- a/src/tests/phantom_db_persistence_test.rs
+++ b/src/tests/phantom_db_persistence_test.rs
@@ -72,6 +72,7 @@ impl Provider for PhantomThenRealProvider {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 

--- a/src/tests/provider_never_ignored_test.rs
+++ b/src/tests/provider_never_ignored_test.rs
@@ -78,6 +78,7 @@ impl Provider for CountingMock {
                     ..Default::default()
                 },
                 streaming_active_secs: None,
+                tool_text_leak: false,
             }),
         }
     }

--- a/src/tests/rate_limit_reporting_test.rs
+++ b/src/tests/rate_limit_reporting_test.rs
@@ -132,6 +132,7 @@ impl Provider for ModelMock {
                 ..Default::default()
             },
             streaming_active_secs: None,
+            tool_text_leak: false,
         })
     }
 


### PR DESCRIPTION
## Summary

Models that emit tool calls as **text** instead of structured calls could leak raw JSON internals into the conversation: an unparsable residue rode through as visible text, a generic ⚠️ "model does not support function calling" warning was appended as a content block — and that warning then fossilized into every subsequent compaction summary, re-injected into context indefinitely. Observed live on weak/non-streaming models during compaction calls (originally investigated as "agents return garbage"): full report with evidence in leshchenko1979/opencrabs#66.

This PR ports the fix (3 commits, live in production on our fork since 2026-09-01, 4-day smoke: 15 real compaction opportunities, 0 leaks, 0 false positives):

1. **`fix(provider): strip unrecoverable tool-call JSON from responses, flag leak`** — tightens the text detector (parseable call-shaped JSON only; fences excluded — code samples about tool calls no longer trip it), strips the raw JSON at parse time so it can never reach the model loop or a compaction summary, and sets a `tool_text_leak` flag on `LLMResponse` instead of persisting a warning block.

2. **`fix(agent): one corrective retry on tool-text leak, then fail clean`** — one structured-calls nudge retry (mirrors the existing truncation-retry pattern); on a second leak the turn fails with a clean `AgentError` instead of delivering raw internals as the final answer.

3. **`fix(agent): wrap tool-text-leak fail-clean in AgentError::Provider`** — error-path plumbing for the loop's `AgentError` surface.

## Notes

- The `⚠️ does not support function calling` content block is no longer appended to responses, so it can no longer be persisted into compaction summaries (the poisoning vector).
- 38 `LLMResponse` construction sites gain the flag (mechanical, `false` default behavior preserved).
- Rebased onto current `adolfousier/main`; one benign conflict vs the new mermaid-regen retry declarations (both kept).

Environment: fork CI evidence (fmt + clippy `-D warnings` + all-features test) cited in comments after the gate completes.

Refs: leshchenko1979/opencrabs#66
