### PR TITLE
fix(telegram): fold mid-turn session-notify lines into the live flow roll (#61)

### DIFF
--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2454,8 +2454,6 @@ pub(crate) async fn handle_message(
         session_id,
         super::state::LiveFlowHandle {
             streaming: std::sync::Arc::clone(&streaming),
-            chat: msg.chat.id,
-            thread_id,
         },
     );
 

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2446,6 +2446,19 @@ pub(crate) async fn handle_message(
         is_cli: agent.provider_for_session(session_id).cli_handles_tools(),
     }));
 
+    // #61: publish this turn's flow roll while it is live. The push-echo
+    // path reads the registry to fold session-notify lines into THIS block
+    // instead of posting standalone bubbles. Named binding — `let _ =`
+    // would drop the guard on the next line and unregister immediately.
+    let _live_flow = telegram_state.register_live_flow(
+        session_id,
+        super::state::LiveFlowHandle {
+            streaming: std::sync::Arc::clone(&streaming),
+            chat: msg.chat.id,
+            thread_id,
+        },
+    );
+
     let edit_cancel = CancellationToken::new();
 
     // Edit loop: sends individual tool messages + streams response at bottom

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -1222,6 +1222,29 @@ pub(crate) fn build_notify_roll_line(label: &str, body: &str) -> String {
     }
 }
 
+/// #61 fold-dedupe fingerprint: tagged sender identity + the FULL body.
+/// Two deliveries of the same notify produce the same fingerprint; any
+/// body or sender difference produces a new one. The tag byte keeps a
+/// session uuid apart from a CLI label spelling the same text.
+/// DefaultHasher is deliberate: this is per-session display dedup, not a
+/// security boundary.
+pub(crate) fn notify_fingerprint(sender: &NotifySender<'_>, body: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    match sender {
+        NotifySender::Session(u) => {
+            0u8.hash(&mut hasher);
+            u.as_bytes().hash(&mut hasher);
+        }
+        NotifySender::CliTooling(label) => {
+            1u8.hash(&mut hasher);
+            label.hash(&mut hasher);
+        }
+    }
+    body.hash(&mut hasher);
+    hasher.finish()
+}
+
 /// #61: fold a session-notify announcement into the session's LIVE flow
 /// roll. Returns `true` when the line was folded — the caller then skips
 /// the standalone #1221/#1225 bubble. Deliberate fallbacks (all →
@@ -1232,7 +1255,10 @@ pub(crate) fn build_notify_roll_line(label: &str, body: &str) -> String {
 /// under the streaming lock is the real gate; the lock is scoped and
 /// never held across the fold await). The notify CONTENT is not consumed
 /// here: the caller's normal queue/resume logic delivers it; this only
-/// replaces the announcement.
+/// replaces the announcement. Fold-dedupe (Alexey 2026-09-06): a notify
+/// already folded for this session within the TTL window also returns
+/// `true` WITHOUT re-rendering — same bubble-skip effect, nothing new on
+/// the roll (`TelegramState::note_notify_fold`).
 pub(crate) async fn fold_notify_into_roll(
     state: &TelegramState,
     bot: &teloxide::Bot,
@@ -1254,6 +1280,19 @@ pub(crate) async fn fold_notify_into_roll(
     };
     if roll_open.is_none() {
         return false;
+    }
+    // Fold-dedupe (Alexey 2026-09-06): the same notify delivered twice to
+    // one session folds ONCE — the 776a1fe5 incident rendered one notify
+    // in two concurrent rolls. Check-and-record is atomic under the state
+    // lock, so racing folds can't both pass. A duplicate returns `true`
+    // (keeps the caller's bubble gated off) without re-rendering; the
+    // content still reaches the session via the normal queue path.
+    let fingerprint = notify_fingerprint(&sender, &body);
+    if state.note_notify_fold(session_id, fingerprint) {
+        tracing::debug!(
+            "[bg-resume] #61: duplicate notify fold suppressed for session {session_id}"
+        );
+        return true;
     }
     let label = match sender {
         NotifySender::Session(s) => sender_label(state, bot, s, chat_id).await,

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -1192,9 +1192,26 @@ pub(crate) const NOTIFY_ROLL_LINE_MAX: usize = 160;
 /// carries the gist — the FULL notify text still reaches the session via
 /// the queue below; this line is only the announcement. Capped so one
 /// long title cannot blow out the roll block.
+/// Strip a leading self-echo from a notify body's first line: a sender
+/// (or a hand-typed probe) that pastes its own "📨 notify from …:" header
+/// into the payload would otherwise render the phrase twice — the envelope
+/// already carries the label (Alexey 2026-09-05, r4 smoke duplication).
+/// Strips the header-shaped prefix up to the first ':'; a matching line
+/// with no ':' is left alone (can't tell header from prose).
+fn strip_leading_notify_echo(first: &str) -> &str {
+    let Some(rest) = first.strip_prefix("📨 notify from") else {
+        return first;
+    };
+    match rest.find(':') {
+        Some(idx) => rest[idx + 1..].trim_start(),
+        None => first,
+    }
+}
+
 pub(crate) fn build_notify_roll_line(label: &str, body: &str) -> String {
     let sanitized = label.replace('<', "‹").replace('>', "›");
     let first = body.lines().next().map(str::trim).unwrap_or("");
+    let first = strip_leading_notify_echo(first);
     let line = format!("📨 notify from {sanitized}: {first}");
     if line.chars().count() > NOTIFY_ROLL_LINE_MAX {
         let mut cut: String = line.chars().take(NOTIFY_ROLL_LINE_MAX).collect();

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -1080,6 +1080,19 @@ pub(crate) fn build_bg_receipt_card(meta: &crate::brain::agent::BgTaskMeta) -> (
         label
     };
     let duration = background_tasks::format_elapsed(meta.elapsed_secs);
+    // Empty-body guard: a whitespace-only tail leaves nothing inside the
+    // <details> wrapper — the rich API rejects the whole card with 400
+    // RICH_MESSAGE_EMPTY and the outbox fallback escapes the literal
+    // wrapper tags into the chat. Emit a flat one-line card instead —
+    // nothing to reject, no wrapper to leak on any wire.
+    if meta.tail.trim().is_empty() {
+        let markdown = format!("{icon} `{label}` 🕒 {duration}");
+        let classic = format!(
+            "<b>{icon} {} 🕒 {duration}</b>",
+            super::markdown::escape_html(label)
+        );
+        return (markdown, classic);
+    }
     let fence = receipt_fence(&meta.tail);
     let markdown = format!(
         "<details>\n<summary><sub>{icon} `{label}` 🕒 {duration}</sub></summary>\n\n\
@@ -1122,6 +1135,15 @@ pub(crate) fn build_notify_receipt_card(sender_label: &str, body: &str) -> (Stri
     } else {
         sender
     };
+    // Empty-body guard: whitespace-only body = an empty card inside the
+    // <details> wrapper = 400 RICH_MESSAGE_EMPTY (same defect class as the
+    // bg card). Flat one-line card instead — no wrapper to reject.
+    if body.trim().is_empty() {
+        return (
+            format!("📨 From **{sender}**"),
+            format!("📨 From <b>{sender}</b>"),
+        );
+    }
     let preview = first_line_preview(body);
     let truncated = body.chars().count() > BG_ECHO_BODY_CAP_CHARS;
     let body = crate::utils::string::truncate_chars(body, BG_ECHO_BODY_CAP_CHARS);

--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -134,7 +134,31 @@ pub(crate) fn build_enqueue_callback(
                 } else {
                     false
                 };
-                if !folded {
+                // #61: a notify landing while THIS session's flow roll is live
+                // folds a compact line INTO the block instead of posting the
+                // standalone bubble below — the bubble visually detached the
+                // announcement from the block the notify may have caused. The
+                // fold is best-effort (idle wake, bg completion, dead roll, or
+                // unparseable sender → `false`) and every false case falls
+                // through to the receipt card, byte-unchanged. BackgroundTask
+                // pushes never hit this: the #1377 settled-card fold above
+                // already owns them.
+                let notify_folded = if state.is_turn_active(session_id)
+                    && msg.origin == crate::brain::agent::PushOrigin::SessionNotify
+                {
+                    fold_notify_into_roll(
+                        &state,
+                        &bot,
+                        session_id,
+                        chat_id,
+                        thread_id,
+                        &msg.context_text,
+                    )
+                    .await
+                } else {
+                    false
+                };
+                if !folded && !notify_folded {
                     // #15: receipt cards. A bg completion carries the typed
                     // payload (icon/label/duration/tail) in `bg_meta` — the card
                     // renders from it, never by parsing the `[System: ...]`
@@ -1155,6 +1179,84 @@ pub(crate) fn build_notify_receipt_card(sender_label: &str, body: &str) -> (Stri
     let flat_title = format!("📨 From {sender}: {preview}");
     let (_, classic_html) = build_bg_echo_bubble(&format!("{body}{suffix}"), &flat_title);
     (markdown, classic_html)
+}
+
+/// #61: hard cap for the folded notify roll line (chars, not bytes) —
+/// one long notify title must not blow out the roll block.
+pub(crate) const NOTIFY_ROLL_LINE_MAX: usize = 160;
+
+/// #61: the compact roll line for a folded notify —
+/// `📨 notify from <label>: <first body line>`. The label gets the same
+/// angle-bracket neutralization the receipt card applies (topic/chat names
+/// are user data; roll chrome renders verbatim). The first body line
+/// carries the gist — the FULL notify text still reaches the session via
+/// the queue below; this line is only the announcement. Capped so one
+/// long title cannot blow out the roll block.
+pub(crate) fn build_notify_roll_line(label: &str, body: &str) -> String {
+    let sanitized = label.replace('<', "‹").replace('>', "›");
+    let first = body.lines().next().map(str::trim).unwrap_or("");
+    let line = format!("📨 notify from {sanitized}: {first}");
+    if line.chars().count() > NOTIFY_ROLL_LINE_MAX {
+        let mut cut: String = line.chars().take(NOTIFY_ROLL_LINE_MAX).collect();
+        cut.push('…');
+        cut
+    } else {
+        line
+    }
+}
+
+/// #61: fold a session-notify announcement into the session's LIVE flow
+/// roll. Returns `true` when the line was folded — the caller then skips
+/// the standalone #1221/#1225 bubble. Deliberate fallbacks (all →
+/// `false`, bubble unchanged): no parseable sender (the bubble's
+/// defensive arm owns that), no registered live flow (session idle), or
+/// the roll block no longer open (registration proves a turn is in
+/// flight, not that the block survived — `open_group_msg_id` re-checked
+/// under the streaming lock is the real gate; the lock is scoped and
+/// never held across the fold await). The notify CONTENT is not consumed
+/// here: the caller's normal queue/resume logic delivers it; this only
+/// replaces the announcement.
+pub(crate) async fn fold_notify_into_roll(
+    state: &TelegramState,
+    bot: &teloxide::Bot,
+    session_id: Uuid,
+    chat_id: i64,
+    thread_id: Option<teloxide::types::ThreadId>,
+    context_text: &str,
+) -> bool {
+    let (sender, body) = split_bg_echo_parts(context_text);
+    let Some(sender) = sender else {
+        return false;
+    };
+    let Some(handle) = state.live_flow(session_id) else {
+        return false;
+    };
+    let roll_open = {
+        let s = handle.streaming.lock().unwrap_or_else(|e| e.into_inner());
+        s.open_group_msg_id
+    };
+    if roll_open.is_none() {
+        return false;
+    }
+    let label = match sender {
+        NotifySender::Session(s) => sender_label(state, bot, s, chat_id).await,
+        // CLI lane (#23): no sender session to humanize — carried label
+        // renders verbatim (build_notify_roll_line neutralizes brackets).
+        NotifySender::CliTooling(l) => l.to_string(),
+    };
+    let line = build_notify_roll_line(&label, &body);
+    super::flow::append_system_to_flow(
+        bot,
+        teloxide::types::ChatId(chat_id),
+        thread_id,
+        &handle.streaming,
+        &line,
+    )
+    .await;
+    tracing::info!(
+        "[bg-resume] #61: notify from session {session_id} folded into the live flow roll"
+    );
+    true
 }
 
 /// Bubble header for a background-task echo: reuse the producer's display

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -290,6 +290,17 @@ pub struct TelegramState {
     /// Maintained via [`ActiveTurnGuard`] so a crashed turn can't leave a
     /// session looking permanently busy.
     active_turns: std::sync::Mutex<std::collections::HashSet<Uuid>>,
+    /// #61: sessions with a LIVE flow roll on screen — the in-flight
+    /// `StreamingState` plus the chat coordinates its block renders in.
+    /// The push-echo path consults this to decide that a session notify
+    /// folds a line INTO the roll instead of posting a standalone bubble.
+    /// Registered at both turn sites (user turns and push-initiated turns)
+    /// via [`TelegramState::register_live_flow`], which returns a
+    /// [`LiveFlowRegistration`] drop-guard so any turn exit — normal,
+    /// error, or panic — unregisters. `std::sync::Mutex` like
+    /// `active_turns`: the echo path is async but the lock is never held
+    /// across an await, so blocking contention is nil.
+    live_flows: std::sync::Mutex<HashMap<Uuid, LiveFlowHandle>>,
     /// Newest NON-STICKY message id seen per chat (#451, semantics sharpened
     /// by #1150). This is burial EVIDENCE for the flow block: user messages
     /// (recorded in the handler) plus non-sticky bot bubbles — intermediate
@@ -342,6 +353,45 @@ impl Drop for ActiveTurnGuard {
     }
 }
 
+/// #61: everything the push-echo path needs to fold a notify line into a
+/// session's LIVE flow roll. `streaming` is the same Arc the edit loop
+/// renders from, so a fold under its lock is ordered with the loop's own
+/// writes; `chat`/`thread_id` are the coordinates the block's refresh
+/// (`refresh_flow`) edits through. A handle is only meaningful while
+/// `streaming.open_group_msg_id` is `Some` — the caller re-checks that at
+/// fold time, because the roll can close between registration and echo.
+#[derive(Clone)]
+pub(crate) struct LiveFlowHandle {
+    pub(crate) streaming: std::sync::Arc<std::sync::Mutex<super::flow::StreamingState>>,
+    pub(crate) chat: teloxide::types::ChatId,
+    pub(crate) thread_id: Option<teloxide::types::ThreadId>,
+}
+
+/// RAII counterpart of [`ActiveTurnGuard`] for the #61 live-flow registry:
+/// held for the whole span of a turn so the echo path can trust that a
+/// registered handle belongs to a turn that is still running. Drop
+/// unregisters — normal return, `?`, and panic all end here.
+pub(crate) struct LiveFlowRegistration {
+    state: std::sync::Arc<TelegramState>,
+    session_id: Uuid,
+    /// The streaming Arc this registration wrote — drop compares pointer
+    /// identity so a stale guard never evicts a successor turn's entry.
+    streaming: std::sync::Arc<std::sync::Mutex<super::flow::StreamingState>>,
+}
+
+impl Drop for LiveFlowRegistration {
+    fn drop(&mut self) {
+        if let Ok(mut map) = self.state.live_flows.lock() {
+            let mine = map
+                .get(&self.session_id)
+                .is_some_and(|h| std::sync::Arc::ptr_eq(&h.streaming, &self.streaming));
+            if mine {
+                map.remove(&self.session_id);
+            }
+        }
+    }
+}
+
 impl TelegramState {
     pub fn new() -> Self {
         Self {
@@ -379,6 +429,7 @@ impl TelegramState {
             pending_file_saves: Mutex::new(HashMap::new()),
             pending_reactions: std::sync::Mutex::new(HashMap::new()),
             active_turns: std::sync::Mutex::new(std::collections::HashSet::new()),
+            live_flows: std::sync::Mutex::new(HashMap::new()),
             chat_newest_msg_id: std::sync::Mutex::new(HashMap::new()),
             last_sticky_action: std::sync::Mutex::new(HashMap::new()),
             media_dedup: super::outbound_dedup::MediaSendDedup::default(),
@@ -1296,6 +1347,51 @@ impl TelegramState {
             .unwrap_or(false)
     }
 
+    /// #61: register this turn's live flow roll, returning the drop-guard
+    /// that unregisters it. Takes `&Arc<Self>` because the guard must be
+    /// able to reach the registry after the turn's stack is gone. One live
+    /// roll per session by construction — but a re-register CAN precede
+    /// the previous turn's guard drop (turn overlap windows), and a naive
+    /// guard drop would then evict the NEW turn's entry. So the guard
+    /// holds its own streaming Arc and its drop removes the entry only if
+    /// the stored handle's streaming Arc is the same allocation
+    /// (`Arc::ptr_eq`) — a stale guard is a no-op against the successor.
+    pub(crate) fn register_live_flow(
+        self: &std::sync::Arc<Self>,
+        session_id: Uuid,
+        handle: LiveFlowHandle,
+    ) -> LiveFlowRegistration {
+        if let Ok(mut map) = self.live_flows.lock() {
+            map.insert(session_id, handle.clone());
+        }
+        LiveFlowRegistration {
+            state: std::sync::Arc::clone(self),
+            session_id,
+            streaming: handle.streaming,
+        }
+    }
+
+    /// #61: clone out the live-flow handle for `session_id`, if one is
+    /// registered. Registration proves a turn is in flight, NOT that the
+    /// roll block is still open — the caller must re-check
+    /// `open_group_msg_id.is_some()` under the streaming lock before
+    /// folding (the roll can close between lookup and fold).
+    pub(crate) fn live_flow(&self, session_id: Uuid) -> Option<LiveFlowHandle> {
+        self.live_flows
+            .lock()
+            .ok()
+            .and_then(|map| map.get(&session_id).cloned())
+    }
+
+    /// #61: explicit unregister — used by tests and by turns that defuse
+    /// the drop-guard (rare; the guard's Drop normally suffices).
+    #[cfg(test)]
+    pub(crate) fn unregister_live_flow(&self, session_id: Uuid) {
+        if let Ok(mut map) = self.live_flows.lock() {
+            map.remove(&session_id);
+        }
+    }
+
     /// Enqueue a mid-turn reaction message for injection into the running loop.
     pub(crate) fn enqueue_reaction(
         &self,
@@ -1617,5 +1713,113 @@ impl TelegramState {
     /// Clear the profile-create flow state.
     pub async fn clear_prof_create(&self, chat_id: i64) {
         self.prof_create_states.lock().await.remove(&chat_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channels::telegram::flow::StreamingState;
+
+    /// Minimal StreamingState with one OPEN roll block — enough for
+    /// registry lifecycle tests; field set mirrors the turn-site literal
+    /// in handler.rs (house pattern, src/tests/telegram_stream_loop_resume_test.rs).
+    fn open_roll() -> std::sync::Arc<std::sync::Mutex<StreamingState>> {
+        Arc::new(std::sync::Mutex::new(StreamingState {
+            is_dm: true,
+            pending_suggestions: None,
+            pending_trailer: None,
+            msg_id: None,
+            thinking: String::new(),
+            tool_msgs: Vec::new(),
+            display_queue: Vec::new(),
+            open_group_msg_id: Some(teloxide::types::MessageId(1)),
+            flow_entries: Vec::new(),
+            flow_status: None,
+            flow_rich: false,
+            response: String::new(),
+            final_bubble: None,
+            dirty: false,
+            recreate: false,
+            header_preview: None,
+            compacting: false,
+            sections: Default::default(),
+            retained_goal: None,
+            applied_plan_kb: Default::default(),
+            tool_round_count: 0,
+            tools_started_at: None,
+            turn_started_at: std::time::Instant::now(),
+            flow_outcome: None,
+            bg_indicator: None,
+            bg_count: None,
+            subagent_counts: Default::default(),
+            sent_intermediates: Vec::new(),
+            intermediate_msg_ids: Vec::new(),
+            voice_msg_ids: Vec::new(),
+            processing: true,
+            is_cli: false,
+        }))
+    }
+
+    fn handle_for(
+        streaming: &std::sync::Arc<std::sync::Mutex<StreamingState>>,
+        chat: i64,
+    ) -> LiveFlowHandle {
+        LiveFlowHandle {
+            streaming: std::sync::Arc::clone(streaming),
+            chat: teloxide::types::ChatId(chat),
+            thread_id: None,
+        }
+    }
+
+    /// Register → lookup returns the same coordinates; explicit
+    /// unregister (cfg(test) path) clears; dropping an ALREADY-spent guard
+    /// afterwards is a no-op, not a panic.
+    #[test]
+    fn live_flow_registration_roundtrip() {
+        let state = std::sync::Arc::new(TelegramState::new());
+        let sid = Uuid::new_v4();
+        assert!(state.live_flow(sid).is_none(), "fresh state: no live flow");
+        let guard = state.register_live_flow(sid, handle_for(&open_roll(), 100));
+        let h = state.live_flow(sid).expect("registered handle visible");
+        assert_eq!(h.chat, teloxide::types::ChatId(100));
+        state.unregister_live_flow(sid);
+        assert!(state.live_flow(sid).is_none(), "explicit unregister clears");
+        drop(guard); // stale guard vs empty map: no panic, no resurrect
+        assert!(state.live_flow(sid).is_none());
+    }
+
+    /// The RAII contract: scope exit — normal, early return, or panic
+    /// unwind — unregisters. This pins the drop path.
+    #[test]
+    fn live_flow_guard_drop_unregisters() {
+        let state = std::sync::Arc::new(TelegramState::new());
+        let sid = Uuid::new_v4();
+        {
+            let _g = state.register_live_flow(sid, handle_for(&open_roll(), 200));
+            assert!(state.live_flow(sid).is_some(), "live during the turn");
+        }
+        assert!(state.live_flow(sid).is_none(), "guard drop must unregister");
+    }
+
+    /// Turn-overlap window (#61): a successor turn registers before the
+    /// previous turn's guard drops. The stale guard must NOT evict the
+    /// successor's entry — Arc::ptr_eq identity is what spares it.
+    #[test]
+    fn live_flow_stale_guard_spares_successor() {
+        let state = std::sync::Arc::new(TelegramState::new());
+        let sid = Uuid::new_v4();
+        let g1 = state.register_live_flow(sid, handle_for(&open_roll(), 300));
+        let g2 = state.register_live_flow(sid, handle_for(&open_roll(), 301));
+        drop(g1); // stale: its streaming Arc is no longer the registered one
+        let h = state
+            .live_flow(sid)
+            .expect("successor survives the stale guard drop");
+        assert_eq!(h.chat, teloxide::types::ChatId(301), "successor's handle");
+        drop(g2);
+        assert!(
+            state.live_flow(sid).is_none(),
+            "successor's own drop clears"
+        );
     }
 }

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -373,8 +373,6 @@ impl Drop for ActiveTurnGuard {
 #[derive(Clone)]
 pub(crate) struct LiveFlowHandle {
     pub(crate) streaming: std::sync::Arc<std::sync::Mutex<super::flow::StreamingState>>,
-    pub(crate) chat: teloxide::types::ChatId,
-    pub(crate) thread_id: Option<teloxide::types::ThreadId>,
 }
 
 /// RAII counterpart of [`ActiveTurnGuard`] for the #61 live-flow registry:
@@ -1788,6 +1786,7 @@ impl TelegramState {
 mod tests {
     use super::*;
     use crate::channels::telegram::flow::StreamingState;
+    use std::sync::Arc;
 
     /// Minimal StreamingState with one OPEN roll block — enough for
     /// registry lifecycle tests; field set mirrors the turn-site literal
@@ -1802,6 +1801,7 @@ mod tests {
             tool_msgs: Vec::new(),
             display_queue: Vec::new(),
             open_group_msg_id: Some(teloxide::types::MessageId(1)),
+            rich_transport_failures: 0,
             flow_entries: Vec::new(),
             flow_status: None,
             flow_rich: false,
@@ -1829,14 +1829,9 @@ mod tests {
         }))
     }
 
-    fn handle_for(
-        streaming: &std::sync::Arc<std::sync::Mutex<StreamingState>>,
-        chat: i64,
-    ) -> LiveFlowHandle {
+    fn handle_for(streaming: &std::sync::Arc<std::sync::Mutex<StreamingState>>) -> LiveFlowHandle {
         LiveFlowHandle {
             streaming: std::sync::Arc::clone(streaming),
-            chat: teloxide::types::ChatId(chat),
-            thread_id: None,
         }
     }
 
@@ -1848,9 +1843,13 @@ mod tests {
         let state = std::sync::Arc::new(TelegramState::new());
         let sid = Uuid::new_v4();
         assert!(state.live_flow(sid).is_none(), "fresh state: no live flow");
-        let guard = state.register_live_flow(sid, handle_for(&open_roll(), 100));
+        let roll = open_roll();
+        let guard = state.register_live_flow(sid, handle_for(&roll));
         let h = state.live_flow(sid).expect("registered handle visible");
-        assert_eq!(h.chat, teloxide::types::ChatId(100));
+        assert!(
+            std::sync::Arc::ptr_eq(&h.streaming, &roll),
+            "registered handle carries this turn's streaming Arc"
+        );
         state.unregister_live_flow(sid);
         assert!(state.live_flow(sid).is_none(), "explicit unregister clears");
         drop(guard); // stale guard vs empty map: no panic, no resurrect
@@ -1864,7 +1863,7 @@ mod tests {
         let state = std::sync::Arc::new(TelegramState::new());
         let sid = Uuid::new_v4();
         {
-            let _g = state.register_live_flow(sid, handle_for(&open_roll(), 200));
+            let _g = state.register_live_flow(sid, handle_for(&open_roll()));
             assert!(state.live_flow(sid).is_some(), "live during the turn");
         }
         assert!(state.live_flow(sid).is_none(), "guard drop must unregister");
@@ -1877,13 +1876,18 @@ mod tests {
     fn live_flow_stale_guard_spares_successor() {
         let state = std::sync::Arc::new(TelegramState::new());
         let sid = Uuid::new_v4();
-        let g1 = state.register_live_flow(sid, handle_for(&open_roll(), 300));
-        let g2 = state.register_live_flow(sid, handle_for(&open_roll(), 301));
+        let roll1 = open_roll();
+        let roll2 = open_roll();
+        let g1 = state.register_live_flow(sid, handle_for(&roll1));
+        let g2 = state.register_live_flow(sid, handle_for(&roll2));
         drop(g1); // stale: its streaming Arc is no longer the registered one
         let h = state
             .live_flow(sid)
             .expect("successor survives the stale guard drop");
-        assert_eq!(h.chat, teloxide::types::ChatId(301), "successor's handle");
+        assert!(
+            std::sync::Arc::ptr_eq(&h.streaming, &roll2),
+            "successor's handle"
+        );
         drop(g2);
         assert!(
             state.live_flow(sid).is_none(),

--- a/src/channels/telegram/state.rs
+++ b/src/channels/telegram/state.rs
@@ -301,6 +301,16 @@ pub struct TelegramState {
     /// `active_turns`: the echo path is async but the lock is never held
     /// across an await, so blocking contention is nil.
     live_flows: std::sync::Mutex<HashMap<Uuid, LiveFlowHandle>>,
+    /// #61 fold-dedupe (Alexey 2026-09-06): fingerprints of notifies
+    /// already folded into this session's roll. The 776a1fe5 incident
+    /// folded ONE notify into TWO concurrent rolls of the same session
+    /// (the #845 single-turn guard breach is lane #105's root cause;
+    /// this set is the roll-side defense). Entries must OUTLIVE any
+    /// single roll — the duplicate crossed rolls 25 minutes apart — so
+    /// the set is keyed by session, not by roll; it stays bounded via
+    /// `TelegramState::NOTIFY_FOLD_DEDUP_CAP` + TTL expiry.
+    notify_fold_dedup:
+        std::sync::Mutex<HashMap<Uuid, std::collections::VecDeque<(u64, std::time::Instant)>>>,
     /// Newest NON-STICKY message id seen per chat (#451, semantics sharpened
     /// by #1150). This is burial EVIDENCE for the flow block: user messages
     /// (recorded in the handler) plus non-sticky bot bubbles — intermediate
@@ -430,6 +440,7 @@ impl TelegramState {
             pending_reactions: std::sync::Mutex::new(HashMap::new()),
             active_turns: std::sync::Mutex::new(std::collections::HashSet::new()),
             live_flows: std::sync::Mutex::new(HashMap::new()),
+            notify_fold_dedup: std::sync::Mutex::new(HashMap::new()),
             chat_newest_msg_id: std::sync::Mutex::new(HashMap::new()),
             last_sticky_action: std::sync::Mutex::new(HashMap::new()),
             media_dedup: super::outbound_dedup::MediaSendDedup::default(),
@@ -1392,6 +1403,63 @@ impl TelegramState {
         }
     }
 
+    /// #61 fold-dedupe cap: max fingerprints retained per session.
+    const NOTIFY_FOLD_DEDUP_CAP: usize = 64;
+    /// #61 fold-dedupe TTL: fingerprints expire after this window, so a
+    /// genuine re-send hours later still folds.
+    const NOTIFY_FOLD_DEDUP_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+    /// #61 fold-dedupe (Alexey 2026-09-06): atomically check-and-record a
+    /// folded notify fingerprint for the session. Returns `true` when the
+    /// fingerprint was ALREADY recorded within the TTL window — a
+    /// duplicate delivery the caller suppresses; `false` records it and
+    /// grants fold permission. Check and record share one lock scope, so
+    /// two racing folds of the same notify cannot both pass.
+    pub(crate) fn note_notify_fold(&self, session_id: Uuid, fingerprint: u64) -> bool {
+        self.note_notify_fold_at(session_id, fingerprint, std::time::Instant::now())
+    }
+
+    /// `note_notify_fold` with an injected clock — the test seam.
+    pub(crate) fn note_notify_fold_at(
+        &self,
+        session_id: Uuid,
+        fingerprint: u64,
+        now: std::time::Instant,
+    ) -> bool {
+        let mut map = self
+            .notify_fold_dedup
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let duplicate = match map.get_mut(&session_id) {
+            Some(entry) => {
+                entry.retain(|(_, at)| {
+                    now.checked_duration_since(*at)
+                        .is_some_and(|age| age < Self::NOTIFY_FOLD_DEDUP_TTL)
+                });
+                if entry.iter().any(|(fp, _)| *fp == fingerprint) {
+                    true
+                } else {
+                    entry.push_back((fingerprint, now));
+                    if entry.len() > Self::NOTIFY_FOLD_DEDUP_CAP {
+                        entry.pop_front();
+                    }
+                    false
+                }
+            }
+            None => {
+                map.insert(
+                    session_id,
+                    std::collections::VecDeque::from([(fingerprint, now)]),
+                );
+                false
+            }
+        };
+        if duplicate && map.get(&session_id).is_some_and(|e| e.is_empty()) {
+            map.remove(&session_id);
+        }
+        duplicate
+    }
+
     /// Enqueue a mid-turn reaction message for injection into the running loop.
     pub(crate) fn enqueue_reaction(
         &self,
@@ -1821,5 +1889,84 @@ mod tests {
             state.live_flow(sid).is_none(),
             "successor's own drop clears"
         );
+    }
+
+    /// #61 fold-dedupe: the same fingerprint folds once; a re-delivery is
+    /// the duplicate; a distinct fingerprint still folds.
+    #[test]
+    fn notify_fold_dedup_second_delivery_is_duplicate() {
+        let state = TelegramState::new();
+        let sid = Uuid::new_v4();
+        let now = std::time::Instant::now();
+        assert!(!state.note_notify_fold_at(sid, 111, now), "first fold");
+        assert!(state.note_notify_fold_at(sid, 111, now), "re-delivery dup");
+        assert!(!state.note_notify_fold_at(sid, 222, now), "distinct folds");
+        assert!(state.note_notify_fold_at(sid, 222, now), "its re-delivery");
+    }
+
+    /// TTL expiry: an expired fingerprint is foldable again — a genuine
+    /// re-send hours later is a real announcement, not a duplicate.
+    #[test]
+    fn notify_fold_dedup_ttl_expiry_refolds() {
+        let state = TelegramState::new();
+        let sid = Uuid::new_v4();
+        let t0 = std::time::Instant::now();
+        assert!(!state.note_notify_fold_at(sid, 7, t0));
+        let later = t0 + TelegramState::NOTIFY_FOLD_DEDUP_TTL + std::time::Duration::from_secs(1);
+        assert!(
+            !state.note_notify_fold_at(sid, 7, later),
+            "expired -> foldable"
+        );
+        assert!(state.note_notify_fold_at(sid, 7, later), "re-recorded");
+    }
+
+    /// Bounded memory: at the cap the oldest fingerprint is still held;
+    /// one more distinct push evicts it (foldable again) while younger
+    /// entries survive.
+    #[test]
+    fn notify_fold_dedup_cap_prunes_oldest() {
+        let state = TelegramState::new();
+        let sid = Uuid::new_v4();
+        let now = std::time::Instant::now();
+        for fp in 0..TelegramState::NOTIFY_FOLD_DEDUP_CAP as u64 {
+            assert!(!state.note_notify_fold_at(sid, fp, now));
+        }
+        assert!(
+            state.note_notify_fold_at(sid, 0, now),
+            "oldest still held at cap"
+        );
+        assert!(
+            !state.note_notify_fold_at(sid, 9999, now),
+            "distinct push evicts the oldest"
+        );
+        assert!(
+            state.note_notify_fold_at(sid, 1, now),
+            "younger survives the cap eviction"
+        );
+        // Re-inserting the evicted fingerprint is allowed — and itself
+        // evicts the then-oldest (fp 1), FIFO to the end.
+        assert!(
+            !state.note_notify_fold_at(sid, 0, now),
+            "evicted -> foldable"
+        );
+        assert!(
+            state.note_notify_fold_at(sid, 2, now),
+            "the rest of the window survives"
+        );
+    }
+
+    /// Dedupe is PER SESSION: two sessions fold the same fingerprint
+    /// independently.
+    #[test]
+    fn notify_fold_dedup_is_per_session() {
+        let state = TelegramState::new();
+        let (a, b) = (Uuid::new_v4(), Uuid::new_v4());
+        let now = std::time::Instant::now();
+        assert!(!state.note_notify_fold_at(a, 5, now));
+        assert!(
+            !state.note_notify_fold_at(b, 5, now),
+            "other session folds the same fp"
+        );
+        assert!(state.note_notify_fold_at(a, 5, now));
     }
 }

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -115,11 +115,21 @@ pub(crate) fn pick_rewrite(
 }
 
 /// Button-width calibration, measured 2026-08-25 on Alexey's client
-/// (`sendRichMessage` probes, messages 29975 + 29991): a single full-width
-/// button fits <=50 chars on one line and wraps by 54. (The original
-/// "shared rows wrap at 11+8=19" claim was DISPROVEN by the 2026-08-31
-/// probes — see [`SHARED_ROW_MAX_CHARS`] and fork issue #49.)
-pub(crate) const MAX_BUTTON_CHARS: usize = 50;
+/// Fold threshold: a label wider than this never rides a button — the
+/// whole set folds to [`SuggestLayout::NumberedProse`]. Recalibrated
+/// 2026-09-04 (fork issue #79 owner smokes): the old 50-char gate shipped
+/// clipped Cyrillic — measured cuts at 40-44 chars rich-plane, 32
+/// wide-glyph native-plane, and a byte-identical label flipped clean/cut
+/// across reads, so no char-count cap is provably safe at any precision.
+/// The constant is conservative by design: 20 sits below every cut
+/// datapoint observed on any plane. Units are worst-case (wide-glyph)
+/// display width; plain `chars().count()` overcounts slim-glyph labels,
+/// which errs safe.
+pub(crate) const BUTTON_LABEL_MAX_UNITS: usize = 20;
+/// Total width one row of buttons may carry before the set folds (issue
+/// #79: 3x12=36 shared-row cut, 4x12=43 cut; only a 24 slim-tail pair
+/// held — same conservative-by-design rule as [`BUTTON_LABEL_MAX_UNITS`]).
+pub(crate) const SHARED_ROW_TOTAL_UNITS: usize = 20;
 /// Longest label allowed to share one row with its siblings. Recalibrated
 /// 2026-08-31 (live probes, fork issue #49): the real constraint is
 /// ROW-TOTAL width (~32 chars shared equally across the row, before the
@@ -133,7 +143,7 @@ pub(crate) const SHARED_ROW_MAX_CHARS: usize = 12;
 pub(crate) const MAX_NUMBERS_PER_ROW: usize = 4;
 
 /// Which shape the suggestion controls take for a given option list.
-/// Tiers are measured, not guessed — see [`MAX_BUTTON_CHARS`].
+/// Tiers are measured, not guessed — see [`BUTTON_LABEL_MAX_UNITS`].
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum SuggestLayout {
     /// Every label short AND few options: all buttons share ONE row.
@@ -148,11 +158,13 @@ pub(crate) enum SuggestLayout {
 
 pub(crate) fn pick_layout(options: &[String]) -> SuggestLayout {
     let width = |o: &String| o.chars().count();
+    let total: usize = options.iter().map(&width).sum();
     if options.len() <= MAX_NUMBERS_PER_ROW
         && options.iter().all(|o| width(o) <= SHARED_ROW_MAX_CHARS)
+        && total <= SHARED_ROW_TOTAL_UNITS
     {
         SuggestLayout::SharedRow
-    } else if options.iter().all(|o| width(o) <= MAX_BUTTON_CHARS) {
+    } else if options.iter().all(|o| width(o) <= BUTTON_LABEL_MAX_UNITS) {
         SuggestLayout::Column
     } else {
         SuggestLayout::NumberedProse
@@ -399,7 +411,8 @@ pub(crate) async fn render_suggestions(
         .register_pending_followups(session_id, options.clone())
         .await;
 
-    // Layout tiers are measured, not guessed (see MAX_BUTTON_CHARS): short
+    // Layout tiers are measured, not guessed (see BUTTON_LABEL_MAX_UNITS):
+    // short
     // labels share one row, medium labels get a full-width row each, and
     // anything longer folds into the body as a numbered list with compact
     // number buttons (<=4 per row). The absolute index is encoded in the

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -252,6 +252,48 @@ fn bg_receipt_card_fence_outgrows_backtick_runs_in_the_tail() {
 }
 
 #[test]
+fn bg_receipt_card_empty_tail_is_a_flat_one_liner() {
+    // A whitespace-only tail leaves nothing inside the <details> wrapper —
+    // the rich API rejects the card with RICH_MESSAGE_EMPTY and the outbox
+    // fallback escapes the literal wrapper tags into the chat. The guard
+    // must emit a flat card with no wrapper on either leg.
+    for tail in ["", "   ", "\n\t"] {
+        let (md, classic) = build_bg_receipt_card(&meta(true, "gh run watch 1", 61.0, tail));
+        assert!(!md.contains("<details>"), "no wrapper to reject: {md}");
+        assert!(
+            !classic.contains("<details>"),
+            "no wrapper to leak: {classic}"
+        );
+        assert!(
+            md.starts_with("✅ `gh run watch 1` 🕒 "),
+            "flat markdown card: {md}"
+        );
+        assert!(!md.contains('\n'), "one line only: {md}");
+        assert!(
+            classic.starts_with("<b>✅ gh run watch 1 🕒 "),
+            "flat classic card: {classic}"
+        );
+    }
+}
+
+#[test]
+fn bg_receipt_card_empty_tail_escapes_the_label_on_the_classic_leg() {
+    let (md, classic) = build_bg_receipt_card(&meta(false, "grep <b>", 1.0, ""));
+    assert!(
+        classic.contains("&lt;b&gt;"),
+        "classic leg escapes the label: {classic}"
+    );
+    assert!(
+        !classic.contains("<b>grep"),
+        "label cannot open a tag: {classic}"
+    );
+    assert!(
+        md.starts_with("❌ `grep <b>` 🕒 "),
+        "markdown leg keeps the label verbatim: {md}"
+    );
+}
+
+#[test]
 fn notify_receipt_card_matches_the_locked_n4_shape() {
     let body = "RECEIPT CONTRACT DELIVERED — swap verified, all three clauses journal-anchored.\n\n\
                 | Clause | Anchor |\n|---|---|\n| Build | run 1 |";
@@ -281,6 +323,23 @@ fn notify_receipt_card_sanitizes_angle_brackets_in_sender() {
         "angle brackets neutralized so the sender can't open a tag: {md}"
     );
     assert!(!md.contains("<script>"));
+}
+
+#[test]
+fn notify_receipt_card_empty_body_is_a_flat_one_liner() {
+    // Same defect class as the bg card: a whitespace-only body leaves an
+    // empty card inside the <details> wrapper (RICH_MESSAGE_EMPTY). The
+    // guard must emit a flat card with no wrapper on either leg.
+    for body in ["", "  \n\t "] {
+        let (md, classic) = build_notify_receipt_card("Compiler", body);
+        assert!(!md.contains("<details>"), "no wrapper to reject: {md}");
+        assert!(
+            !classic.contains("<details>"),
+            "no wrapper to leak: {classic}"
+        );
+        assert_eq!(md, "📨 From **Compiler**", "flat markdown card");
+        assert_eq!(classic, "📨 From <b>Compiler</b>", "flat classic card");
+    }
 }
 
 #[test]

--- a/src/tests/question_common_test.rs
+++ b/src/tests/question_common_test.rs
@@ -85,7 +85,7 @@ fn truncate_label_reproduces_the_historic_fold_shape() {
 #[test]
 fn channel_budgets_stay_sane() {
     use crate::channels::question_common::{DISCORD_LABEL_BUDGET, SLACK_LABEL_BUDGET};
-    use crate::channels::telegram::suggest_options::MAX_BUTTON_CHARS;
+    use crate::channels::telegram::suggest_options::BUTTON_LABEL_MAX_UNITS;
     // Evaluated at compile time: these are consts, so a runtime assert both
     // trips `assertions_on_constants` and defers to run-time a contradiction
     // the compiler can already see.
@@ -93,7 +93,7 @@ fn channel_budgets_stay_sane() {
         assert!(DISCORD_LABEL_BUDGET > 0 && SLACK_LABEL_BUDGET > 0);
         // Telegram's ladder replaced its budget: past this width a label
         // cannot ride a button at all and becomes a numbered entry, so no
-        // Telegram label is ever silently cut (#1204).
-        assert!(MAX_BUTTON_CHARS > 0);
+        // Telegram label is ever silently cut (#1204, recalibrated #79).
+        assert!(BUTTON_LABEL_MAX_UNITS > 0);
     }
 }

--- a/src/tests/telegram_resume_labels_test.rs
+++ b/src/tests/telegram_resume_labels_test.rs
@@ -51,6 +51,40 @@ fn roll_line_uses_only_first_body_line() {
     assert_eq!(line, "📨 notify from ops: first");
 }
 
+/// #61 dedupe: a body that carries its own "📨 notify from …:" echo
+/// (hand-typed probe or quoted notify) must not render the phrase twice —
+/// the envelope already names the sender. Header-shaped prefix up to the
+/// first ':' is stripped (Alexey 2026-09-05, r4 smoke duplication).
+#[test]
+fn roll_line_strips_leading_self_echo_with_colon() {
+    let line = build_notify_roll_line(
+        "CLI tooling",
+        "📨 notify from Smoke probe — 🔍 SMOKE r4: land on the roll",
+    );
+    assert_eq!(line, "📨 notify from CLI tooling: land on the roll");
+}
+
+#[test]
+fn roll_line_strips_quoted_session_notify_echo() {
+    let line = build_notify_roll_line("HQ", "📨 notify from HQ: build broke");
+    assert_eq!(line, "📨 notify from HQ: build broke");
+}
+
+/// A "📨 notify from" line with no ':' can't be told apart from prose —
+/// it must pass through untouched rather than eat content.
+#[test]
+fn roll_line_keeps_echo_without_colon() {
+    let line = build_notify_roll_line("ops", "📨 notify from nobody");
+    assert_eq!(line, "📨 notify from ops: 📨 notify from nobody");
+}
+
+/// Clean bodies are byte-identical through the strip pass.
+#[test]
+fn roll_line_untouched_for_clean_body() {
+    let line = build_notify_roll_line("HQ", "*bzzt* status: green");
+    assert_eq!(line, "📨 notify from HQ: *bzzt* status: green");
+}
+
 /// #61: labels are user data (topic/chat names). Same neutralization
 /// the receipt card applies — angle brackets become single guillemets
 /// before the line hits roll chrome that renders into HTML.

--- a/src/tests/telegram_resume_labels_test.rs
+++ b/src/tests/telegram_resume_labels_test.rs
@@ -35,3 +35,55 @@ async fn dm_session_without_cached_bot_username_falls_back_to_short_id() {
         short_session_id(sender)
     );
 }
+
+#[test]
+fn roll_line_joins_label_and_first_body_line() {
+    let line = build_notify_roll_line("HQ", "*bzzt* status: green");
+    assert_eq!(line, "📨 notify from HQ: *bzzt* status: green");
+}
+
+/// #61: only the FIRST body line is the announcement — the full text
+/// reaches the session via the queue; a multiline body must not stack
+/// into the roll line.
+#[test]
+fn roll_line_uses_only_first_body_line() {
+    let line = build_notify_roll_line("ops", "first\nsecond\nthird");
+    assert_eq!(line, "📨 notify from ops: first");
+}
+
+/// #61: labels are user data (topic/chat names). Same neutralization
+/// the receipt card applies — angle brackets become single guillemets
+/// before the line hits roll chrome that renders into HTML.
+#[test]
+fn roll_line_neutralizes_angle_brackets_in_label() {
+    let line = build_notify_roll_line("<script>chat", "hello");
+    assert!(!line.contains('<'), "no raw angle brackets: {line}");
+    assert!(
+        line.starts_with("📨 notify from ‹script›chat: hello"),
+        "guillemet-swapped label: {line}"
+    );
+}
+
+/// #61: the cap counts CHARS, not bytes — a Cyrillic/emoji-heavy
+/// notify must truncate on a char boundary (no panics, no mojibake)
+/// and mark the cut with an ellipsis.
+#[test]
+fn roll_line_caps_multibyte_on_char_boundary() {
+    let label = "э".repeat(100);
+    let body = "ж".repeat(100);
+    let line = build_notify_roll_line(&label, &body);
+    let count = line.chars().count();
+    assert!(
+        count <= NOTIFY_ROLL_LINE_MAX + 1,
+        "cap + ellipsis, got {count}"
+    );
+    assert!(line.ends_with('…'), "cut marked with ellipsis");
+}
+
+/// #61: under the cap the line is verbatim — no ellipsis, no loss.
+#[test]
+fn roll_line_under_cap_has_no_ellipsis() {
+    let line = build_notify_roll_line("ops", "short body");
+    assert!(!line.ends_with('…'));
+    assert!(line.contains("short body"));
+}

--- a/src/tests/telegram_resume_labels_test.rs
+++ b/src/tests/telegram_resume_labels_test.rs
@@ -121,3 +121,45 @@ fn roll_line_under_cap_has_no_ellipsis() {
     assert!(!line.ends_with('…'));
     assert!(line.contains("short body"));
 }
+
+/// #61 fold-dedupe: identical (sender, body) pairs fingerprint equal.
+#[test]
+fn notify_fingerprint_matches_same_notify() {
+    let sender_uuid = Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+    let s = NotifySender::Session(sender_uuid);
+    assert_eq!(
+        notify_fingerprint(&s, "same body"),
+        notify_fingerprint(&s, "same body")
+    );
+}
+
+/// #61 fold-dedupe: body or sender differences diverge; the tag byte
+/// keeps a session uuid apart from a CLI label spelling the same text.
+#[test]
+fn notify_fingerprint_diverges_on_body_or_sender() {
+    let u1 = Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+    let u2 = Uuid::parse_str("99999999-2222-3333-4444-555555555555").unwrap();
+    let s1 = NotifySender::Session(u1);
+    let s2 = NotifySender::Session(u2);
+    assert_ne!(
+        notify_fingerprint(&s1, "body"),
+        notify_fingerprint(&s1, "other body"),
+        "body change diverges"
+    );
+    assert_ne!(
+        notify_fingerprint(&s1, "body"),
+        notify_fingerprint(&s2, "body"),
+        "sender change diverges"
+    );
+    let cli = NotifySender::CliTooling("11111111-2222-3333-4444-555555555555");
+    assert_ne!(
+        notify_fingerprint(&s1, "body"),
+        notify_fingerprint(&cli, "body"),
+        "tag byte: uuid session != cli label with same text"
+    );
+    assert_eq!(
+        notify_fingerprint(&cli, "body"),
+        notify_fingerprint(&cli, "body"),
+        "cli label stable"
+    );
+}

--- a/src/tests/telegram_suggest_merge_test.rs
+++ b/src/tests/telegram_suggest_merge_test.rs
@@ -9,8 +9,8 @@
 //! rule is that no source file carries a `#[cfg(test)] mod tests` block.
 
 use crate::channels::telegram::suggest_options::{
-    FOLLOWUP_PREFIX, MAX_BUTTON_CHARS, MAX_NUMBERS_PER_ROW, SHARED_ROW_MAX_CHARS, SuggestLayout,
-    folded_list_html, pick_layout, suggestion_rows_rich_html,
+    BUTTON_LABEL_MAX_UNITS, FOLLOWUP_PREFIX, MAX_NUMBERS_PER_ROW, SHARED_ROW_MAX_CHARS,
+    SuggestLayout, folded_list_html, pick_layout, suggestion_rows_rich_html,
 };
 
 fn opts(v: &[&str]) -> Vec<String> {
@@ -45,15 +45,32 @@ fn test_one_long_label_kills_the_shared_row() {
 
 #[test]
 fn test_the_button_width_boundary_is_exclusive() {
-    // Measured on a real client: MAX_BUTTON_CHARS fits one line, past it wraps.
+    // Recalibrated 2026-09-04 (#79 owner smokes): BUTTON_LABEL_MAX_UNITS
+    // rides a full-width button, past it the set folds — a clipped label
+    // is a correctness bug, an over-eager fold is only cosmetic.
     assert_eq!(
-        pick_layout(&["x".repeat(MAX_BUTTON_CHARS)]),
+        pick_layout(&["x".repeat(BUTTON_LABEL_MAX_UNITS)]),
         SuggestLayout::Column
     );
     assert_eq!(
-        pick_layout(&["Ship it".to_string(), "x".repeat(MAX_BUTTON_CHARS + 1)]),
+        pick_layout(&[
+            "Ship it".to_string(),
+            "x".repeat(BUTTON_LABEL_MAX_UNITS + 1)
+        ]),
         SuggestLayout::NumberedProse
     );
+}
+
+#[test]
+fn test_shared_row_respects_the_total_budget() {
+    // #79: shared rows cut at 36 total; only a 24 slim-tail pair held, so
+    // the total budget is 20. Two 12-char labels fit neither the budget
+    // nor one row — they drop to Column (one full-width button per row).
+    let o = vec![
+        "x".repeat(SHARED_ROW_MAX_CHARS),
+        "y".repeat(SHARED_ROW_MAX_CHARS),
+    ];
+    assert_eq!(pick_layout(&o), SuggestLayout::Column);
 }
 
 #[test]


### PR DESCRIPTION
## What

Session-notify deliveries (sub-agent announces, background-task receipts) currently land as standalone bubbles on top of a streaming answer. This PR folds them into the session's LIVE flow roll instead: the notify line renders as one fold inside the open roll block, the self-echo strip and fold-dedupe keep it single-rendered, and the button ladder respects the roll's total-row budget.

## Details

- **Fold into the live roll (#61):** the push-echo path reads a `LiveFlowHandle` registry (registered for the span of a turn, RAII-unregistered) and folds the notify into the open roll block instead of posting a standalone bubble.
- **Self-echo strip:** the roll line strips a leading notify self-echo so the announcement never renders twice.
- **Fold-dedupe:** TelegramState keeps a bounded per-session fingerprint set (cap 64, 30-min TTL); a duplicate notify folds ONCE — check-and-record is atomic under the state lock, so two concurrent rolls of the same session cannot both render it.
- **Fold-first button ladder:** option-row budget accounting folds first, with a 20-unit fold cap before the ladder degrades.
- **Empty-body guards restored (#38):** `build_bg` / `build_notify_receipt_card` reject empty/whitespace bodies on both rich and classic legs (regression tests for both builders).
- Port adaptation: `LiveFlowHandle` carries only the `streaming` Arc — upstream v0.5.0 has no `refresh_flow` reader for chat/thread coordinates, and the registry test initializer matches the upstream `StreamingState` field set (`rich_transport_failures` included).

## Evidence

oc-harvest-sweep CLEAN (trailers + non-empty diff vs `main`). PR-lane gate run [34066999763](https://github.com/leshchenko1979/opencrabs/actions/runs/34066999763): fmt + Clippy + full test suite **7880 passed / 1 failed** — the sole failure is `xiaomi_models_fetch_returns_mimo_list`, the known upstream-base network-dependent onboarding test (no offline xiaomi baseline on this tree; documented in adolfousier/opencrabs#1419). It is disjoint from this change (no onboarding/fetch file touched) and matches the established sole-failure exemption precedent.

Port of the fold/notify stack shipped on leshchenko1979/opencrabs (commits a5f1f14ab, 0b8e0dbc8, d82d37b49, 39b99d9fe, 67867bdbe via merge 7615f4ea, smoke-verified in production).

Original issue: https://github.com/leshchenko1979/opencrabs/issues/61