### PR TITLE
fix(onboarding): xiaomi model list falls back to binary baseline when /models fails

### DIFF
--- a/src/tui/onboarding/fetch.rs
+++ b/src/tui/onboarding/fetch.rs
@@ -381,6 +381,12 @@ pub async fn fetch_provider_models(
             .and_then(|c| c.providers.xiaomi.clone())
             .map(|p| p.models)
             .unwrap_or_default();
+        if api_models.is_empty() {
+            // Live fetch failed (401 / offline) — fall back to the binary
+            // baseline so the picker is never empty (#1419). Mirrors the
+            // MiniMax fallback above.
+            return merge_minimax_baseline(xiaomi_baseline_models(), user_models);
+        }
         return merge_minimax_baseline(api_models, user_models);
     }
 
@@ -759,6 +765,22 @@ fn minimax_baseline_models() -> Vec<String> {
         "MiniMax-M2.1".to_string(),
         "MiniMax-M2.1-highspeed".to_string(),
         "MiniMax-M2".to_string(),
+    ]
+}
+
+/// Binary's known Xiaomi MiMo models, used as fallback when the live
+/// /models fetch fails — the endpoint is keyless but geo/credential
+/// sensitive (401 on some CI runners, #1419). Newest first so the
+/// picker highlights the current model. Live fetch is the primary
+/// source — this only covers offline / unreachable-API scenarios.
+fn xiaomi_baseline_models() -> Vec<String> {
+    vec![
+        "mimo-v2.5-pro".to_string(),
+        "mimo-v2-pro".to_string(),
+        "mimo-v2-omni".to_string(),
+        "mimo-v2-flash".to_string(),
+        "mimo-v2-pro-free".to_string(),
+        "mimo-v2-omni-free".to_string(),
     ]
 }
 


### PR DESCRIPTION
## What

`fetch_provider_models("xiaomi")` currently returns an empty list when the live /models endpoint fails (network Err, or empty runner config) — no offline baseline exists. The test `xiaomi_models_fetch_returns_mimo_list` asserts non-empty and therefore requires live internet to api.xiaomimimo.com, making it deterministically RED on any offline CI gate (evidence: adolfousier/opencrabs#1419, plus gate runs 34061653423 / 34063416863 / 34065501068 / 34066999763 — all sole-failing on exactly this test).

## Details

Mirrors the existing MiniMax pattern: adds a `xiaomi_baseline_models()` const list (six mimo models) used as the fallback when the fetch branch returns empty. Fix is confined to `src/onboarding/fetch.rs`. This change is already shipped and smoke-proven on the fork's production deployment.

## Evidence

- Upstream issue: adolfousier/opencrabs#1419
- On the fork, `xiaomi_baseline_models()` sits at fetch.rs:776 with the empty-fetch fallback wired at :378
- Unblocks every upstream-base wave-1 CI gate currently sole-failing on this test (#1414–#1418 family, #1422)

Original issue: leshchenko1979/opencrabs#85