### PR TITLE
Restick plan card on interrupt/teardown turns (fork #69)

### DIFF
--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -2622,6 +2622,26 @@ pub(crate) async fn handle_message(
         if let Some(mid) = streaming_msg_id {
             best_effort_delete(&bot, msg.chat.id, mid, "keep-history teardown").await;
         }
+        // #69: a preempted turn used to `return Ok(())` here and skip the #62
+        // re-stick entirely — during an interrupt chain (rapid-fire messages,
+        // exactly the scenario #62 targets) every reply was interrupt-delivered
+        // and the plan card stayed buried at a stale position until a normal
+        // settle finally happened. Run the SAME settle-path tail here: the
+        // keyboard is recomputed for a finished turn (turn_active == false, so
+        // Approve/Discard rides the resticked card), and the shared sticky
+        // budget (#1150) + governors G2/G3 gate it exactly like a normal
+        // settle — no new throttle, no #814 cooldown reintroduced.
+        let (_, plan_kb) = super::flow_chrome::load_plan_state_section(session_id, false).await;
+        super::plan_card::restick_plan_card_after_turn(
+            &bot,
+            msg.chat.id,
+            thread_id,
+            &telegram_state,
+            &agent,
+            session_id,
+            plan_kb,
+        )
+        .await;
         return Ok(());
     }
 
@@ -2742,57 +2762,20 @@ pub(crate) async fn handle_message(
                 .sections
                 .plan_kb
         };
-        // Re-stick on EVERY user-message settle (owner-approved #62): the card
-        // must stay reachable for the Approve button while a pre-approval plan
-        // is being discussed, and a restick per human turn is paced by typing
-        // speed, not by machine loops. Flood safety is NOT this gate's job:
-        // the fresh post goes through the G3 sends governor, the in-place
-        // refresh below rides G2 (#1211), so the old 90s RESTICK_COOLDOWN
-        // (#814) was a pre-governor duplicate — deleted. The ONLY gate left is
-        // the shared sticky-stack budget (#1150): a flow restick moments ago
-        // already spent this chat's delete+create allowance; skipping here
-        // costs nothing (no cooldown is recorded — retry next settle) and the
-        // refresh below still edits in place.
-        if crate::utils::plan_files::peek_plan_just_archived(session_id).await {
-            // Plan completed THIS settle (#1158, #1231): finalize the tracked
-            // card (✅ header, keyboard stripped, one-shot untrack) and re-stick
-            // the completed card to the bottom of the thread instead of
-            // re-sticking or refreshing a now-archived plan. Finalize consumes
-            // the flag only after the notice LANDED (#16): a flood-aborted
-            // finalize leaves it in place, so the next settle retries instead
-            // of losing the completion notice forever.
-            super::plan_card::finalize_plan_card(
-                &bot,
-                msg.chat.id,
-                thread_id,
-                &telegram_state,
-                session_id,
-            )
-            .await;
-        } else {
-            // Gate the claim on a tracked card (in-memory only — cheap): a
-            // cardless settle must not spend the sticky budget, or the
-            // flow-block restick starves for 15s after EVERY settle (#62).
-            if telegram_state.plan_card_cached(session_id).await.is_some()
-                && telegram_state.claim_sticky_action(
-                    msg.chat.id.0,
-                    super::state::TelegramState::STICKY_STACK_MIN_INTERVAL,
-                )
-            {
-                super::plan_card::remove_plan_card(&bot, msg.chat.id, &telegram_state, session_id)
-                    .await;
-            }
-            super::plan_card::refresh_plan_card(
-                &bot,
-                msg.chat.id,
-                thread_id,
-                &telegram_state,
-                &agent,
-                session_id,
-                plan_kb,
-            )
-            .await;
-        }
+        // #69: the block below is the #62 re-stick tail, now shared with the
+        // interrupt/replacement teardown (which used to early-return before
+        // it, leaving the card buried during interrupt chains). The keyboard
+        // value this settle just computed rides along unchanged.
+        super::plan_card::restick_plan_card_after_turn(
+            &bot,
+            msg.chat.id,
+            thread_id,
+            &telegram_state,
+            &agent,
+            session_id,
+            plan_kb,
+        )
+        .await;
     }
 
     // Drop the active-turn guard before flushing so any reaction arriving during

--- a/src/channels/telegram/plan_card.rs
+++ b/src/channels/telegram/plan_card.rs
@@ -859,6 +859,55 @@ pub(crate) async fn remove_plan_card(
     remove_plan_card_locked(bot, chat, state, session_id).await;
 }
 
+/// Settle-path plan-card tail (#69): the #62 re-stick block shared by BOTH
+/// delivery paths. The normal settle runs it after final delivery; the
+/// interrupt/replacement teardown (handle_message's cancel_token guard) runs
+/// the SAME tail, because a preempted turn's `return Ok(())` used to skip the
+/// re-stick entirely — during rapid-fire discussion the card stayed buried at
+/// a stale position for as long as the interrupt chain lasted (#69 live
+/// observation: zero normal settles for 2+ hours, resticks only from
+/// stream_loop flow-burial). Same gates as the normal path, unchanged:
+/// finalize-on-archive first, then the tracked-card claim on the shared
+/// sticky-stack budget (#1150) — a cardless settle spends nothing and retries
+/// on the next settle — then the in-place refresh riding G2, fresh post
+/// riding G3 (#1211). No cooldown: the #814 legacy stays deleted.
+///
+/// `plan_kb` is passed by the caller: the normal path forwards the value its
+/// settle render just computed (bit-identical to the pre-#69 block); the
+/// interrupt path recomputes it for a finished turn (`load_plan_state_section`
+/// with `turn_active == false`, mirroring the settle path's `refresh_sections`)
+/// so the Approve/Discard keyboard rides the resticked card.
+pub(crate) async fn restick_plan_card_after_turn(
+    bot: &Bot,
+    chat: ChatId,
+    thread_id: Option<ThreadId>,
+    state: &Arc<TelegramState>,
+    agent: &AgentService,
+    session_id: Uuid,
+    plan_kb: PlanKb,
+) {
+    if crate::utils::plan_files::peek_plan_just_archived(session_id).await {
+        // Plan completed THIS settle (#1158, #1231): finalize the tracked
+        // card (✅ header, keyboard stripped, one-shot untrack) and re-stick
+        // the completed card to the bottom of the thread instead of
+        // re-sticking or refreshing a now-archived plan. Finalize consumes
+        // the flag only after the notice LANDED (#16): a flood-aborted
+        // finalize leaves it in place, so the next settle retries instead
+        // of losing the completion notice forever.
+        finalize_plan_card(bot, chat, thread_id, state, session_id).await;
+    } else {
+        // Gate the claim on a tracked card (in-memory only — cheap): a
+        // cardless settle must not spend the sticky budget, or the
+        // flow-block restick starves for 15s after EVERY settle (#62).
+        if state.plan_card_cached(session_id).await.is_some()
+            && state.claim_sticky_action(chat.0, TelegramState::STICKY_STACK_MIN_INTERVAL)
+        {
+            remove_plan_card(bot, chat, state, session_id).await;
+        }
+        refresh_plan_card(bot, chat, thread_id, state, agent, session_id, plan_kb).await;
+    }
+}
+
 /// Removal body, for callers already holding the per-session card lock.
 ///
 /// Split out because `refresh_plan_card` takes the lock and then needs to

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -808,6 +808,7 @@ pub mod telegram_mermaid_test;
 pub mod telegram_model_callback_data_test;
 pub mod telegram_outbox_record_test;
 pub mod telegram_photo_batching_test;
+pub mod telegram_plan_card_interrupt_restick_test;
 pub mod telegram_plan_finalize_test;
 pub mod telegram_plan_render_test;
 pub mod telegram_pre_tool_rolling_test;

--- a/src/tests/telegram_plan_card_interrupt_restick_test.rs
+++ b/src/tests/telegram_plan_card_interrupt_restick_test.rs
@@ -1,0 +1,101 @@
+//! #69 regression tests: interrupt-delivered turns must re-stick the plan
+//! card through the SAME settle-path tail as normal settles.
+//!
+//! Before #69, a preempted turn early-returned through the cancel_token
+//! teardown (`return Ok(())`) before the #62 re-stick block ran, so during an
+//! interrupt chain every reply skipped the restick and the card stayed buried
+//! at a stale position until a normal settle finally happened. The fix routes
+//! the teardown through `plan_card::restick_plan_card_after_turn` — the exact
+//! block the normal settle runs.
+//!
+//! These tests pin the three seams the interrupt tail must satisfy, without
+//! touching the network or the Bot:
+//! 1. The interrupt restick draws from the SAME shared sticky-stack budget
+//!    (#1150) as normal settles — no independent gate, no bypass.
+//! 2. A cardless turn spends NOTHING from that budget (the tracked-card claim
+//!    gates it) — the flow-block restick must not starve for 15s after every
+//!    interrupt-delivered cardless reply (#62 lesson).
+//! 3. The keyboard the interrupt path passes is recomputed for a FINISHED
+//!    turn (`turn_active == false` via `load_plan_state_section`), so the
+//!    Approve/Discard keyboard materializes on the resticked card exactly as
+//!    it does on the normal settle path (#571 gate).
+//!
+//! Fixtures are synthetic and carry no user identifiers.
+
+use crate::channels::telegram::flow_chrome::{PlanKb, plan_state_chrome};
+use crate::channels::telegram::state::TelegramState;
+use crate::utils::plan_files::PlanModeState;
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Seam 1 + 2: the interrupt tail calls `claim_sticky_action` with the same
+/// shared `STICKY_STACK_MIN_INTERVAL` the settle path uses, gated on a tracked
+/// card. Pinned against the real state object: a chat whose sticky action was
+/// just spent must refuse the claim within the interval (budget is shared,
+/// regardless of which path spent it), and a session with no tracked card
+/// never reaches the claim at all (`plan_card_cached` is the gate).
+#[tokio::test]
+async fn interrupt_restick_shares_the_sticky_budget_and_spends_nothing_cardless() {
+    let state = Arc::new(TelegramState::new());
+    let session = Uuid::new_v4();
+    let chat = teloxide::types::ChatId(690_001);
+
+    // Seam 2: cardless — the exact gate the tail evaluates before claiming.
+    assert!(
+        state.plan_card_cached(session).await.is_none(),
+        "cardless session must not reach the sticky claim at all"
+    );
+
+    // Simulate a settle-path restick having just spent the budget (the normal
+    // path claims via the same helper): the shared budget is now hot.
+    assert!(
+        state.claim_sticky_action(chat.0, TelegramState::STICKY_STACK_MIN_INTERVAL),
+        "first claim (simulated normal settle) must be admitted"
+    );
+
+    // The interrupt tail's claim, moments later: REFUSED — the two paths draw
+    // from ONE budget, this is the flood-safety contract (#1150, #814 stays
+    // deleted: no cooldown is recorded on a skip, but a real burst refuses).
+    assert!(
+        !state.claim_sticky_action(chat.0, TelegramState::STICKY_STACK_MIN_INTERVAL),
+        "interrupt-path restick must share the settle-path sticky budget"
+    );
+
+    // After the interval elapses the budget frees up for the next restick,
+    // whichever path needs it. (Same seam the settle path uses; pinned here so
+    // a future per-path budget split fails loudly.)
+    std::thread::sleep(TelegramState::STICKY_STACK_MIN_INTERVAL + Duration::from_millis(5));
+    assert!(
+        state.claim_sticky_action(chat.0, TelegramState::STICKY_STACK_MIN_INTERVAL),
+        "budget must free up after the interval for the next restick"
+    );
+}
+
+/// Seam 3: the interrupt path recomputes the keyboard for a finished turn.
+/// The teardown calls `load_plan_state_section(session_id, false)` — the
+/// turn is over, so `turn_active == false` and the PostInitEditing state
+/// yields the Approve/Discard keyboard, mirroring the settle path's
+/// `refresh_sections` recompute (#571). Pinned at the pure seam
+/// (`plan_state_chrome`) the loader delegates to, with the live plan files
+/// absent (NoPlan is the state any CI environment sees).
+#[test]
+fn interrupt_tail_recomputes_keyboard_for_a_finished_turn() {
+    // What the teardown computes: turn finished (turn_active == false).
+    let (label, kb) = plan_state_chrome(PlanModeState::PostInitEditing, false, false);
+    assert_eq!(label, Some("✍️ Editing plan".to_string()));
+    assert_eq!(
+        kb,
+        PlanKb::ApproveDiscard,
+        "the resticked card must carry the Approve/Discard keyboard after an \
+         interrupt-delivered turn ends, exactly like a normal settle (#571)"
+    );
+
+    // Contrast: the same state mid-turn (a concurrent in-flight turn elsewhere
+    // recomputed during the interrupt window) strips the keyboard.
+    assert_eq!(
+        plan_state_chrome(PlanModeState::PostInitEditing, true, false).1,
+        PlanKb::None,
+        "an in-flight turn must still render keyboardless chrome"
+    );
+}


### PR DESCRIPTION
## Summary

Interrupted/replaced streaming turns (cancel-token teardown path) early-returned before the plan-card restick block ran, so the plan card could go stale after an interrupt — the restick guarantee held only for normal settles.

**Fix:** the post-turn restick tail is extracted verbatim into `plan_card::restick_plan_card_after_turn` (finalize-on-archive → tracked-card claim on the shared sticky budget → G2 edit / G3 post). The normal-settle path forwards its already-computed keyboard (bit-identical behavior); the interrupt teardown now calls the same tail before its early return, with the keyboard recomputed for the finished turn. No new throttle; the #814 cooldown stays deleted; sticky governors untouched.

## Tests

New `telegram_plan_card_interrupt_restick_test` module pins: shared sticky-budget refusal across both paths, cardless turns spend nothing, keyboard recompute seam for finished turns. No network, no Bot dependency.

## Evidence

- Gate: [PR-lane gates (6db2f6f5)](https://github.com/leshchenko1979/opencrabs/actions/runs/34100393773) — fmt + clippy green; tests 7860 passed / 1 failed
- The single failure is `xiaomi_models_fetch_returns_mimo_list`, a pre-existing upstream-base defect: the test requires live internet to api.xiaomimimo.com and the xiaomi branch of `fetch_provider_models` has no offline baseline (upstream diagnosis verified from source; independent runs on disjoint diffs fail identically). This PR's diff does not touch onboarding. Precedent for merging with this sole failure: #1422, #1426. A pending upstream fix exists as #1424.
- Drift disclosure: cherry-pick from the fork dropped one rustfmt-only reflow hunk in `refresh_plan_card` (base drift, upstream's newer goal-section load shape kept); the substantive helper is byte-identical between fork and this head, verified by diff.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/69


**Update (rebase, 2026-09-07):** rebased onto fresh upstream main `221d7423` (carries the #1424 xiaomi offline baseline). Clean-GREEN gate on the rebased head `45f35190`: [run 34140966104](https://github.com/leshchenko1979/opencrabs/actions/runs/34140966104) — **full suite pass, 0 failures**, fmt + clippy green. The exempted-RED evidence above is superseded: no exemption is needed for this head.
