### PR TITLE
fix(telegram): re-run the #58 promotion guard on the displaced host in options-reclaim (#92)

### DIFF
--- a/src/channels/telegram/flow.rs
+++ b/src/channels/telegram/flow.rs
@@ -2159,6 +2159,21 @@ pub(crate) fn settle_options_reclaim(
         } else {
             Some(text)
         };
+        // #92 demoted-host guard: re-run the promotion guard on the demoted
+        // host. A fence-bearing (or oversized) displaced host riding the
+        // trailer slot would ship its fence raw — the fence→PNG conversion
+        // runs only on the final-answer send (#92). Concatenate it into the
+        // answer slot (owner-approved fix shape) so BOTH texts ride the
+        // render path; the promoted trailer keeps the answer head (#58
+        // priority stands), the trailer slot dies with nothing left to ride.
+        if let Some(d) = demoted.as_ref().filter(|d| {
+            trailer_promotes_to_answer(
+                super::rich::mermaid::should_render_mermaid(d),
+                d.chars().count(),
+            )
+        }) {
+            return (format!("{t}\n\n{d}"), None);
+        }
         return (t.clone(), demoted);
     }
     (text, trailer)

--- a/src/tests/telegram_options_reclaim_test.rs
+++ b/src/tests/telegram_options_reclaim_test.rs
@@ -302,3 +302,34 @@ fn settle_oversized_trailer_empty_host_drops_demote() {
         "empty host demotes to None, not an empty trailer"
     );
 }
+
+#[test]
+fn settle_demoted_host_trips_guard_concatenates_into_answer() {
+    // #92 demoted-host leg (the #58 matrix covered the trailer leg only):
+    // the displaced host itself trips the promotion guard — an oversized
+    // run, the config-independent leg (`should_render_mermaid` reads
+    // `Config::current()`; the fence leg shares the same guard call pinned
+    // by `trailer_promotes_to_answer_matrix`). Before the fix the
+    // fence-bearing host rode the trailer slot and shipped raw; now it is
+    // concatenated after the promoted trailer in the answer slot so BOTH
+    // texts ride the final-answer render path.
+    let big_host = "host ".repeat(121);
+    let big_trailer = "trailer ".repeat(76);
+    assert!(big_host.chars().count() > MAX_TRAILER_CHARS);
+    assert!(big_trailer.chars().count() > MAX_TRAILER_CHARS);
+    let (text, trailer) = settle_options_reclaim(
+        "unused content".into(),
+        Some(big_host.clone()),
+        Some(big_trailer.clone()),
+    );
+    assert_eq!(
+        text,
+        format!("{big_trailer}\n\n{big_host}"),
+        "promoted trailer keeps the answer head; the tripping demoted host \
+         concatenates after it"
+    );
+    assert_eq!(
+        trailer, None,
+        "trailer slot dies — both texts ride the answer render path"
+    );
+}


### PR DESCRIPTION
## What

In `settle_options_reclaim`, when a long demoted host message forces the trailer's promotion to answer (#58 path), the demoted host text is returned raw — if it carries a Telegram code fence, that fence ships unrendered because the fence→PNG conversion runs only on the final-answer send. This PR re-runs the #58 promotion guard on the demoted host before returning it: a fence-bearing (or oversized) displaced host is concatenated into the answer slot so BOTH texts ride the render path. The promoted trailer keeps the answer head (#58 priority stands); the trailer slot dies with nothing left to ride.

## Details

- **Guard re-run (#92):** inside the promotion branch, the demoted host is checked with the same `trailer_promotes_to_answer(should_render_mermaid(d), d.chars().count())` gate the trailer faces; if it trips, `return (format!("{t}\n\n{d}"), None)` — concatenated after the promoted trailer.
- **Regression test:** `settle_demoted_host_trips_guard_concatenates_into_answer` — host (605 chars) and trailer (608 chars) both above `MAX_TRAILER_CHARS`, asserts the promoted trailer keeps the answer head, the tripping demoted host concatenates after it, and the trailer slot is `None`.
- Clean cherry-pick from leshchenko1979/opencrabs (commit `1097b444ab756ddf1f6b43bf547bfe75879120c0`, patch-id verified, trailers `Session-Id` + `Issue-Ref` intact); shipped and smoke-verified in production on the fork (deployed sha `1097b444`, features `telegram,code-graph`).

## Evidence

oc-harvest-sweep CLEAN (trailers + non-empty diff vs `main`). PR-lane gate runs on this head: `34061653423`, `34063416863`, and `34084920421` — fmt + Clippy green, full suite **7859 passed / 1 failed** each; the sole failure is `xiaomi_models_fetch_returns_mimo_list`, the known upstream-base network-dependent onboarding test (no offline xiaomi baseline on this tree; the offline baseline fix is pending in adolfousier/opencrabs#1424). The failure is disjoint from this change (no onboarding/fetch file touched), reproduced identically across three runs with disjoint diffs, and matches the established sole-failure exemption precedent (n=1615; family-C precedent PR #1422). Gate run `34084920421` is terminal: `failure` on the same sole test — final evidence state for this head.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/92



**Update (rebase, 2026-09-07):** rebased onto fresh upstream main `221d7423` (carries the #1424 xiaomi offline baseline). Clean-GREEN gate on the rebased head `3c4ac6c0`: [run 34140891456](https://github.com/leshchenko1979/opencrabs/actions/runs/34140891456) — **full suite pass, 0 failures**, fmt + clippy green. The exempted-RED evidence above is superseded: no exemption is needed for this head.
