### PR TITLE
feat: markdown-plane hosts for merged suggestion controls (tables survive merging)

### DIFF
--- a/src/channels/telegram/agent.rs
+++ b/src/channels/telegram/agent.rs
@@ -317,11 +317,11 @@ impl TelegramAgent {
                                             // so the bubble stops silently eating taps.
                                             // #59: the strip is HOST-AWARE — the #597
                                             // clear rescues the merged-host record, so the
-                                            // shape is known: rich (non-glued) hosts carry
-                                            // the buttons INSIDE the body (a markup strip
-                                            // is a guaranteed "message is not modified"
-                                            // no-op — the zombie), glued/classic hosts
-                                            // carry a reply-markup.
+                                            // shape is known: rich hosts carry the buttons
+                                            // INSIDE the body (a markup strip there is a
+                                            // guaranteed "message is not modified" no-op —
+                                            // the zombie); classic/unknown hosts carry a
+                                            // reply-markup.
                                             if let Some(msg) = query
                                                 .message
                                                 .as_ref()
@@ -330,27 +330,47 @@ impl TelegramAgent {
                                                 let stale_host =
                                                     state.peek_stale_host(&cb_token).await;
                                                 let strip = match &stale_host {
-                                                    Some(h) if h.rich && !h.glued => {
+                                                    Some(h) if h.rich => {
                                                         // Rich host: rewrite the body without
                                                         // the button rows; no reply-markup
                                                         // ever existed on this bubble.
-                                                        let body =
-                                                            super::suggest_options::strip_button_rows(&h.html);
-                                                        super::rich::api::edit_rich_html(
-                                                            bot.api_url().as_str(),
-                                                            bot.token(),
-                                                            msg.chat.id.0,
-                                                            msg.id.0,
-                                                            &body,
-                                                            None,
-                                                            "stale-strip",
-                                                            "#59 stale rich strip",
-                                                        )
-                                                        .await
-                                                        .map_err(|e| e.to_string())
+                                                        // Markdown-plane hosts (#79 piece 4)
+                                                        // ride the markdown strip source so
+                                                        // tables survive the strip (#679).
+                                                        if let Some(md) = &h.markdown {
+                                                            let body =
+                                                                super::suggest_options::strip_button_rows(md);
+                                                            super::rich::api::edit_rich_markdown(
+                                                                bot.api_url().as_str(),
+                                                                bot.token(),
+                                                                msg.chat.id.0,
+                                                                msg.id.0,
+                                                                &body,
+                                                                None,
+                                                                "stale-strip",
+                                                                "#59 stale rich strip",
+                                                            )
+                                                            .await
+                                                            .map_err(|e| e.to_string())
+                                                        } else {
+                                                            let body = super::suggest_options::
+                                                                strip_button_rows(&h.html);
+                                                            super::rich::api::edit_rich_html(
+                                                                bot.api_url().as_str(),
+                                                                bot.token(),
+                                                                msg.chat.id.0,
+                                                                msg.id.0,
+                                                                &body,
+                                                                None,
+                                                                "stale-strip",
+                                                                "#59 stale rich strip",
+                                                            )
+                                                            .await
+                                                            .map_err(|e| e.to_string())
+                                                        }
                                                     }
                                                     _ => {
-                                                        // Glued/classic/unknown: markup strip.
+                                                        // Classic/unknown: markup strip.
                                                         // Unknown = pre-#59 record (or none):
                                                         // keep the #1226 blind strip as the
                                                         // last resort — it is the correct
@@ -469,9 +489,6 @@ impl TelegramAgent {
                                                 &crate::channels::telegram::suggest_options::
                                                     picked_block(&text, chooser.as_deref()),
                                             );
-                                        // #68: true when the echo fallback is owned by the
-                                        // deferred retry task (do NOT echo into the same
-                                        // 429 window — the old immediate echo died there).
                                         let mut echo_deferred = false;
                                         let recorded = match prompt_msg_id {
                                             Some(mid) => {
@@ -485,80 +502,47 @@ impl TelegramAgent {
                                                 // hosts ride teloxide's edit_message_text.
                                                 let host_info =
                                                     merged_host.as_ref().and_then(|h| {
-                                                        (h.message_id == mid)
-                                                            .then(|| (h.html.clone(), h.rich, h.glued))
+                                                        (h.message_id == mid).then(|| {
+                                                            (
+                                                                h.html.clone(),
+                                                                h.rich,
+                                                                h.markdown.clone(),
+                                                            )
+                                                        })
                                                     });
-                                                let empty_kb =
-                                                    super::suggest_options::empty_keyboard();
+                                                let empty_kb = teloxide::types::
+                                                    InlineKeyboardMarkup::new(
+                                                        Vec::<Vec<teloxide::types::InlineKeyboardButton>>::new(),
+                                                    );
                                                 // #39: the pick record is baked into the body
                                                 // BEFORE any transport arm runs — one format
                                                 // site, so no arm can drop the choice again
-                                                // #68: capture the rewrite payload so a
-                                                // Retry-After deferral can re-fire a
-                                                // byte-identical edit outside the 429 window.
-                                                // Initialized here (outside the if/else) so it's
-                                                // accessible in the error handling below.
-                                                let mut tap_retry = None;
-
                                                 // (the classic merged host used to edit the
                                                 // answer HTML alone and lose the record).
-                                                let outcome: Result<(), String> =
-                                                    if host_info
-                                                        .as_ref()
-                                                        .is_some_and(|(_, _, glued)| *glued)
-                                                        {
-                                                        // #55 glue tier: the host body is not
-                                                        // merge-safe (table-bearing rich answer) —
-                                                        // a text edit would flatten it. Strip the
-                                                        // dead keyboard markup-only, then echo the
-                                                        // pick record as its own note bubble.
-                                                        // Sequential, not and_then/map: the note
-                                                        // future must be awaited, which no
-                                                        // Result-combinator closure can do.
-                                                        let stripped = bot_clone
-                                                            .edit_message_reply_markup(chat_id, mid)
-                                                            .reply_markup(empty_kb)
-                                                            .await
-                                                            .map(|_| ())
-                                                            .map_err(|e| e.to_string());
-                                                        if stripped.is_ok() {
-                                                            crate::channels::telegram::send::
-                                                                best_effort_note(
-                                                                    &bot_clone,
-                                                                    chat_id,
-                                                                    thread_id,
-                                                                    &picked,
-                                                                    Some(teloxide::types::ParseMode::Html),
-                                                                    "tap-glue",
-                                                                    "pick record after glued tap",
-                                                                    "the glued host body must not be rewritten",
-                                                                )
-                                                                .await;
-                                                        }
-                                                        stripped
-                                                    } else {
-                                                        // #39: the pick record is baked into the body
-                                                        // BEFORE any transport arm runs — one format
-                                                        // site, so no arm can drop the choice again.
-                                                        let rewrite =
-                                                            super::suggest_options::pick_rewrite(
-                                                                host_info.as_ref().map(
-                                                                    |(full, rich, _glued)| {
-                                                                        (full.as_str(), *rich)
-                                                                    },
-                                                                ),
-                                                                picked,
-                                                                picked_idx,
-                                                            );
-                                                        // #68: capture the rewrite payload so a
-                                                        // Retry-After deferral can re-fire a
-                                                        // byte-identical edit outside the 429 window.
-                                                        tap_retry = Some(match &rewrite {
-                                                            super::suggest_options::PickRewrite::RichHost(body) => TapRetry::Rich(chat_id, mid, body.clone(), empty_kb.clone()),
-                                                            super::suggest_options::PickRewrite::ClassicHost(body) => TapRetry::Classic(chat_id, mid, body.clone(), empty_kb.clone()),
-                                                            super::suggest_options::PickRewrite::Standalone(body) => TapRetry::Standalone(chat_id, mid, body.clone()),
-                                                        });
-                                                        match rewrite {
+                                                let rewrite =
+                                                    super::suggest_options::pick_rewrite(
+                                                        host_info.as_ref().map(|(full, rich, md)| {
+                                                            (full.as_str(), *rich, md.as_deref())
+                                                        }),
+                                                        picked,
+                                                        picked_idx,
+                                                    );
+                                                let outcome: Result<(), String> = match rewrite.clone() {
+                                                    super::suggest_options::PickRewrite::RichMarkdownHost(
+                                                        body,
+                                                    ) => super::rich::api::edit_rich_markdown(
+                                                        bot_clone.api_url().as_str(),
+                                                        bot_clone.token(),
+                                                        chat_id.0,
+                                                        mid.0,
+                                                        &body,
+                                                        Some(&serde_json::json!(empty_kb)),
+                                                        "turn",
+                                                        "-",
+                                                    )
+                                                    .await
+                                                    .map(|_| ())
+                                                    .map_err(|e| e.to_string()),
                                                     super::suggest_options::PickRewrite::RichHost(
                                                         body,
                                                     ) => super::rich::api::edit_rich_html(
@@ -579,20 +563,19 @@ impl TelegramAgent {
                                                     ) => bot_clone
                                                         .edit_message_text(chat_id, mid, &body)
                                                         .parse_mode(teloxide::types::ParseMode::Html)
-                                                        .reply_markup(empty_kb)
+                                                        .reply_markup(empty_kb.clone())
                                                         .await
                                                         .map(|_| ())
                                                         .map_err(|e| e.to_string()),
-                                                            super::suggest_options::PickRewrite::Standalone(
-                                                                body,
-                                                            ) => bot_clone
-                                                                .edit_message_text(chat_id, mid, &body)
-                                                                .parse_mode(teloxide::types::ParseMode::Html)
-                                                                .await
-                                                                .map(|_| ())
-                                                                .map_err(|e| e.to_string()),
-                                                        }
-                                                    };
+                                                    super::suggest_options::PickRewrite::Standalone(
+                                                        body,
+                                                    ) => bot_clone
+                                                        .edit_message_text(chat_id, mid, &body)
+                                                        .parse_mode(teloxide::types::ParseMode::Html)
+                                                        .await
+                                                        .map(|_| ())
+                                                        .map_err(|e| e.to_string()),
+                                                };
                                                 if let Err(e) = outcome {
                                                     match super::edit_retry::classify_str(&e) {
                                                         super::edit_retry::EditErr::RetryAfter(wait) => {
@@ -601,41 +584,64 @@ impl TelegramAgent {
                                                                  429 (retry after {wait:?}) — deferring one \
                                                                  identical retry"
                                                             );
-                                                            if let Some(retry) = tap_retry.take() {
-                                                                let bot_r = bot_clone.clone();
-                                                                let bot_e = bot_clone.clone();
-                                                                let echo_text = text.clone();
-                                                                let echo_chooser = chooser.clone();
-                                                                super::edit_retry::spawn_deferred(
-                                                                    wait,
-                                                                    move || async move {
-                                                                        refire_pick_edit(&bot_r, retry)
-                                                                            .await
-                                                                    },
-                                                                    move || async move {
-                                                                        // The legacy quoted echo — now
-                                                                        // safely outside the 429 window
-                                                                        // that killed attempt 1 (#68).
-                                                                        let echo = crate::channels::telegram::handler::md_to_html(
-                                                                            &crate::channels::telegram::suggest_options::
-                                                                                echo_fallback(&echo_text, echo_chooser.as_deref()),
+                                                            let bot_r = bot_clone.clone();
+                                                            let bot_e = bot_clone.clone();
+                                                            let retry = (
+                                                                chat_id,
+                                                                mid,
+                                                                rewrite.clone(),
+                                                                empty_kb.clone(),
+                                                            );
+                                                            let echo_text = text.clone();
+                                                            let echo_chooser = chooser.clone();
+                                                            super::edit_retry::spawn_deferred(
+                                                                wait,
+                                                                move || async move {
+                                                                    refire_pick_edit(&bot_r, retry)
+                                                                        .await
+                                                                },
+                                                                move || async move {
+                                                                    // Contract point 2 (#76): the
+                                                                    // pick-record edit failed TWICE —
+                                                                    // the bubble never showed the pick
+                                                                    // (#71 lesson: telemetry ≠ visual).
+                                                                    // The echo below is the only record.
+                                                                    tracing::warn!(
+                                                                        "Telegram followup tap: pick \
+                                                                         REDRAW_FAILED on msg {} in chat \
+                                                                         {} — second 429; choice registered \
+                                                                         via echo fallback only",
+                                                                        mid, chat_id
+                                                                    );
+                                                                    // The legacy quoted echo — now
+                                                                    // safely outside the 429 window
+                                                                    // that killed attempt 1 (#68).
+                                                                    let echo = crate::channels::telegram::
+                                                                        handler::md_to_html(
+                                                                            &crate::channels::telegram::
+                                                                                suggest_options::echo_fallback(
+                                                                                    &echo_text,
+                                                                                    echo_chooser.as_deref(),
+                                                                                ),
                                                                         );
-                                                                        if let Err(e) =
-                                                                            crate::channels::telegram::send::message_in_thread(
-                                                                                &bot_e, chat_id, thread_id, echo,
+                                                                    if let Err(e) =
+                                                                        crate::channels::telegram::send::
+                                                                            message_in_thread(
+                                                                                &bot_e, chat_id, thread_id,
+                                                                                echo,
                                                                             )
-                                                                            .parse_mode(teloxide::types::ParseMode::Html)
+                                                                            .parse_mode(teloxide::types::
+                                                                                ParseMode::Html)
                                                                             .await
-                                                                        {
-                                                                            tracing::warn!(
-                                                                                "Telegram followup tap: echo fallback \
-                                                                                 also failed: {e}"
-                                                                            );
-                                                                        }
-                                                                    },
-                                                                );
-                                                                echo_deferred = true;
-                                                            }
+                                                                    {
+                                                                        tracing::warn!(
+                                                                            "Telegram followup tap: echo \
+                                                                             fallback also failed: {e}"
+                                                                        );
+                                                                    }
+                                                                },
+                                                            );
+                                                            echo_deferred = true;
                                                         }
                                                         super::edit_retry::EditErr::Fatal(_) => {
                                                             tracing::warn!(
@@ -1761,7 +1767,8 @@ impl TelegramAgent {
                                     session_id,
                                     crate::tui::plan::ApprovalSource::User,
                                 )
-                                .await {
+                                .await
+                                {
                                     crate::utils::plan_mode::ApproveOutcome::Refused(msg) => {
                                         let _ =
                                             bot.answer_callback_query(query.id.clone()).await;
@@ -2143,47 +2150,37 @@ type PendingEdits = Arc<Mutex<HashMap<(ChatId, MessageId), (u64, Message)>>>;
 /// Cloneable bundle of everything `handle_message` needs, so the message,
 /// edited-message, and settle paths can dispatch without threading nine
 /// arguments through each.
-#[derive(Clone)]
-struct DispatchDeps {
-    agent: Arc<AgentService>,
-    session_svc: SessionService,
-    bot_token: Arc<String>,
-    shared_session: Arc<Mutex<Option<Uuid>>>,
-    telegram_state: Arc<TelegramState>,
-    config_rx: tokio::sync::watch::Receiver<Config>,
-    channel_msg_repo: ChannelMessageRepository,
-    session_binding_repo: SessionBindingRepository,
-}
-
-/// Prebuilt retry payload for the tap pick-record edit (#68). Built BEFORE
-/// the first attempt fires, so the deferred retry is byte-identical to
-/// attempt 1 — same body, same empty keyboard, same transport arm.
-#[derive(Clone)]
-enum TapRetry {
-    /// Rich merged host: body rides `edit_rich_html`.
-    Rich(
-        ChatId,
-        MessageId,
-        String,
-        teloxide::types::InlineKeyboardMarkup,
-    ),
-    /// Classic merged host: body + empty keyboard strip the dead buttons.
-    Classic(
-        ChatId,
-        MessageId,
-        String,
-        teloxide::types::InlineKeyboardMarkup,
-    ),
-    /// Standalone suggestion block becomes the pick record.
-    Standalone(ChatId, MessageId, String),
-}
-
 /// Re-fire a tap pick-record edit exactly as attempt 1 fired it (#68).
-async fn refire_pick_edit(bot: &Bot, retry: TapRetry) -> Result<(), String> {
+/// HEAD adaptation of fork's `TapRetry` plumbing: the `PickRewrite` payload is
+/// already in scope at the failure site and is `Clone`, so the deferred retry
+/// is byte-identical by construction — no parallel enum needed.
+async fn refire_pick_edit(
+    bot: &teloxide::Bot,
+    (chat_id, mid, rewrite, kb): (
+        teloxide::types::ChatId,
+        teloxide::types::MessageId,
+        super::suggest_options::PickRewrite,
+        teloxide::types::InlineKeyboardMarkup,
+    ),
+) -> Result<(), String> {
     use teloxide::payloads::EditMessageTextSetters;
     use teloxide::prelude::Requester;
-    match retry {
-        TapRetry::Rich(chat_id, mid, body, kb) => super::rich::api::edit_rich_html(
+    match rewrite {
+        super::suggest_options::PickRewrite::RichMarkdownHost(body) => {
+            super::rich::api::edit_rich_markdown(
+                bot.api_url().as_str(),
+                bot.token(),
+                chat_id.0,
+                mid.0,
+                &body,
+                Some(&serde_json::json!(kb)),
+                "turn",
+                "-",
+            )
+            .await
+            .map_err(|e| e.to_string())
+        }
+        super::suggest_options::PickRewrite::RichHost(body) => super::rich::api::edit_rich_html(
             bot.api_url().as_str(),
             bot.token(),
             chat_id.0,
@@ -2195,20 +2192,32 @@ async fn refire_pick_edit(bot: &Bot, retry: TapRetry) -> Result<(), String> {
         )
         .await
         .map_err(|e| e.to_string()),
-        TapRetry::Classic(chat_id, mid, body, kb) => bot
+        super::suggest_options::PickRewrite::ClassicHost(body) => bot
             .edit_message_text(chat_id, mid, &body)
             .parse_mode(teloxide::types::ParseMode::Html)
             .reply_markup(kb)
             .await
             .map(|_| ())
             .map_err(|e| e.to_string()),
-        TapRetry::Standalone(chat_id, mid, body) => bot
+        super::suggest_options::PickRewrite::Standalone(body) => bot
             .edit_message_text(chat_id, mid, &body)
             .parse_mode(teloxide::types::ParseMode::Html)
             .await
             .map(|_| ())
             .map_err(|e| e.to_string()),
     }
+}
+
+#[derive(Clone)]
+struct DispatchDeps {
+    agent: Arc<AgentService>,
+    session_svc: SessionService,
+    bot_token: Arc<String>,
+    shared_session: Arc<Mutex<Option<Uuid>>>,
+    telegram_state: Arc<TelegramState>,
+    config_rx: tokio::sync::watch::Receiver<Config>,
+    channel_msg_repo: ChannelMessageRepository,
+    session_binding_repo: SessionBindingRepository,
 }
 
 /// Should this message be held until its edit stream settles? True only for

--- a/src/channels/telegram/delivery.rs
+++ b/src/channels/telegram/delivery.rs
@@ -533,17 +533,15 @@ pub(crate) async fn deliver_final_response(
                             rich_md.len(),
                             intermediate_ids.len()
                         );
-                        // Merge candidate (#tg-suggest-merge): the id is
-                        // captured ALWAYS. Table-free rich bubbles capture the
-                        // body too; table-bearing ones capture body=None — #55
-                        // glue tier (keyboard attaches via
-                        // edit_message_reply_markup, body never re-sent), not
-                        // the old skip-to-standalone.
+                        // Merge candidate (#tg-suggest-merge): every rich
+                        // bubble can carry the suggestion controls now —
+                        // table-bearing answers ride the markdown plane,
+                        // whose server-side render keeps tables intact
+                        // (#79 piece 4; the html plane flattened them,
+                        // #679, which is why they used to be excluded).
                         final_bubble = Some(super::state::MergeBubble {
                             message_id: teloxide::types::MessageId(rich_msg_id),
-                            body: (!super::rich::contains_table(&pre_dedup_text)).then(|| {
-                                super::state::BubbleBody::Markdown(pre_dedup_text.clone())
-                            }),
+                            body: super::state::BubbleBody::Markdown(pre_dedup_text.clone()),
                         });
                         // Store bot reply in channel_messages even though
                         // text_only is empty (dedup stripped it). The rich
@@ -804,17 +802,16 @@ pub(crate) async fn deliver_final_response(
                                     rich_md.len()
                                 );
                                 sent_reply_id = Some(id);
-                                // Merge candidate (#tg-suggest-merge): the id
-                                // is captured ALWAYS. Table-free bubbles carry
-                                // the controls in-body; table-bearing ones
-                                // capture body=None — merging re-sends as rich
-                                // HTML input, which flattens tables (#679), so
-                                // #55 glues the keyboard markup-only instead.
+                                // Merge candidate (#tg-suggest-merge): the
+                                // controls can ride this bubble — table-bearing
+                                // answers included: the merge edit goes back out
+                                // on the markdown plane, whose server-side
+                                // render keeps tables intact (#79 piece 4; the
+                                // old html-plane merge flattened them, #679,
+                                // which is why tables used to be excluded).
                                 final_bubble = Some(super::state::MergeBubble {
                                     message_id: teloxide::types::MessageId(id),
-                                    body: (!super::rich::contains_table(&rich_md)).then(|| {
-                                        super::state::BubbleBody::Markdown(rich_md.clone())
-                                    }),
+                                    body: super::state::BubbleBody::Markdown(rich_md.clone()),
                                 });
                                 true
                             }
@@ -904,7 +901,7 @@ pub(crate) async fn deliver_final_response(
                                 // answer bubble suggest_options can ride on.
                                 final_bubble = Some(super::state::MergeBubble {
                                     message_id: mid,
-                                    body: Some(super::state::BubbleBody::Html(chunks[0].clone())),
+                                    body: super::state::BubbleBody::Html(chunks[0].clone()),
                                 });
                             }
                             Err(teloxide::RequestError::RetryAfter(secs)) => {
@@ -918,9 +915,9 @@ pub(crate) async fn deliver_final_response(
                                         sent_reply_id = Some(mid.0);
                                         final_bubble = Some(super::state::MergeBubble {
                                             message_id: mid,
-                                            body: Some(super::state::BubbleBody::Html(
+                                            body: super::state::BubbleBody::Html(
                                                 chunks[0].clone(),
-                                            )),
+                                            ),
                                         });
                                     }
                                     Err(e) => {
@@ -946,9 +943,9 @@ pub(crate) async fn deliver_final_response(
                                             sent_reply_id = Some(sent.0);
                                             final_bubble = Some(super::state::MergeBubble {
                                                 message_id: sent,
-                                                body: Some(super::state::BubbleBody::Html(
+                                                body: super::state::BubbleBody::Html(
                                                     chunks[0].clone(),
-                                                )),
+                                                ),
                                             });
                                         } else {
                                             tracing::error!(
@@ -972,9 +969,9 @@ pub(crate) async fn deliver_final_response(
                                     sent_reply_id = Some(sent.0);
                                     final_bubble = Some(super::state::MergeBubble {
                                         message_id: sent,
-                                        body: Some(super::state::BubbleBody::Html(
+                                        body: super::state::BubbleBody::Html(
                                             chunks[0].clone(),
-                                        )),
+                                        ),
                                     });
                                 }
                             }
@@ -993,7 +990,7 @@ pub(crate) async fn deliver_final_response(
                                 sent_reply_id = Some(sent.0);
                                 final_bubble = Some(super::state::MergeBubble {
                                     message_id: sent,
-                                    body: Some(super::state::BubbleBody::Html(chunk.clone())),
+                                    body: super::state::BubbleBody::Html(chunk.clone()),
                                 });
                             }
                         }

--- a/src/channels/telegram/rich/api.rs
+++ b/src/channels/telegram/rich/api.rs
@@ -419,21 +419,19 @@ pub(crate) async fn send_rich_markdown_media_target_id(
         .ok_or_else(|| anyhow::anyhow!("sendRichMessage ok but response carried no message_id"))
 }
 
-/// Build the multipart/form-data request for a `sendRichMessage` whose media
-/// array references uploaded PNG bytes via `attach://<id>`. Every top-level
-/// scalar field of the JSON body (`chat_id`, `message_thread_id`,
-/// `reply_parameters`, `rich_message`) becomes a string form part; each byte
-/// entry becomes a file part named exactly `<id>` so Telegram's
-/// `attach://<id>` reference resolves (§ Bot API multipart media convention).
-/// The JSON body is still passed in for correlation telemetry
-/// ([`rich_send_fields`] reads its `rich_message` pointer).
-fn build_multipart_form(
-    media: &[super::mermaid::MediaEntry],
-    body: &serde_json::Value,
-) -> reqwest::multipart::Form {
+/// Scalar string form parts for a rich multipart request: the JSON body's
+/// top-level fields Telegram needs as form parts. Split out so the part
+/// shape is unit-testable without a live bot. `message_id` is edit-only:
+/// `editMessageText` multipart rejects with `message to edit not found`
+/// when the part is missing; `sendRichMessage` bodies carry no
+/// `message_id`, so sends are unchanged.
+pub(crate) fn multipart_scalar_fields(body: &serde_json::Value) -> Vec<(String, String)> {
     let mut fields: Vec<(String, String)> = Vec::new();
     if let Some(v) = body.get("chat_id") {
         fields.push(("chat_id".to_string(), v.to_string()));
+    }
+    if let Some(v) = body.get("message_id") {
+        fields.push(("message_id".to_string(), v.to_string()));
     }
     if let Some(v) = body.get("message_thread_id") {
         fields.push(("message_thread_id".to_string(), v.to_string()));
@@ -444,9 +442,22 @@ fn build_multipart_form(
     if let Some(v) = body.get("rich_message") {
         fields.push(("rich_message".to_string(), v.to_string()));
     }
+    fields
+}
 
+/// Build the multipart/form-data request for a `sendRichMessage` whose media
+/// array references uploaded PNG bytes via `attach://<id>`. Scalar parts come
+/// from [`multipart_scalar_fields`]; each byte entry becomes a file part
+/// named exactly `<id>` so Telegram's `attach://<id>` reference resolves
+/// (§ Bot API multipart media convention). The JSON body is still passed in
+/// for correlation telemetry ([`rich_send_fields`] reads its `rich_message`
+/// pointer).
+fn build_multipart_form(
+    media: &[super::mermaid::MediaEntry],
+    body: &serde_json::Value,
+) -> reqwest::multipart::Form {
     let mut form = reqwest::multipart::Form::new();
-    for (name, value) in fields {
+    for (name, value) in multipart_scalar_fields(body) {
         form = form.text(name, value);
     }
     for m in media {

--- a/src/channels/telegram/rich/api.rs
+++ b/src/channels/telegram/rich/api.rs
@@ -8,6 +8,7 @@
 
 use super::mermaid;
 use super::render_html::markdown_to_html_mermaid;
+use crate::channels::telegram::suggest_options::enforce_button_fit;
 use teloxide::types::ThreadId;
 
 /// Send `html` as a native rich message and return the new message id
@@ -59,7 +60,7 @@ pub(crate) async fn edit_rich_markdown(
     let mut body = serde_json::json!({
         "chat_id": chat_id,
         "message_id": message_id,
-        "rich_message": { "markdown": markdown },
+        "rich_message": { "markdown": enforce_button_fit(markdown) },
     });
     if let Some(kb) = reply_markup {
         body["reply_markup"] = kb.clone();
@@ -84,7 +85,7 @@ pub(crate) async fn edit_rich_html(
     let mut body = serde_json::json!({
         "chat_id": chat_id,
         "message_id": message_id,
-        "rich_message": { "html": html },
+        "rich_message": { "html": enforce_button_fit(html) },
     });
     if let Some(kb) = reply_markup {
         body["reply_markup"] = kb.clone();
@@ -342,7 +343,7 @@ pub(crate) fn build_body_target(
 ) -> serde_json::Value {
     let mut body = serde_json::json!({
         "chat_id": chat_id,
-        "rich_message": { "markdown": markdown },
+        "rich_message": { "markdown": enforce_button_fit(markdown) },
     });
     if let Some(t) = thread_id {
         // ThreadId wraps a MessageId(i32).
@@ -364,7 +365,7 @@ pub(crate) fn build_body_html(
 ) -> serde_json::Value {
     let mut body = serde_json::json!({
         "chat_id": chat_id,
-        "rich_message": { "html": html },
+        "rich_message": { "html": enforce_button_fit(html) },
     });
     if let Some(t) = thread_id {
         body["message_thread_id"] = serde_json::json!(t.0.0);
@@ -603,7 +604,7 @@ pub(crate) fn build_body_markdown_media_target(
         .collect();
     let mut body = serde_json::json!({
         "chat_id": chat_id,
-        "rich_message": { "markdown": markdown, "media": media_arr },
+        "rich_message": { "markdown": enforce_button_fit(markdown), "media": media_arr },
     });
     if let Some(t) = thread_id {
         body["message_thread_id"] = serde_json::json!(t.0.0);

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -24,8 +24,9 @@ const STALE_HOST_CAP: usize = 32;
 #[derive(Clone)]
 pub(crate) struct MergedHost {
     pub message_id: MessageId,
-    /// HTML last rendered in that bubble (final response text, plus the
-    /// folded option list when present).
+    /// Body last rendered in that bubble (final response text, plus the
+    /// folded option list when present). HTML for html-plane hosts; the
+    /// merged markdown payload for markdown-plane hosts.
     pub html: String,
     /// Host lives on the native rich API: tap-record edits must ride
     /// `super::rich::api::edit_rich_html`, not teloxide's edit_message_text.
@@ -35,6 +36,11 @@ pub(crate) struct MergedHost {
     /// unknown/unsafe to rewrite, so a tap strips the keyboard markup-only
     /// and echoes the pick record as its own note instead of editing text.
     pub glued: bool,
+    /// Markdown-plane host (#79 piece 4): the merged markdown payload.
+    /// When set, pick redraws and strips ride `edit_rich_markdown` —
+    /// the server-side render keeps tables intact (#679). `None` = the
+    /// html plane.
+    pub markdown: Option<String>,
 }
 
 /// Merge candidate captured by deliver_final_response (#tg-suggest-merge):
@@ -1137,6 +1143,10 @@ impl TelegramState {
                         // Port note (#55): persisted rows predate the glue
                         // tier; restore as non-glued (pre-glue tap path).
                         glued: false,
+                        // Port note (#79 p4): the markdown column is NULL
+                        // for rows persisted before this change, so hydrate
+                        // reads the plane straight from the row.
+                        markdown: h.markdown,
                     });
                     let token = row.token;
                     let entry = PendingFollowupEntry {
@@ -1174,6 +1184,7 @@ impl TelegramState {
                     message_id: i64::from(h.message_id.0),
                     html: h.html.clone(),
                     rich: h.rich,
+                    markdown: h.markdown.clone(),
                 }),
         };
         let guard = self.followup_store.lock().await;

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -29,13 +29,9 @@ pub(crate) struct MergedHost {
     /// merged markdown payload for markdown-plane hosts.
     pub html: String,
     /// Host lives on the native rich API: tap-record edits must ride
-    /// `super::rich::api::edit_rich_html`, not teloxide's edit_message_text.
+    /// `super::rich::api::edit_rich_html` (or `edit_rich_markdown` for
+    /// markdown-plane hosts), not teloxide's edit_message_text.
     pub rich: bool,
-    /// #55: the keyboard was GLUED onto this bubble (glue tier — the body
-    /// was not merge-safe, e.g. a table-bearing rich answer). The body is
-    /// unknown/unsafe to rewrite, so a tap strips the keyboard markup-only
-    /// and echoes the pick record as its own note instead of editing text.
-    pub glued: bool,
     /// Markdown-plane host (#79 piece 4): the merged markdown payload.
     /// When set, pick redraws and strips ride `edit_rich_markdown` —
     /// the server-side render keeps tables intact (#679). `None` = the
@@ -48,11 +44,12 @@ pub(crate) struct MergedHost {
 #[derive(Clone)]
 pub(crate) struct MergeBubble {
     pub message_id: MessageId,
-    /// `Some` = merge-safe body (classic HTML or table-free rich markdown).
-    /// `None` = rich answer carries a table (#55): merging would flatten it,
-    /// but the id is still a valid GLUE target — `edit_message_reply_markup`
-    /// attaches the keyboard without ever touching the body.
-    pub body: Option<BubbleBody>,
+    /// Body last delivered in that bubble: classic HTML for classic
+    /// bubbles, the captured markdown for rich ones. Markdown-plane
+    /// hosts (#79 piece 4) keep the raw markdown — the merge edit rides
+    /// `edit_rich_markdown`, whose server-side render keeps tables
+    /// intact (#679).
+    pub body: BubbleBody,
 }
 
 /// How a captured [`MergeBubble`] was sent — decides which edit call merges
@@ -1140,9 +1137,6 @@ impl TelegramState {
                         message_id: MessageId(h.message_id as i32),
                         html: h.html,
                         rich: h.rich,
-                        // Port note (#55): persisted rows predate the glue
-                        // tier; restore as non-glued (pre-glue tap path).
-                        glued: false,
                         // Port note (#79 p4): the markdown column is NULL
                         // for rows persisted before this change, so hydrate
                         // reads the plane straight from the row.

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -488,6 +488,7 @@ pub(crate) async fn render_suggestions(
             new_html,
             rich,
             glue: false,
+            new_markdown: None,
         }
     });
 
@@ -630,6 +631,10 @@ struct MergePayload {
     /// #55 glue tier: attach via `edit_message_reply_markup` only — the
     /// host body is not merge-safe (table) and must never be re-sent.
     glue: bool,
+    /// Markdown-plane payload (#79 piece 4): when set, the merge edit and
+    /// every later redraw ride `edit_rich_markdown`; `new_html` then only
+    /// feeds the host record's strip source.
+    new_markdown: Option<String>,
 }
 
 /// Deferred placement attempts after a Retry-After, on top of the inline
@@ -708,6 +713,7 @@ async fn place_once(
                             html: mp.new_html.clone(),
                             rich: mp.rich,
                             glued: mp.glue,
+                            markdown: mp.new_markdown.clone(),
                         },
                     )
                     .await;

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -10,19 +10,31 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use teloxide::payloads::{
-    EditMessageReplyMarkupSetters, EditMessageTextSetters, SendMessageSetters,
-};
+use teloxide::payloads::{EditMessageTextSetters, SendMessageSetters};
 use teloxide::types::{
     ChatId, InlineKeyboardButton, InlineKeyboardMarkup, MessageId, ParseMode, ThreadId,
 };
 use uuid::Uuid;
 
 use super::TelegramState;
-use super::edit_retry::{EditErr, classify, classify_str};
 
 /// Callback-data prefix for a tapped follow-up suggestion: `followup:<session>:<idx>`.
 pub(crate) const FOLLOWUP_PREFIX: &str = "followup:";
+
+/// Body for the standalone fallback bubble (#1226 item 4). Prose mode keeps
+/// just the folded list (it has no buttons, nothing can expire); button
+/// modes carry the bare lamp plus an expiry marker — this fallback fires
+/// when the merge lost a rate-limit race, so the bubble is subject to the
+/// stale-shell lifecycle and operators kept reading dead fallbacks as
+/// fresh, answerable questions (msgs 30997 / 31010: one was tapped 32
+/// minutes after its choices were consumed).
+pub(crate) fn standalone_fallback_body(layout: &SuggestLayout, options: &[String]) -> String {
+    if *layout == SuggestLayout::NumberedProse {
+        folded_list_html(options).trim_start().to_string()
+    } else {
+        String::from("\u{1f4a1} <i>(choices may have expired)</i>")
+    }
+}
 
 /// What the suggestion block becomes once one of its options is tapped.
 ///
@@ -69,15 +81,15 @@ pub(crate) enum PickRewrite {
     /// Rich merged host: body rides `edit_rich_html`, empty markup strips
     /// the dead buttons.
     RichHost(String),
+    /// Markdown-plane merged host (#79 piece 4): body rides
+    /// `edit_rich_markdown` — the server render keeps tables intact
+    /// (#679); empty markup strips the dead buttons.
+    RichMarkdownHost(String),
     /// Classic merged host: body rides `edit_message_text` + empty markup
     /// to strip the dead buttons.
     ClassicHost(String),
     /// Standalone suggestion block: body rides plain `edit_message_text`.
     Standalone(String),
-    // NOTE (#55): glued hosts (table-bearing rich answers, keyboard attached
-    // via edit_message_reply_markup) never reach pick_rewrite — the tap
-    // handler routes them by the `glued` flag BEFORE calling this function,
-    // because a tap on a glued host must NEVER rewrite the body.
 }
 
 /// The single construction site for a post-tap body (#39).
@@ -86,199 +98,41 @@ pub(crate) enum PickRewrite {
 /// message IS it; merged host → answer HTML + pick record, standalone →
 /// pick record alone.
 pub(crate) fn pick_rewrite(
-    host: Option<(&str, bool)>,
+    host: Option<(&str, bool, Option<&str>)>,
     picked: String,
     picked_idx: usize,
 ) -> PickRewrite {
     match host {
-        Some((full, rich)) => {
-            let body = if rich {
+        Some((full, rich, markdown)) => {
+            if rich {
                 // #67 tap-redraw: the rows must not survive as live
                 // controls — they are rewritten to the picked state
                 // (success+✓+disabled / disabled) instead of stripped, so
-                // the bubble keeps showing what was chosen.
-                format!("{}\n\n{picked}", mark_picked_button(full, picked_idx))
+                // the bubble keeps showing what was chosen. `mark_picked_button`
+                // is a byte-level `<tg-button` scan, plane-agnostic — the
+                // same rewrite serves the html and markdown planes.
+                let body = format!("{}\n\n{picked}", mark_picked_button(full, picked_idx));
+                if markdown.is_some() {
+                    PickRewrite::RichMarkdownHost(body)
+                } else {
+                    PickRewrite::RichHost(body)
+                }
             } else {
                 // Classic hosts keep their buttons as reply markup (not in
                 // the body) — the empty-markup arm strips those; nothing to
                 // rewrite here.
-                format!("{full}\n\n{picked}")
-            };
-            if rich {
-                PickRewrite::RichHost(body)
-            } else {
-                PickRewrite::ClassicHost(body)
+                PickRewrite::ClassicHost(format!("{full}\n\n{picked}"))
             }
         }
         None => PickRewrite::Standalone(picked),
     }
 }
 
-/// Button-width calibration, measured 2026-08-25 on Alexey's client
-/// (`sendRichMessage` probes, messages 29975 + 29991): a single full-width
-/// button fits <=50 chars on one line and wraps by 54. (The original
-/// "shared rows wrap at 11+8=19" claim was DISPROVEN by the 2026-08-31
-/// probes — see [`SHARED_ROW_MAX_CHARS`] and fork issue #49.)
-pub(crate) const MAX_BUTTON_CHARS: usize = 50;
-/// Longest label allowed to share one row with its siblings. Recalibrated
-/// 2026-08-31 (live probes, fork issue #49): the real constraint is
-/// ROW-TOTAL width (~32 chars shared equally across the row, before the
-/// body-width-dependent truncation Alexey observed), not per-label chars —
-/// 4×8=32 held, 15+18=33 clipped ~2 symbols, and bubble width varies with
-/// the message body, so 12 keeps a safety margin under the worst bubble
-/// while doubling information per row vs the old 8.
-pub(crate) const SHARED_ROW_MAX_CHARS: usize = 12;
-/// Tap ergonomics (Alexey, 2026-08-25): numbered buttons never pack more
-/// than 4 per row, so every target stays big enough for a finger.
-pub(crate) const MAX_NUMBERS_PER_ROW: usize = 4;
-
-/// Which shape the suggestion controls take for a given option list.
-/// Tiers are measured, not guessed — see [`MAX_BUTTON_CHARS`].
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum SuggestLayout {
-    /// Every label short AND few options: all buttons share ONE row.
-    SharedRow,
-    /// Every label fits a full-width button: one button per row.
-    Column,
-    /// Some label too long even full-width: texts fold into the message
-    /// body as a numbered list, buttons collapse to bare numbers packed
-    /// [`MAX_NUMBERS_PER_ROW`] per row.
-    NumberedProse,
-}
-
-pub(crate) fn pick_layout(options: &[String]) -> SuggestLayout {
-    let width = |o: &String| o.chars().count();
-    if options.len() <= MAX_NUMBERS_PER_ROW
-        && options.iter().all(|o| width(o) <= SHARED_ROW_MAX_CHARS)
-    {
-        SuggestLayout::SharedRow
-    } else if options.iter().all(|o| width(o) <= MAX_BUTTON_CHARS) {
-        SuggestLayout::Column
-    } else {
-        SuggestLayout::NumberedProse
-    }
-}
-
-/// The folded option list as rich HTML. REUSES the canonical inline
-/// primitives from `super::markdown` — `escape_html` → `format_inline`,
-/// the exact pair the outbound renderer's default line branch applies —
-/// instead of a private formatter. Options are independent ONE-line texts,
-/// so they deliberately skip document-level interpretation (a stray `|`
-/// must not turn the list into a table); inline markup (`code`, bold) and
-/// HTML escaping behave identically to every other Telegram surface.
-/// No "Suggested next" header — the list rides directly under the answer
-/// text in the same bubble (#tg-suggest-merge), so the label would only
-/// duplicate what the buttons already say.
-pub(crate) fn folded_list_html(options: &[String]) -> String {
-    options
-        .iter()
-        .enumerate()
-        .map(|(i, opt)| {
-            format!(
-                "{}. {}",
-                i + 1,
-                super::markdown::format_inline(&super::markdown::escape_html(opt))
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-/// Rich-surface variant of [`folded_list_html`]: the rich (sendRichMessage)
-/// HTML input collapses raw newlines, so each numbered line rides its own
-/// `<p>` block or the options list renders as one long line (#1226).
-/// Classic ParseMode::Html preserves raw newlines and keeps using
-/// [`folded_list_html`].
-pub(crate) fn folded_list_html_p(options: &[String]) -> String {
-    options
-        .iter()
-        .enumerate()
-        .map(|(i, opt)| {
-            format!(
-                "<p>{}. {}</p>",
-                i + 1,
-                super::markdown::format_inline(&super::markdown::escape_html(opt))
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("")
-}
-
-/// The suggestion controls as native rich-button rows (Bot API 10.3
-/// #59: cut every `<tg-button-row>…</tg-button-row>` span out of a rich
-/// bubble body — the inverse of [`suggestion_rows_rich_html`]. Used by the
-/// host-aware stale-shell strip: the #597 clear killed the stash, but the
-/// buttons keep rendering inside the body until the body is rewritten clean.
-pub(crate) fn strip_button_rows(html: &str) -> String {
-    let mut out = String::with_capacity(html.len());
-    let mut rest = html;
-    while let Some(start) = rest.find("<tg-button-row>") {
-        match rest[start..].find("</tg-button-row>") {
-            Some(rel) => {
-                let end = start + rel + "</tg-button-row>".len();
-                out.push_str(&rest[..start]);
-                rest = &rest[end..];
-            }
-            None => break, // unterminated span: leave the remainder untouched
-        }
-    }
-    out.push_str(rest);
-    out.trim_end().to_string()
-}
-
-/// #59 (DRY): the empty reply-markup used to strip dead keyboards — one
-/// construction site instead of one per strip arm.
-pub(crate) fn empty_keyboard() -> teloxide::types::InlineKeyboardMarkup {
-    teloxide::types::InlineKeyboardMarkup::new(
-        Vec::<Vec<teloxide::types::InlineKeyboardButton>>::new(),
-    )
-}
-
-/// `<tg-button-row>`), laid out per the measured ladder. Primary style
-/// throughout — picked over app-default after Alexey compared both live.
-/// Callback payloads stay `followup:<session>:<idx>`, so taps route through
-/// the existing callback dispatcher unchanged regardless of surface.
-pub(crate) fn suggestion_rows_rich_html(options: &[String], token: &str) -> String {
-    let btn = |i: usize, label: &str| {
-        format!(
-            "<tg-button type=\"callback_data\" data=\"{FOLLOWUP_PREFIX}{token}:{i}\" \
-             style=\"primary\">{}</tg-button>",
-            super::markdown::escape_html(label)
-        )
-    };
-    match pick_layout(options) {
-        SuggestLayout::SharedRow => format!(
-            "<tg-button-row>{}</tg-button-row>",
-            options
-                .iter()
-                .enumerate()
-                .map(|(i, opt)| btn(i, opt))
-                .collect::<String>()
-        ),
-        SuggestLayout::Column => options
-            .iter()
-            .enumerate()
-            .map(|(i, opt)| format!("<tg-button-row>{}</tg-button-row>", btn(i, opt)))
-            .collect::<Vec<_>>()
-            .join("\n"),
-        SuggestLayout::NumberedProse => (0..options.len())
-            .map(|i| btn(i, &(i + 1).to_string()))
-            .collect::<Vec<_>>()
-            .chunks(MAX_NUMBERS_PER_ROW)
-            .map(|c| format!("<tg-button-row>{}</tg-button-row>", c.concat()))
-            .collect::<Vec<_>>()
-            .join("\n"),
-    }
-}
-
-/// #67 tap-redraw: rewrite suggestion buttons in a rich bubble body to
-/// their post-pick state. The picked button (whose
-/// `data="followup:<token>:<idx>"` payload ends in `picked_idx`) becomes
-/// `style="success"` with a `✓ ` label prefix; every sibling follow-up
-/// button keeps its style and gains `disabled`. Non-follow-up markup and
-/// row containers pass through byte-for-byte. Best-effort by design: if
-/// the `disabled` attribute form is ever ignored by the client, a second
-/// tap routes to the stale-shell guard, so nothing can loop.
+/// #67 tap-redraw: rewrite the follow-up button rows of a rich merged host
+/// to the post-tap state. The tapped button flips to success style, gains a
+/// ✓ and `disabled`; every sibling follow-up button loses its style (bare
+/// `disabled` is the only reliably grayed form — #71) and gains `disabled`.
+/// Non-follow-up markup passes through byte-identical.
 pub(crate) fn mark_picked_button(html: &str, picked_idx: usize) -> String {
     let mut out = String::with_capacity(html.len() + 64);
     let mut rest = html;
@@ -361,6 +215,265 @@ pub(crate) fn mark_picked_button(html: &str, picked_idx: usize) -> String {
     out
 }
 
+/// Button-width calibration, measured 2026-08-25 on Alexey's client
+/// Fold threshold: a label wider than this never rides a button — the
+/// whole set folds to [`SuggestLayout::NumberedProse`]. Recalibrated
+/// 2026-09-04 (fork issue #79 owner smokes): the old 50-char gate shipped
+/// clipped Cyrillic — measured cuts at 40-44 chars rich-plane, 32
+/// wide-glyph native-plane, and a byte-identical label flipped clean/cut
+/// across reads, so no char-count cap is provably safe at any precision.
+/// The constant is conservative by design: 20 sits below every cut
+/// datapoint observed on any plane. Units are worst-case (wide-glyph)
+/// display width; plain `chars().count()` overcounts slim-glyph labels,
+/// which errs safe.
+pub(crate) const BUTTON_LABEL_MAX_UNITS: usize = 20;
+/// Total width one row of buttons may carry before the set folds (issue
+/// #79: 3x12=36 shared-row cut, 4x12=43 cut; only a 24 slim-tail pair
+/// held — same conservative-by-design rule as [`BUTTON_LABEL_MAX_UNITS`]).
+pub(crate) const SHARED_ROW_TOTAL_UNITS: usize = 20;
+/// Longest label allowed to share one row with its siblings. Recalibrated
+/// 2026-08-31 (live probes, fork issue #49): the real constraint is
+/// ROW-TOTAL width (~32 chars shared equally across the row, before the
+/// body-width-dependent truncation Alexey observed), not per-label chars —
+/// 4×8=32 held, 15+18=33 clipped ~2 symbols, and bubble width varies with
+/// the message body, so 12 keeps a safety margin under the worst bubble
+/// while doubling information per row vs the old 8.
+pub(crate) const SHARED_ROW_MAX_CHARS: usize = 12;
+/// Tap ergonomics (Alexey, 2026-08-25): numbered buttons never pack more
+/// than 4 per row, so every target stays big enough for a finger.
+pub(crate) const MAX_NUMBERS_PER_ROW: usize = 4;
+
+/// Which shape the suggestion controls take for a given option list.
+/// Tiers are measured, not guessed — see [`BUTTON_LABEL_MAX_UNITS`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SuggestLayout {
+    /// Every label short AND few options: all buttons share ONE row.
+    SharedRow,
+    /// Every label fits a full-width button: one button per row.
+    Column,
+    /// Some label too long even full-width: texts fold into the message
+    /// body as a numbered list, buttons collapse to bare numbers packed
+    /// [`MAX_NUMBERS_PER_ROW`] per row.
+    NumberedProse,
+}
+
+pub(crate) fn pick_layout(options: &[String]) -> SuggestLayout {
+    let width = |o: &String| o.chars().count();
+    let total: usize = options.iter().map(&width).sum();
+    if options.len() <= MAX_NUMBERS_PER_ROW
+        && options.iter().all(|o| width(o) <= SHARED_ROW_MAX_CHARS)
+        && total <= SHARED_ROW_TOTAL_UNITS
+    {
+        SuggestLayout::SharedRow
+    } else if options.iter().all(|o| width(o) <= BUTTON_LABEL_MAX_UNITS) {
+        SuggestLayout::Column
+    } else {
+        SuggestLayout::NumberedProse
+    }
+}
+
+/// The folded option list as rich HTML. REUSES the canonical inline
+/// primitives from `super::markdown` — `escape_html` → `format_inline`,
+/// the exact pair the outbound renderer's default line branch applies —
+/// instead of a private formatter. Options are independent ONE-line texts,
+/// so they deliberately skip document-level interpretation (a stray `|`
+/// must not turn the list into a table); inline markup (`code`, bold) and
+/// HTML escaping behave identically to every other Telegram surface.
+/// No "Suggested next" header — the list rides directly under the answer
+/// text in the same bubble (#tg-suggest-merge), so the label would only
+/// duplicate what the buttons already say.
+pub(crate) fn folded_list_html(options: &[String]) -> String {
+    options
+        .iter()
+        .enumerate()
+        .map(|(i, opt)| {
+            format!(
+                "{}. {}",
+                i + 1,
+                super::markdown::format_inline(&super::markdown::escape_html(opt))
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// NumberedProse fold for the markdown plane (#79 piece 4): a plain
+/// numbered list — the server's markdown render keeps the numbering and
+/// the line breaks, no `<p>` wrapping needed on this plane.
+pub(crate) fn folded_list_markdown(options: &[String]) -> String {
+    options
+        .iter()
+        .enumerate()
+        .map(|(i, opt)| format!("{}. {}", i + 1, opt))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// host-aware stale-shell strip: the #597 clear killed the stash, but the
+/// buttons keep rendering inside the body until the body is rewritten clean.
+pub(crate) fn strip_button_rows(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html;
+    while let Some(start) = rest.find("<tg-button-row>") {
+        match rest[start..].find("</tg-button-row>") {
+            Some(rel) => {
+                let end = start + rel + "</tg-button-row>".len();
+                out.push_str(&rest[..start]);
+                rest = &rest[end..];
+            }
+            None => break, // unterminated span: leave the remainder untouched
+        }
+    }
+    out.push_str(rest);
+    out.trim_end().to_string()
+}
+
+/// #59 (DRY): the empty reply-markup used to strip dead keyboards — one
+/// construction site instead of one per strip arm.
+pub(crate) fn empty_keyboard() -> teloxide::types::InlineKeyboardMarkup {
+    teloxide::types::InlineKeyboardMarkup::new(
+        Vec::<Vec<teloxide::types::InlineKeyboardButton>>::new(),
+    )
+}
+
+/// #79 chokepoint: EVERY rich body that may carry `<tg-button-row>`
+/// controls passes through here on send and edit (the `rich/api.rs`
+/// funnel), so hand-authored button rows from any lane get the same
+/// measured fit rule the suggestion cards enforce at their own emitter —
+/// the n8n-card cut class. If every label fits [`BUTTON_LABEL_MAX_UNITS`]
+/// and every row's total fits [`SHARED_ROW_TOTAL_UNITS`], the body ships
+/// byte-identical. Otherwise the whole set folds to the NumberedProse
+/// shape (proven cut-free twice in #79): buttons keep their attributes —
+/// callback data and URL routing are untouched — but render their 1-based
+/// index, and the original labels move into an `<ol>` after the last row.
+/// Idempotent: a folded body's digit labels never re-trigger the fold.
+/// Width is the raw character count of the (already escaped) label text;
+/// entities overcount display width, which errs safe.
+pub(crate) fn enforce_button_fit(html: &str) -> String {
+    const ROW_OPEN: &str = "<tg-button-row>";
+    const ROW_CLOSE: &str = "</tg-button-row>";
+    const BTN_OPEN: &str = "<tg-button";
+    const BTN_CLOSE: &str = "</tg-button>";
+
+    let width = |s: &str| s.chars().count();
+
+    // Pass 1 — collect row spans, per-row open tags, and all labels.
+    let mut rows: Vec<(usize, usize)> = Vec::new();
+    let mut open_tags: Vec<Vec<&str>> = Vec::new();
+    let mut labels: Vec<&str> = Vec::new();
+    let mut fits = true;
+    let mut scan_from = 0usize;
+    while let Some(rel) = html[scan_from..].find(ROW_OPEN) {
+        let row_start = scan_from + rel;
+        let Some(crel) = html[row_start..].find(ROW_CLOSE) else {
+            break; // unterminated row: leave the remainder untouched
+        };
+        let row_end = row_start + crel + ROW_CLOSE.len();
+        let block = &html[row_start + ROW_OPEN.len()..row_end - ROW_CLOSE.len()];
+        let mut row_total = 0usize;
+        let mut tags_in_row: Vec<&str> = Vec::new();
+        let mut bscan = 0usize;
+        while let Some(brel) = block[bscan..].find(BTN_OPEN) {
+            let bstart = bscan + brel;
+            // Skip a prefix hit like `<tg-button-row>` itself.
+            let after = &block[bstart + BTN_OPEN.len()..];
+            if !after.starts_with(' ') && !after.starts_with('>') {
+                bscan = bstart + BTN_OPEN.len();
+                continue;
+            }
+            let Some(orel) = after.find('>') else {
+                break;
+            };
+            let open_tag = &block[bstart..bstart + BTN_OPEN.len() + orel];
+            let label_start = bstart + BTN_OPEN.len() + orel + 1;
+            let Some(lrel) = block[label_start..].find(BTN_CLOSE) else {
+                break;
+            };
+            let label = &block[label_start..label_start + lrel];
+            row_total += width(label);
+            fits &= width(label) <= BUTTON_LABEL_MAX_UNITS;
+            tags_in_row.push(open_tag);
+            labels.push(label);
+            bscan = label_start + lrel + BTN_CLOSE.len();
+        }
+        fits &= row_total <= SHARED_ROW_TOTAL_UNITS;
+        rows.push((row_start, row_end));
+        open_tags.push(tags_in_row);
+        scan_from = row_end;
+    }
+    if rows.is_empty() || fits {
+        return html.to_string();
+    }
+
+    // Pass 2 — fold: index digits on the buttons, labels into an `<ol>`.
+    let mut out = String::with_capacity(html.len() + 64);
+    let mut pos = 0usize;
+    let mut index = 0usize;
+    let last_row = rows.len() - 1;
+    for (i, &(row_start, row_end)) in rows.iter().enumerate() {
+        out.push_str(&html[pos..row_start]);
+        out.push_str(ROW_OPEN);
+        for tag in &open_tags[i] {
+            index += 1;
+            out.push_str(tag);
+            out.push('>');
+            out.push_str(&index.to_string());
+            out.push_str(BTN_CLOSE);
+        }
+        out.push_str(ROW_CLOSE);
+        pos = row_end;
+        if i == last_row {
+            out.push_str("\n<ol>");
+            for label in &labels {
+                out.push_str("<li>");
+                out.push_str(label);
+                out.push_str("</li>");
+            }
+            out.push_str("</ol>");
+        }
+    }
+    out.push_str(&html[pos..]);
+    out
+}
+
+/// The suggestion controls as native rich-button rows (Bot API 10.3
+/// `<tg-button-row>`), laid out per the measured ladder. Primary style
+/// throughout — picked over app-default after Alexey compared both live.
+/// Callback payloads stay `followup:<session>:<idx>`, so taps route through
+/// the existing callback dispatcher unchanged regardless of surface.
+pub(crate) fn suggestion_rows_rich_html(options: &[String], token: &str) -> String {
+    let btn = |i: usize, label: &str| {
+        format!(
+            "<tg-button type=\"callback_data\" data=\"{FOLLOWUP_PREFIX}{token}:{i}\" \
+             style=\"primary\">{}</tg-button>",
+            super::markdown::escape_html(label)
+        )
+    };
+    match pick_layout(options) {
+        SuggestLayout::SharedRow => format!(
+            "<tg-button-row>{}</tg-button-row>",
+            options
+                .iter()
+                .enumerate()
+                .map(|(i, opt)| btn(i, opt))
+                .collect::<String>()
+        ),
+        SuggestLayout::Column => options
+            .iter()
+            .enumerate()
+            .map(|(i, opt)| format!("<tg-button-row>{}</tg-button-row>", btn(i, opt)))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        SuggestLayout::NumberedProse => (0..options.len())
+            .map(|i| btn(i, &(i + 1).to_string()))
+            .collect::<Vec<_>>()
+            .chunks(MAX_NUMBERS_PER_ROW)
+            .map(|c| format!("<tg-button-row>{}</tg-button-row>", c.concat()))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    }
+}
+
 #[allow(clippy::too_many_arguments)] // #31: trailer rides the existing arg set
 pub(crate) async fn render_suggestions(
     bot: &teloxide::Bot,
@@ -399,7 +512,8 @@ pub(crate) async fn render_suggestions(
         .register_pending_followups(session_id, options.clone())
         .await;
 
-    // Layout tiers are measured, not guessed (see MAX_BUTTON_CHARS): short
+    // Layout tiers are measured, not guessed (see BUTTON_LABEL_MAX_UNITS):
+    // short
     // labels share one row, medium labels get a full-width row each, and
     // anything longer folds into the body as a numbered list with compact
     // number buttons (<=4 per row). The absolute index is encoded in the
@@ -444,40 +558,49 @@ pub(crate) async fn render_suggestions(
     // content instead of re-deriving it.
     let merge_payload: Option<MergePayload> = merge_host.map(|host| {
         let mid = host.message_id;
-        // #55 glue tier: table-bearing rich answers capture body=None — a
-        // body-rewriting merge would flatten the table (#679), so the
-        // keyboard rides `edit_message_reply_markup` instead and the body
-        // is never touched.
-        let Some(body) = host.body else {
-            return MergePayload {
-                message_id: mid,
-                new_html: String::new(),
-                rich: false,
-                glue: true,
-            };
-        };
-        // Base body + surface: classic bubbles keep their exact delivered
-        // HTML; rich bubbles re-render from the captured markdown.
-        let (mut new_html, rich) = match body {
-            super::state::BubbleBody::Html(html) => (html, false),
-            super::state::BubbleBody::Markdown(md) => (super::rich::markdown_to_html_p(&md), true),
-        };
-        if layout == SuggestLayout::NumberedProse {
-            if rich {
-                // Rich HTML collapses raw newlines (#1226): the numbered list
-                // rides <p>-wrapped lines so it keeps its shape; classic hosts
-                // preserve the raw newline join via folded_list_html.
-                new_html.push_str(&folded_list_html_p(&options));
-            } else {
-                new_html.push('\n');
-                new_html.push_str(folded_list_html(&options).trim_start());
+        // Base body + plane: classic bubbles keep their exact delivered
+        // HTML; markdown-plane hosts (#79 piece 4) keep the raw markdown —
+        // including tables, which the markdown plane renders intact
+        // server-side (C1 probe) where rich HTML input flattens them
+        // (#679). The html conversion of the merged payload is kept only
+        // as the host record's strip source.
+        let (mut new_html, rich, new_markdown) = match host.body {
+            super::state::BubbleBody::Html(html) => {
+                let mut body = html;
+                if layout == SuggestLayout::NumberedProse {
+                    // Classic hosts preserve the raw newline join via
+                    // folded_list_html.
+                    body.push('\n');
+                    body.push_str(folded_list_html(&options).trim_start());
+                }
+                (body, false, None)
             }
-        }
-        if rich {
+            super::state::BubbleBody::Markdown(md) => {
+                let mut new_md = md;
+                if layout == SuggestLayout::NumberedProse {
+                    // Markdown plane: plain numbered list — the server's
+                    // markdown render keeps numbering and line breaks.
+                    new_md.push('\n');
+                    new_md.push_str(&folded_list_markdown(&options));
+                }
+                new_md.push('\n');
+                new_md.push_str(&suggestion_rows_rich_html(&options, &token));
+                // #31: the sign-off paragraph rides AFTER the button rows —
+                // one message carries answer + controls + trailer, in that
+                // order. Raw markdown: no conversion on this plane.
+                if let Some(t) = &trailer {
+                    new_md.push('\n');
+                    new_md.push_str(t);
+                }
+                let strip_source = super::rich::markdown_to_html_p(&new_md);
+                (strip_source, true, Some(new_md))
+            }
+        };
+        if rich && new_markdown.is_none() {
+            // Legacy html-plane rich host: the rows ride the html dialect
+            // as before (#1226 newline handling applies).
             new_html.push('\n');
             new_html.push_str(&suggestion_rows_rich_html(&options, &token));
-            // #31: the sign-off paragraph rides AFTER the button rows — one
-            // message carries answer + controls + trailer, in that order.
             if let Some(t) = &trailer {
                 new_html.push('\n');
                 new_html.push_str(&super::rich::markdown_to_html_p(t));
@@ -487,21 +610,15 @@ pub(crate) async fn render_suggestions(
             message_id: mid,
             new_html,
             rich,
-            glue: false,
-            new_markdown: None,
+            new_markdown,
         }
     });
 
-    // Standalone fallback (no merge candidate, no glue target, or the edit
-    // lost a race / grew too old): the header sentence is still gone per
-    // #tg-suggest-merge — prose mode shows just the numbered list, button
-    // modes need SOME text for the Bot API to accept the message. #55: the
-    // bare lamp is retired — "Pick one:" says the same with words.
-    let standalone_body = if layout == SuggestLayout::NumberedProse {
-        folded_list_html(&options).trim_start().to_string()
-    } else {
-        String::from("Pick one:")
-    };
+    // Standalone fallback (no merge candidate, or the edit lost a race / grew
+    // too old): the header sentence is still gone per #tg-suggest-merge —
+    // prose mode shows just the numbered list, button modes need SOME text
+    // for the Bot API to accept the message, so they degrade to the bare 💡.
+    let standalone_body = standalone_fallback_body(&layout, &options);
 
     let option_count = options.len();
     match place_once(
@@ -531,13 +648,13 @@ pub(crate) async fn render_suggestions(
                 send_trailer_bubble(bot, chat_id, thread_id, t).await;
             }
         }
-        Err(EditErr::Fatal(e)) => {
+        Err(PlaceErr::Fatal(e)) => {
             tracing::warn!("Telegram suggest_options: send failed: {e}");
             // The buttons never landed — drop the stash so a stale entry can't
             // swallow an unrelated future tap.
             state.drop_pending_followup(&token).await;
         }
-        Err(EditErr::RetryAfter(wait)) => {
+        Err(PlaceErr::RetryAfter(wait)) => {
             // #30: a 429 here used to drop the stash at once — but BOTH arms
             // die inside the same flood window (the standalone send followed
             // the merge edit by 22ms into the same 41s ban), and the buttons
@@ -591,7 +708,7 @@ pub(crate) async fn render_suggestions(
                             }
                             return;
                         }
-                        Err(EditErr::Fatal(e)) => {
+                        Err(PlaceErr::Fatal(e)) => {
                             tracing::warn!(
                                 "Telegram suggest_options: deferred placement {attempt} \
                                  failed permanently: {e}"
@@ -599,7 +716,7 @@ pub(crate) async fn render_suggestions(
                             state.drop_pending_followup(&token).await;
                             return;
                         }
-                        Err(EditErr::RetryAfter(w)) => {
+                        Err(PlaceErr::RetryAfter(w)) => {
                             tracing::warn!(
                                 "Telegram suggest_options: deferred placement {attempt} hit \
                                  Retry-After {}s again (token {token})",
@@ -628,13 +745,20 @@ struct MergePayload {
     message_id: MessageId,
     new_html: String,
     rich: bool,
-    /// #55 glue tier: attach via `edit_message_reply_markup` only — the
-    /// host body is not merge-safe (table) and must never be re-sent.
-    glue: bool,
     /// Markdown-plane payload (#79 piece 4): when set, the merge edit and
     /// every later redraw ride `edit_rich_markdown`; `new_html` then only
     /// feeds the host record's strip source.
     new_markdown: Option<String>,
+}
+
+/// Placement error class (#30): decides whether the stash survives the
+/// failure.
+enum PlaceErr {
+    /// Telegram answered 429 with a Retry-After — the placement may succeed
+    /// once the window passes, so the stash MUST survive the wait.
+    RetryAfter(Duration),
+    /// Anything else: retrying cannot fix it; the stash drops as before.
+    Fatal(String),
 }
 
 /// Deferred placement attempts after a Retry-After, on top of the inline
@@ -642,6 +766,31 @@ struct MergePayload {
 /// windows while comfortably covering the 31–42s windows observed in the
 /// #30 ledger.
 const MAX_DEFERRED_PLACEMENT_ATTEMPTS: u32 = 2;
+
+/// Wait used when only the rich arm's stringified "(429)" survives — see
+/// [`classify_rich_err`].
+const RICH_429_FALLBACK_WAIT_SECS: u64 = 30;
+
+fn classify_request_err(e: teloxide::RequestError) -> PlaceErr {
+    match e {
+        teloxide::RequestError::RetryAfter(secs) => PlaceErr::RetryAfter(secs.duration()),
+        other => PlaceErr::Fatal(other.to_string()),
+    }
+}
+
+/// The rich arm buries Telegram's exact retry_after inside its own internal
+/// retry loop (`post_rich`) and surfaces only an anyhow string, so
+/// classification keys off the status marker. The wait is a middle-of-the-
+/// road default: the rich path already slept out the true value
+/// RICH_MAX_RETRIES times before bailing, and the observed flood windows
+/// run 31–42s (#30 ledger).
+fn classify_rich_err(e: &str) -> PlaceErr {
+    if e.contains("(429)") {
+        PlaceErr::RetryAfter(Duration::from_secs(RICH_429_FALLBACK_WAIT_SECS))
+    } else {
+        PlaceErr::Fatal(e.to_string())
+    }
+}
 
 /// One placement pass (#30): merge onto the answer bubble when a payload
 /// exists, standalone otherwise. RetryAfter-class errors bubble up so the
@@ -657,18 +806,26 @@ async fn place_once(
     keyboard: &InlineKeyboardMarkup,
     merge: Option<&MergePayload>,
     standalone_body: &str,
-) -> Result<(), EditErr> {
+) -> Result<(), PlaceErr> {
     use teloxide::prelude::Requester;
 
     if let Some(mp) = merge {
         let mid = mp.message_id;
-        let outcome: Result<(), EditErr> = if mp.glue {
-            // #55 glue tier: attach the keyboard without touching the body.
-            bot.edit_message_reply_markup(chat_id, mid)
-                .reply_markup(keyboard.clone())
-                .await
-                .map(|_| ())
-                .map_err(|e| classify(&e))
+        let outcome: Result<(), PlaceErr> = if let Some(md) = &mp.new_markdown {
+            // Markdown-plane host (#79 piece 4): raw markdown + embedded
+            // button rows — the server render keeps tables intact (#679).
+            super::rich::api::edit_rich_markdown(
+                bot.api_url().as_str(),
+                bot.token(),
+                chat_id.0,
+                mid.0,
+                md,
+                None,
+                "turn",
+                "-",
+            )
+            .await
+            .map_err(|e| classify_rich_err(&e.to_string()))
         } else if mp.rich {
             super::rich::api::edit_rich_html(
                 bot.api_url().as_str(),
@@ -681,14 +838,14 @@ async fn place_once(
                 "-",
             )
             .await
-            .map_err(|e| classify_str(&e.to_string()))
+            .map_err(|e| classify_rich_err(&e.to_string()))
         } else {
             bot.edit_message_text(chat_id, mid, &mp.new_html)
                 .parse_mode(ParseMode::Html)
                 .reply_markup(keyboard.clone())
                 .await
                 .map(|_| ())
-                .map_err(|e| classify(&e))
+                .map_err(classify_request_err)
         };
         match outcome {
             Ok(()) => {
@@ -697,8 +854,8 @@ async fn place_once(
                 tracing::info!(
                     "Telegram suggest_options: keyboard merged onto msg {mid} \
                      ({} host, token {token}, {option_count} options)",
-                    if mp.glue {
-                        "glue"
+                    if mp.new_markdown.is_some() {
+                        "rich-md"
                     } else if mp.rich {
                         "rich"
                     } else {
@@ -712,15 +869,14 @@ async fn place_once(
                             message_id: mid,
                             html: mp.new_html.clone(),
                             rich: mp.rich,
-                            glued: mp.glue,
                             markdown: mp.new_markdown.clone(),
                         },
                     )
                     .await;
                 return Ok(());
             }
-            Err(EditErr::RetryAfter(wait)) => return Err(EditErr::RetryAfter(wait)),
-            Err(EditErr::Fatal(e)) => {
+            Err(PlaceErr::RetryAfter(wait)) => return Err(PlaceErr::RetryAfter(wait)),
+            Err(PlaceErr::Fatal(e)) => {
                 tracing::warn!(
                     "Telegram suggest_options: merge onto msg {mid} failed ({e}) — standalone fallback"
                 );
@@ -744,7 +900,7 @@ async fn place_once(
             );
             Ok(())
         }
-        Err(e) => Err(classify(&e)),
+        Err(e) => Err(classify_request_err(e)),
     }
 }
 

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -83,6 +83,7 @@ pub(crate) const MIGRATION_SQL: &[&str] = &[
     include_str!("../migrations/20260826000001_add_session_bindings.sql"),
     include_str!("../migrations/20260828000001_pending_requests_origin.sql"),
     include_str!("../migrations/20260902000001_add_pending_followups.sql"),
+    include_str!("../migrations/20260904000000_add_pending_followups_host_markdown.sql"),
 ];
 
 pub(crate) fn build_migrations() -> Migrations<'static> {

--- a/src/db/repository/pending_followup.rs
+++ b/src/db/repository/pending_followup.rs
@@ -25,6 +25,11 @@ pub struct FollowupHost {
     pub message_id: i64,
     pub html: String,
     pub rich: bool,
+    /// Merged markdown payload for markdown-plane hosts (#79 piece 4):
+    /// when set, every edit of this bubble rides `edit_rich_markdown`
+    /// (server-side render keeps tables intact); the `html` copy is then
+    /// a fallback/strip source only. `None` = html-plane host.
+    pub markdown: Option<String>,
 }
 
 /// One armed suggestion keyboard, as stored.
@@ -55,7 +60,7 @@ impl PendingFollowupRepository {
             .interact(move |conn| -> Result<Vec<PendingFollowup>> {
                 let mut stmt = conn.prepare(
                     "SELECT token, session_id, options_json, host_message_id, host_html, \
-                     host_rich FROM pending_followups",
+                     host_rich, host_markdown FROM pending_followups",
                 )?;
                 let rows = stmt
                     .query_map([], |row| {
@@ -67,24 +72,28 @@ impl PendingFollowupRepository {
                             row.get::<_, Option<i64>>(3)?,
                             row.get::<_, Option<String>>(4)?,
                             row.get::<_, i64>(5)? != 0,
+                            row.get::<_, Option<String>>(6)?,
                         ))
                     })?
                     .collect::<std::result::Result<Vec<_>, _>>()?;
                 rows.into_iter()
-                    .map(|(token, session_id, options_json, mid, html, rich)| {
-                        let options = serde_json::from_str(&options_json)
-                            .with_context(|| format!("decode options for token {token}"))?;
-                        Ok(PendingFollowup {
-                            token,
-                            session_id,
-                            options,
-                            host: mid.map(|message_id| FollowupHost {
-                                message_id,
-                                html: html.unwrap_or_default(),
-                                rich,
-                            }),
-                        })
-                    })
+                    .map(
+                        |(token, session_id, options_json, mid, html, rich, markdown)| {
+                            let options = serde_json::from_str(&options_json)
+                                .with_context(|| format!("decode options for token {token}"))?;
+                            Ok(PendingFollowup {
+                                token,
+                                session_id,
+                                options,
+                                host: mid.map(|message_id| FollowupHost {
+                                    message_id,
+                                    html: html.unwrap_or_default(),
+                                    rich,
+                                    markdown,
+                                }),
+                            })
+                        },
+                    )
                     .collect()
             })
             .await
@@ -97,9 +106,14 @@ impl PendingFollowupRepository {
     pub async fn save(&self, entry: &PendingFollowup) -> Result<()> {
         let options_json =
             serde_json::to_string(&entry.options).context("encode followup options")?;
-        let (mid, html, rich) = match &entry.host {
-            Some(h) => (Some(h.message_id), Some(h.html.clone()), h.rich),
-            None => (None, None, false),
+        let (mid, html, rich, markdown) = match &entry.host {
+            Some(h) => (
+                Some(h.message_id),
+                Some(h.html.clone()),
+                h.rich,
+                h.markdown.clone(),
+            ),
+            None => (None, None, false, None),
         };
         let token = entry.token.clone();
         let session_id = entry.session_id.clone();
@@ -111,16 +125,17 @@ impl PendingFollowupRepository {
                 conn.execute(
                     "INSERT INTO pending_followups \
                        (token, session_id, options_json, host_message_id, host_html, \
-                        host_rich, updated_at) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, strftime('%s','now')) \
+                        host_rich, host_markdown, updated_at) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, strftime('%s','now')) \
                      ON CONFLICT(token) DO UPDATE SET \
                        session_id = excluded.session_id, \
                        options_json = excluded.options_json, \
                        host_message_id = excluded.host_message_id, \
                        host_html = excluded.host_html, \
                        host_rich = excluded.host_rich, \
+                       host_markdown = excluded.host_markdown, \
                        updated_at = excluded.updated_at",
-                    params![token, session_id, options_json, mid, html, rich],
+                    params![token, session_id, options_json, mid, html, rich, markdown],
                 )
             })
             .await

--- a/src/migrations/20260904000000_add_pending_followups_host_markdown.sql
+++ b/src/migrations/20260904000000_add_pending_followups_host_markdown.sql
@@ -1,0 +1,11 @@
+-- Markdown-plane host bodies for pending follow-ups (#79, A1 piece 4).
+-- Table-bearing answers can now carry the suggestion controls: the merge
+-- edit rides the rich MARKDOWN plane (editMessageText + rich_message.markdown),
+-- whose server-side render keeps tables intact — the HTML plane flattens
+-- them (#679), which is why those answers were excluded from merging.
+-- The merged markdown payload is stored alongside the html copy so every
+-- later edit of the bubble (pick redraw, stale strip) re-sends it through
+-- the same markdown plane instead of flattening the table.
+-- Nullable: NULL = html-plane host (all rows written before this change).
+
+ALTER TABLE pending_followups ADD COLUMN host_markdown TEXT;

--- a/src/tests/question_common_test.rs
+++ b/src/tests/question_common_test.rs
@@ -85,7 +85,7 @@ fn truncate_label_reproduces_the_historic_fold_shape() {
 #[test]
 fn channel_budgets_stay_sane() {
     use crate::channels::question_common::{DISCORD_LABEL_BUDGET, SLACK_LABEL_BUDGET};
-    use crate::channels::telegram::suggest_options::MAX_BUTTON_CHARS;
+    use crate::channels::telegram::suggest_options::BUTTON_LABEL_MAX_UNITS;
     // Evaluated at compile time: these are consts, so a runtime assert both
     // trips `assertions_on_constants` and defers to run-time a contradiction
     // the compiler can already see.
@@ -93,7 +93,7 @@ fn channel_budgets_stay_sane() {
         assert!(DISCORD_LABEL_BUDGET > 0 && SLACK_LABEL_BUDGET > 0);
         // Telegram's ladder replaced its budget: past this width a label
         // cannot ride a button at all and becomes a numbered entry, so no
-        // Telegram label is ever silently cut (#1204).
-        assert!(MAX_BUTTON_CHARS > 0);
+        // Telegram label is never silently cut (#1204, recalibrated #79).
+        assert!(BUTTON_LABEL_MAX_UNITS > 0);
     }
 }

--- a/src/tests/telegram_followup_pick_test.rs
+++ b/src/tests/telegram_followup_pick_test.rs
@@ -12,9 +12,14 @@
 //!
 //! Fixtures are synthetic and carry no user identifiers.
 
+use std::sync::Arc;
+
+use teloxide::types::MessageId;
+
+use crate::channels::telegram::state::{MergedHost, TelegramState};
 use crate::channels::telegram::suggest_options::{
-    PickRewrite, echo_fallback, mark_picked_button, pick_rewrite, picked_block,
-    suggestion_rows_rich_html,
+    PickRewrite, echo_fallback, folded_list_markdown, mark_picked_button, pick_rewrite,
+    picked_block, suggestion_rows_rich_html,
 };
 
 const CHOICE: &str = "Update the SKILL.md with the new callback routing";
@@ -113,7 +118,7 @@ fn classic_host_body_keeps_answer_and_pick() {
     // classic merged host edited the answer HTML alone and the pick
     // record vanished. The body must carry BOTH, answer first.
     let rewrite = pick_rewrite(
-        Some(("<b>the answer</b>", false)),
+        Some(("<b>the answer</b>", false, None)),
         picked_block(CHOICE, None),
         0,
     );
@@ -131,7 +136,7 @@ fn classic_host_body_keeps_answer_and_pick() {
 #[test]
 fn rich_host_body_keeps_answer_and_pick() {
     let rewrite = pick_rewrite(
-        Some(("<b>the answer</b>", true)),
+        Some(("<b>the answer</b>", true, None)),
         picked_block(CHOICE, None),
         0,
     );
@@ -159,18 +164,117 @@ fn the_rich_flag_decides_the_transport_not_the_body() {
     // Same host html, same pick — only the rich flag flips, so the two
     // bodies must match byte for byte; only the variant differs.
     let picked = picked_block(CHOICE, None);
-    let classic = pick_rewrite(Some(("host", false)), picked.clone(), 0);
-    let rich = pick_rewrite(Some(("host", true)), picked, 0);
+    let classic = pick_rewrite(Some(("host", false, None)), picked.clone(), 0);
+    let rich = pick_rewrite(Some(("host", true, None)), picked, 0);
     fn body_of(r: &PickRewrite) -> &str {
         match r {
-            PickRewrite::RichHost(b) | PickRewrite::ClassicHost(b) | PickRewrite::Standalone(b) => {
-                b.as_str()
-            }
+            PickRewrite::RichHost(b)
+            | PickRewrite::RichMarkdownHost(b)
+            | PickRewrite::ClassicHost(b)
+            | PickRewrite::Standalone(b) => b.as_str(),
         }
     }
     assert_eq!(body_of(&classic), body_of(&rich));
     assert_ne!(classic, rich, "the variant must flip with the flag");
 }
+
+// ---- #59: stale-shell taps must know the host shape after a #597 clear ----
+//
+// The #597 clear wipes the stash when the user sends their own message, but
+// RICH-merged buttons keep rendering inside the bubble body. The clear now
+// rescues the merged-host record into a bounded stale map, so the stale-shell
+// tap can strip by host shape instead of firing a blind markup strip (a
+// guaranteed no-op on rich bubbles — the zombie).
+//
+// (Adapted to the upstream MergedHost shape: no `glued` field — that is the
+// fork's #55 glue tier, disposition ASK, not ported.)
+
+fn host(mid: i32, rich: bool) -> MergedHost {
+    MergedHost {
+        message_id: MessageId(mid),
+        html: "<p>answer</p><tg-button-row><tg-button>Go</tg-button></tg-button-row>".into(),
+        rich,
+        markdown: None,
+    }
+}
+
+async fn register_one(state: &TelegramState, sid: uuid::Uuid, token_tag: u8) -> String {
+    let token = state
+        .register_pending_followups(sid, vec![format!("Option {token_tag}")])
+        .await;
+    state
+        .attach_followup_host(&token, host(100 + i32::from(token_tag), true))
+        .await;
+    token
+}
+
+#[tokio::test]
+async fn clear_rescues_host_records_for_stale_taps() {
+    let state = Arc::new(TelegramState::new());
+    let sid = uuid::Uuid::new_v4();
+    let token = register_one(&state, sid, 1).await;
+
+    // No stale record before the clear.
+    assert!(state.peek_stale_host(&token).await.is_none());
+
+    state.clear_pending_followups(sid).await;
+
+    // After the clear the stash is gone, but the rescued record survives.
+    let h = state
+        .peek_stale_host(&token)
+        .await
+        .expect("clear must rescue the merged-host record (#59)");
+    assert!(h.rich);
+    assert_eq!(h.message_id.0, 101);
+}
+
+#[tokio::test]
+async fn forget_removes_only_the_stripped_record() {
+    let state = Arc::new(TelegramState::new());
+    let sid = uuid::Uuid::new_v4();
+    let a = register_one(&state, sid, 1).await;
+    let b = register_one(&state, sid, 2).await;
+    state.clear_pending_followups(sid).await;
+
+    state.forget_stale_host(&a).await;
+    assert!(state.peek_stale_host(&a).await.is_none());
+    assert!(
+        state.peek_stale_host(&b).await.is_some(),
+        "unrelated records must survive a forget"
+    );
+    // Idempotent: forgetting again is a no-op, not a panic.
+    state.forget_stale_host(&a).await;
+}
+
+#[tokio::test]
+async fn unmerged_entries_leave_no_stale_record() {
+    let state = Arc::new(TelegramState::new());
+    let sid = uuid::Uuid::new_v4();
+    // Registered but the merge never landed: no host to attach, nothing to
+    // strip later — the clear must NOT mint a stale record for it.
+    let _ = state
+        .register_pending_followups(sid, vec!["Bare option".to_string()])
+        .await;
+    state.clear_pending_followups(sid).await;
+    assert_eq!(state.stale_host_count().await, 0);
+}
+
+#[tokio::test]
+async fn stale_map_is_bounded_at_the_cap() {
+    let state = Arc::new(TelegramState::new());
+    let sid = uuid::Uuid::new_v4();
+    // CAP + 5 registrations, all cleared in one sweep: the deque must shed
+    // the oldest records down to the cap.
+    for i in 0..37 {
+        let _ = register_one(&state, sid, (i % 250 + 1) as u8).await;
+    }
+    state.clear_pending_followups(sid).await;
+    assert!(
+        state.stale_host_count().await <= 32,
+        "stale-host map must be bounded (FIFO eviction)"
+    );
+}
+
 // ── #67 tap-redraw: mark_picked_button ──────────────────────────────────────
 
 fn shared_row_html() -> String {
@@ -229,7 +333,7 @@ fn tap_redraw_rich_host_body_has_marked_rows_and_record() {
     // End-to-end through pick_rewrite: rows rewritten to the picked state,
     // record appended, #39 order preserved (answer/rows first, record last).
     let host = format!("<b>the answer</b>\n{}", shared_row_html());
-    let rewrite = pick_rewrite(Some((&host, true)), picked_block(CHOICE, None), 1);
+    let rewrite = pick_rewrite(Some((&host, true, None)), picked_block(CHOICE, None), 1);
     let PickRewrite::RichHost(body) = rewrite else {
         panic!("rich host stays rich")
     };
@@ -246,103 +350,47 @@ fn tap_redraw_rich_host_body_has_marked_rows_and_record() {
     );
 }
 
-// ---- #59: stale-shell taps must know the host shape after a #597 clear ----
-//
-// The #597 clear wipes the stash when the user sends their own message, but
-// RICH-merged buttons keep rendering inside the bubble body. The clear now
-// rescues the merged-host record into a bounded stale map, so the stale-shell
-// tap can strip by host shape instead of firing a blind markup strip (a
-// guaranteed no-op on rich bubbles — the zombie).
+#[test]
+fn markdown_host_routes_to_the_markdown_plane() {
+    // #79 piece 4: a markdown-plane host (markdown: Some) must produce the
+    // RichMarkdownHost variant even though its body bytes rewrite exactly
+    // like an html-plane host — the plane decides the transport, not the
+    // content.
+    let host = "<b>answer</b>\n| a | b |\n|---|---|\n| 1 | 2 |".to_string();
+    let rewrite = pick_rewrite(
+        Some((host.as_str(), true, Some(host.as_str()))),
+        picked_block(CHOICE, None),
+        0,
+    );
+    let PickRewrite::RichMarkdownHost(body) = rewrite else {
+        panic!("markdown host must ride the markdown plane: {rewrite:?}")
+    };
+    assert!(body.starts_with("<b>answer</b>"), "answer first: {body}");
+    assert!(
+        body.contains("| a | b |"),
+        "markdown table survives: {body}"
+    );
+    assert!(body.contains(CHOICE), "pick record survives: {body}");
+}
 
-use std::sync::Arc;
-
-use teloxide::types::MessageId;
-
-use crate::channels::telegram::state::{MergedHost, TelegramState};
-
-fn host(mid: i32, rich: bool, glued: bool) -> MergedHost {
-    MergedHost {
-        message_id: MessageId(mid),
-        html: "<p>answer</p><tg-button-row><tg-button>Go</tg-button></tg-button-row>".into(),
-        rich,
-        glued,
-        markdown: None,
+#[test]
+fn markdown_and_html_hosts_rewrite_identically() {
+    // Same body bytes, different plane: the rewritten bodies must match
+    // byte for byte — only the variant (transport) differs.
+    let host = "<b>the answer</b>";
+    let picked = picked_block(CHOICE, None);
+    let html_plane = pick_rewrite(Some((host, true, None)), picked.clone(), 0);
+    let md_plane = pick_rewrite(Some((host, true, Some(host))), picked, 0);
+    match (html_plane, md_plane) {
+        (PickRewrite::RichHost(a), PickRewrite::RichMarkdownHost(b)) => {
+            assert_eq!(a, b, "rewrite is plane-agnostic")
+        }
+        other => panic!("unexpected variants: {other:?}"),
     }
 }
 
-async fn register_one(state: &TelegramState, sid: uuid::Uuid, token_tag: u8) -> String {
-    let token = state
-        .register_pending_followups(sid, vec![format!("Option {token_tag}")])
-        .await;
-    state
-        .attach_followup_host(&token, host(100 + i32::from(token_tag), true, false))
-        .await;
-    token
-}
-
-#[tokio::test]
-async fn clear_rescues_host_records_for_stale_taps() {
-    let state = Arc::new(TelegramState::new());
-    let sid = uuid::Uuid::new_v4();
-    let token = register_one(&state, sid, 1).await;
-
-    // No stale record before the clear.
-    assert!(state.peek_stale_host(&token).await.is_none());
-
-    state.clear_pending_followups(sid).await;
-
-    // After the clear the stash is gone, but the rescued record survives.
-    let h = state
-        .peek_stale_host(&token)
-        .await
-        .expect("clear must rescue the merged-host record (#59)");
-    assert!(h.rich && !h.glued);
-    assert_eq!(h.message_id.0, 101);
-}
-
-#[tokio::test]
-async fn forget_removes_only_the_stripped_record() {
-    let state = Arc::new(TelegramState::new());
-    let sid = uuid::Uuid::new_v4();
-    let a = register_one(&state, sid, 1).await;
-    let b = register_one(&state, sid, 2).await;
-    state.clear_pending_followups(sid).await;
-
-    state.forget_stale_host(&a).await;
-    assert!(state.peek_stale_host(&a).await.is_none());
-    assert!(
-        state.peek_stale_host(&b).await.is_some(),
-        "unrelated records must survive a forget"
-    );
-    // Idempotent: forgetting again is a no-op, not a panic.
-    state.forget_stale_host(&a).await;
-}
-
-#[tokio::test]
-async fn unmerged_entries_leave_no_stale_record() {
-    let state = Arc::new(TelegramState::new());
-    let sid = uuid::Uuid::new_v4();
-    // Registered but the merge never landed: no host to attach, nothing to
-    // strip later — the clear must NOT mint a stale record for it.
-    let _ = state
-        .register_pending_followups(sid, vec!["Bare option".to_string()])
-        .await;
-    state.clear_pending_followups(sid).await;
-    assert_eq!(state.stale_host_count().await, 0);
-}
-
-#[tokio::test]
-async fn stale_map_is_bounded_at_the_cap() {
-    let state = Arc::new(TelegramState::new());
-    let sid = uuid::Uuid::new_v4();
-    // CAP + 5 registrations, all cleared in one sweep: the deque must shed
-    // the oldest records down to the cap.
-    for i in 0..37 {
-        let _ = register_one(&state, sid, (i % 250 + 1) as u8).await;
-    }
-    state.clear_pending_followups(sid).await;
-    assert!(
-        state.stale_host_count().await <= 32,
-        "stale-host map must be bounded (FIFO eviction)"
-    );
+#[test]
+fn folded_list_markdown_numbers_each_option() {
+    let list = folded_list_markdown(&["первый".to_string(), "второй|с таблицей".to_string()]);
+    assert_eq!(list, "1. первый\n2. второй|с таблицей");
 }

--- a/src/tests/telegram_followup_pick_test.rs
+++ b/src/tests/telegram_followup_pick_test.rs
@@ -266,6 +266,7 @@ fn host(mid: i32, rich: bool, glued: bool) -> MergedHost {
         html: "<p>answer</p><tg-button-row><tg-button>Go</tg-button></tg-button-row>".into(),
         rich,
         glued,
+        markdown: None,
     }
 }
 

--- a/src/tests/telegram_mermaid_test.rs
+++ b/src/tests/telegram_mermaid_test.rs
@@ -8,7 +8,9 @@
 //! point `should_render_mermaid` is not unit-tested because it reads the live
 //! `Config`, whose values in tests depend on the embedded example config.
 
-use crate::channels::telegram::rich::api::build_body_markdown_media_target;
+use crate::channels::telegram::rich::api::{
+    build_body_markdown_media_target, multipart_scalar_fields,
+};
 use crate::channels::telegram::rich::ast::{Block, Inline, MermaidResult};
 use crate::channels::telegram::rich::markdown_to_html_mermaid;
 use crate::channels::telegram::rich::mermaid::{
@@ -660,4 +662,24 @@ fn png_dims_rejects_non_png_and_short_buffers() {
     hdr.extend_from_slice(b"IDAT"); // wrong chunk type
     hdr.extend_from_slice(&[0u8; 16]);
     assert_eq!(png_dims(&hdr), None);
+}
+
+#[test]
+fn multipart_scalar_fields_carries_message_id_for_edits_only() {
+    let edit_body = serde_json::json!({
+        "chat_id": -100,
+        "message_id": 40827,
+        "rich_message": { "markdown": "text", "media": [] },
+    });
+    let edit_parts = multipart_scalar_fields(&edit_body);
+    assert!(edit_parts.contains(&("message_id".to_string(), "40827".to_string())));
+    assert!(edit_parts.contains(&("chat_id".to_string(), "-100".to_string())));
+    assert!(edit_parts.iter().any(|(name, _)| name == "rich_message"));
+
+    let send_body = serde_json::json!({
+        "chat_id": -100,
+        "rich_message": { "markdown": "text", "media": [] },
+    });
+    let send_parts = multipart_scalar_fields(&send_body);
+    assert!(!send_parts.iter().any(|(name, _)| name == "message_id"));
 }

--- a/src/tests/telegram_suggest_merge_test.rs
+++ b/src/tests/telegram_suggest_merge_test.rs
@@ -9,8 +9,8 @@
 //! rule is that no source file carries a `#[cfg(test)] mod tests` block.
 
 use crate::channels::telegram::suggest_options::{
-    FOLLOWUP_PREFIX, MAX_BUTTON_CHARS, MAX_NUMBERS_PER_ROW, SHARED_ROW_MAX_CHARS, SuggestLayout,
-    folded_list_html, pick_layout, suggestion_rows_rich_html,
+    BUTTON_LABEL_MAX_UNITS, FOLLOWUP_PREFIX, MAX_NUMBERS_PER_ROW, SHARED_ROW_MAX_CHARS,
+    SuggestLayout, enforce_button_fit, folded_list_html, pick_layout, suggestion_rows_rich_html,
 };
 
 fn opts(v: &[&str]) -> Vec<String> {
@@ -45,15 +45,32 @@ fn test_one_long_label_kills_the_shared_row() {
 
 #[test]
 fn test_the_button_width_boundary_is_exclusive() {
-    // Measured on a real client: MAX_BUTTON_CHARS fits one line, past it wraps.
+    // Recalibrated 2026-09-04 (#79 owner smokes): BUTTON_LABEL_MAX_UNITS
+    // rides a full-width button, past it the set folds — a clipped label
+    // is a correctness bug, an over-eager fold is only cosmetic.
     assert_eq!(
-        pick_layout(&["x".repeat(MAX_BUTTON_CHARS)]),
+        pick_layout(&["x".repeat(BUTTON_LABEL_MAX_UNITS)]),
         SuggestLayout::Column
     );
     assert_eq!(
-        pick_layout(&["Ship it".to_string(), "x".repeat(MAX_BUTTON_CHARS + 1)]),
+        pick_layout(&[
+            "Ship it".to_string(),
+            "x".repeat(BUTTON_LABEL_MAX_UNITS + 1)
+        ]),
         SuggestLayout::NumberedProse
     );
+}
+
+#[test]
+fn test_shared_row_respects_the_total_budget() {
+    // #79: shared rows cut at 36 total; only a 24 slim-tail pair held, so
+    // the total budget is 20. Two 12-char labels fit neither the budget
+    // nor one row — they drop to Column (one full-width button per row).
+    let o = vec![
+        "x".repeat(SHARED_ROW_MAX_CHARS),
+        "y".repeat(SHARED_ROW_MAX_CHARS),
+    ];
+    assert_eq!(pick_layout(&o), SuggestLayout::Column);
 }
 
 #[test]
@@ -112,4 +129,50 @@ fn test_callback_data_stays_within_the_cap_at_the_worst_index() {
         "#1204: {} bytes exceeds the callback_data cap",
         widest.len()
     );
+}
+
+#[test]
+fn test_enforce_button_fit_ships_fitting_bodies_byte_identical() {
+    let body = "<p>Готово</p>\n<tg-button-row>\
+                <tg-button type=\"callback_data\" data=\"followup:tok:0\" \
+                style=\"primary\">Полёт</tg-button></tg-button-row>";
+    assert_eq!(enforce_button_fit(body), body);
+}
+
+#[test]
+fn test_enforce_button_fit_folds_oversized_labels_keeping_routing() {
+    // 30-char Cyrillic label: past BUTTON_LABEL_MAX_UNITS=20 -> the set
+    // folds; the button keeps its attrs (routing untouched) but shows its
+    // index, and the original label moves into the <ol>.
+    let long = "Проверка ширины кнопки хххххххххЖЖЖ";
+    let body = format!(
+        "<tg-button-row><tg-button type=\"url\" data=\"https://x/{long}\">{long}\
+         </tg-button></tg-button-row>"
+    );
+    let out = enforce_button_fit(&body);
+    assert!(
+        out.contains("<tg-button type=\"url\" data=\"https://x/"),
+        "{out}"
+    );
+    assert!(out.contains(">1</tg-button>"), "{out}");
+    assert!(out.contains("<li>"), "{out}");
+    assert!(out.contains(long), "{out}");
+    // Idempotent: the folded body passes through unchanged.
+    assert_eq!(enforce_button_fit(&out), out);
+}
+
+#[test]
+fn test_enforce_button_fit_folds_rows_over_the_total_budget() {
+    // Two 12-char labels = 24 total: past SHARED_ROW_TOTAL_UNITS=20 (#79).
+    let body = "<tg-button-row>\
+                <tg-button type=\"callback_data\" data=\"followup:t:0\">Полёт норм!!\
+                </tg-button><tg-button type=\"callback_data\" data=\"followup:t:1\">\
+                Всё чётко!!!</tg-button></tg-button-row>";
+    let out = enforce_button_fit(body);
+    assert!(
+        out.contains(">1</tg-button>") && out.contains(">2</tg-button>"),
+        "{out}"
+    );
+    assert!(out.contains("<li>Полёт норм!!</li>"), "{out}");
+    assert!(out.contains("<li>Всё чётко!!!</li>"), "{out}");
 }

--- a/src/tui/onboarding/fetch.rs
+++ b/src/tui/onboarding/fetch.rs
@@ -381,6 +381,12 @@ pub async fn fetch_provider_models(
             .and_then(|c| c.providers.xiaomi.clone())
             .map(|p| p.models)
             .unwrap_or_default();
+        if api_models.is_empty() {
+            // Live fetch failed (401 / offline) — fall back to the binary
+            // baseline so the picker is never empty (#1419). Mirrors the
+            // MiniMax fallback above.
+            return merge_minimax_baseline(xiaomi_baseline_models(), user_models);
+        }
         return merge_minimax_baseline(api_models, user_models);
     }
 
@@ -759,6 +765,22 @@ fn minimax_baseline_models() -> Vec<String> {
         "MiniMax-M2.1".to_string(),
         "MiniMax-M2.1-highspeed".to_string(),
         "MiniMax-M2".to_string(),
+    ]
+}
+
+/// Binary's known Xiaomi MiMo models, used as fallback when the live
+/// /models fetch fails — the endpoint is keyless but geo/credential
+/// sensitive (401 on some CI runners, #1419). Newest first so the
+/// picker highlights the current model. Live fetch is the primary
+/// source — this only covers offline / unreachable-API scenarios.
+fn xiaomi_baseline_models() -> Vec<String> {
+    vec![
+        "mimo-v2.5-pro".to_string(),
+        "mimo-v2-pro".to_string(),
+        "mimo-v2-omni".to_string(),
+        "mimo-v2-flash".to_string(),
+        "mimo-v2-pro-free".to_string(),
+        "mimo-v2-omni-free".to_string(),
     ]
 }
 


### PR DESCRIPTION
## What

Table-bearing rich answers could not carry the suggestion controls: the merge edit rode the rich **HTML** plane, whose server-side render flattens markdown tables. This PR adds the **markdown plane** for merged hosts: the merged payload is stored raw (new nullable `host_markdown` column) and every later edit of the bubble — merge, tap redraw, stale strip — rides `editMessageText` + `rich_message.markdown`, whose server-side render keeps tables intact.

Two commits, ported from leshchenko1979/opencrabs#79 (piece 4, owner-smoke-verified on our fork — see evidence below):

1. **Markdown-plane host persistence** — `host_markdown` column (nullable; NULL = html-plane host, all pre-existing rows), carried through the followup repo + hydration. Slotted after `20260902000001_add_pending_followups` in `MIGRATION_SQL` (derived `MIGRATION_COUNT` needs no manual bump).
2. **Markdown-plane merge + pick routing** — the two `contains_table` capture gates are removed: every rich answer is a merge candidate. Markdown-plane hosts build a markdown payload (answer + numbered-prose fold + the existing rich button-row dialect + trailer) and `place_once` routes the merge through `edit_rich_markdown`. Pick redraws gain a `RichMarkdownHost` variant (`mark_picked_button` is a byte-level `<tg-button` scan, plane-agnostic). Html-plane and classic hosts are byte-identical to before.

## Port notes

- Upstream's #55 glue tier (`glued` flag + `edit_message_reply_markup`) is **retired on the rich path** by this port — the fork removed it once every answer became merge-safe. `MergeBubble.body` becomes non-optional (the html plane never had a reason to skip merging; tables ride markdown now). Classic chunked-delivery capture sites are updated accordingly.
- Fold-threshold constants (Cyrillic-safe ladder) are NOT part of this port — upstream keeps its current `SuggestLayout` gating; the ladder recalibration is a separate fork change (leshchenko1979/opencrabs#79 ladder commits), available on request.

## Evidence (fork, owner eye-confirmed)

- Table answer + merged controls render with the table intact (C1 probe: table real + buttons styled).
- Full-chain owner smoke: diagram + buttons merged onto one rich-md host, tap redraw kept both, zero tag soup, paragraphs flush (fork issues leshchenko1979/opencrabs#96, leshchenko1979/opencrabs#98, leshchenko1979/opencrabs#102, leshchenko1979/opencrabs#108 — all closed with receipts).
- Live API probes for the multipart edit path this build sits on: see PR #1414.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/79
