### PR TITLE
Bind sub-agent status to the spawning session — deliver revived agent outcomes to the parent

### DIFF
--- a/src/brain/agent/service/restart_recovery.rs
+++ b/src/brain/agent/service/restart_recovery.rs
@@ -481,7 +481,7 @@ pub(crate) fn deliver_revived_agent_outcome(
     let agent_id = status.id.clone();
     let label = status.label.clone();
     let msg = crate::brain::tools::subagent::spawn::completion_message(&label, &agent_id, outcome);
-    match crate::brain::agent::service::session_routes::deliver_to_session(parent, msg, true) {
+    match crate::brain::agent::service::session_routes::deliver_to_session(parent, msg.clone(), true) {
         crate::brain::agent::service::session_routes::Delivery::Delivered => {
             tracing::info!(
                 target: "background_task",

--- a/src/brain/agent/service/restart_recovery.rs
+++ b/src/brain/agent/service/restart_recovery.rs
@@ -361,22 +361,25 @@ pub async fn recover(local: Option<MessageEnqueueCallback>) -> usize {
     // not, so every file still mid-flight is an agent that no longer exists.
     let orphans = crate::brain::tools::subagent::reconcile::reconcile_orphaned_agents();
     let mut reported = 0usize;
-    for orphan in orphans {
-        match Uuid::parse_str(&orphan.session_id) {
-            Ok(session_id) => {
+    for mut orphan in orphans {
+        match interrupted_report_target(&orphan) {
+            Some(session_id) => {
                 deliver_or_park(session_id, subagent_interrupted_message(&orphan));
                 reported += 1;
             }
-            Err(e) => {
+            None => {
                 // Nothing to route to. Say so rather than dropping it, since
                 // the agent's parent is waiting on a result either way.
                 tracing::error!(
                     target: "background_task",
-                    "Sub-agent '{}' has an unparseable parent session '{}', its interruption \
-                     cannot be reported: {e}",
+                    "Sub-agent '{}' has an unparseable parent session '{}' or '{}', its \
+                     interruption cannot be reported",
                     orphan.label,
+                    orphan.parent_session_id.as_deref().unwrap_or("<none>"),
                     orphan.session_id
                 );
+                // Still finalize the file so it cannot zombie.
+                orphan.mark_interrupted().ok();
             }
         }
     }
@@ -423,5 +426,115 @@ fn subagent_interrupted_message(
         display_text: format!("⚠️ Sub-agent interrupted by restart: {}", status.label),
         origin: PushOrigin::Recovery,
         bg_meta: None,
+    }
+}
+
+/// Route an interrupted sub-agent's report to the session that spawned it.
+///
+/// The status file carries `parent_session_id` since #110; older files (and
+/// any agent spawned before the binding existed) fall back to `session_id`,
+/// the pre-#26 routing value this field replaced. Returns the session to
+/// report to, if either field parses as a UUID.
+fn interrupted_report_target(
+    status: &crate::brain::agent::service::work_status::WorkStatus,
+) -> Option<Uuid> {
+    status
+        .parent_session_id
+        .as_deref()
+        .or(Some(status.session_id.as_str()))
+        .and_then(|p| Uuid::parse_str(p).ok())
+}
+
+/// Deliver a boot-resumed sub-agent's outcome to the session that spawned it,
+/// and finalize the status file either way (#110).
+///
+/// Boot-resume revives an interrupted child session, but the child has no
+/// channel binding: the default surface route would drop the result where
+/// nobody reads it. The status file carries the spawning session, so the
+/// outcome goes there instead — the same delivery the live completion path
+/// uses (`deliver_to_session`, interrupt=true). On Parked or NoRoute the
+/// message rides the durable park machinery (`deliver_or_park` handles the
+/// park; NoRoute falls back to it), so the failure direction is a duplicate
+/// report, never a lost one — no tombstone infrastructure required.
+///
+/// Returns whether the outcome was routed to a parent session (informational).
+pub(crate) fn deliver_revived_agent_outcome(
+    status: &mut crate::brain::agent::service::work_status::WorkStatus,
+    outcome: std::result::Result<&str, &str>,
+) -> bool {
+    let Some(parent) = status
+        .parent_session_id
+        .as_deref()
+        .and_then(|p| Uuid::parse_str(p).ok())
+    else {
+        // Legacy file without a parent: nothing to route to, but still
+        // finalize so the file cannot zombie.
+        tracing::warn!(
+            target: "background_task",
+            "Revived sub-agent '{}' has no parent session recorded; finalizing status only",
+            status.id
+        );
+        finalize_revived_status(status, outcome);
+        return false;
+    };
+
+    let agent_id = status.id.clone();
+    let label = status.label.clone();
+    let msg = crate::brain::tools::subagent::spawn::completion_message(&label, &agent_id, outcome);
+    match crate::brain::agent::service::session_routes::deliver_to_session(parent, msg, true) {
+        crate::brain::agent::service::session_routes::Delivery::Delivered => {
+            tracing::info!(
+                target: "background_task",
+                "Revived sub-agent {agent_id}'s result delivered to parent session {parent}"
+            );
+        }
+        crate::brain::agent::service::session_routes::Delivery::NoRoute => {
+            // No live route right now: hand it to the park machinery so the
+            // report leaves when the owning channel claims the session, or
+            // at worst flushes after the grace period — same durability the
+            // live completion path has.
+            tracing::warn!(
+                target: "background_task",
+                "Revived sub-agent {agent_id}'s result had no route for parent {parent}; parked"
+            );
+            deliver_or_park(parent, msg);
+        }
+        _ => {
+            // Parked / redirected: the delivery machinery owns it from here.
+            tracing::info!(
+                target: "background_task",
+                "Revived sub-agent {agent_id}'s result for parent {parent} handled by the \
+                 delivery machinery (parked or redirected)"
+            );
+        }
+    }
+    finalize_revived_status(status, outcome);
+    true
+}
+
+/// Stamp the terminal outcome onto a revived agent's status file.
+fn finalize_revived_status(
+    status: &mut crate::brain::agent::service::work_status::WorkStatus,
+    outcome: std::result::Result<&str, &str>,
+) {
+    match outcome {
+        Ok(output) => {
+            if let Err(e) = status.mark_completed(output.chars().take(512).collect()) {
+                tracing::warn!(
+                    target: "background_task",
+                    "Could not finalize revived sub-agent status '{}': {e}",
+                    status.id
+                );
+            }
+        }
+        Err(error) => {
+            if let Err(e) = status.mark_failed(error.to_string()) {
+                tracing::warn!(
+                    target: "background_task",
+                    "Could not finalize revived sub-agent status '{}': {e}",
+                    status.id
+                );
+            }
+        }
     }
 }

--- a/src/brain/agent/service/work_status.rs
+++ b/src/brain/agent/service/work_status.rs
@@ -513,6 +513,7 @@ pub fn migrate_legacy_dir(legacy: &Path) -> usize {
             id: old.id.clone(),
             kind: WorkKind::Agent,
             session_id: old.parent_session_id,
+            parent_session_id: None,
             label: old.label,
             task: old.prompt,
             spawned_at: old.started_at,

--- a/src/brain/agent/service/work_status.rs
+++ b/src/brain/agent/service/work_status.rs
@@ -201,6 +201,12 @@ pub struct WorkStatus {
     /// routes the interruption report by (the pre-#26 `parent_session_id`
     /// value); for commands, the owning session.
     pub session_id: String,
+    /// The session that spawned this agent (#110). `None` for legacy files
+    /// written before the field existed and for detached commands. The
+    /// boot-resume path uses it to deliver a revived agent's result to the
+    /// session that is waiting on it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
     pub label: String,
     /// The work itself: the shell command for [`WorkKind::Command`], the
     /// prompt for [`WorkKind::Agent`].
@@ -222,12 +228,14 @@ impl WorkStatus {
         label: &str,
         session_id: &str,
         prompt: &str,
+        parent_session_id: Option<&str>,
     ) -> std::io::Result<Self> {
         ensure_dir()?;
         let status = Self {
             id: id.to_string(),
             kind: WorkKind::Agent,
             session_id: session_id.to_string(),
+            parent_session_id: parent_session_id.map(str::to_string),
             label: label.to_string(),
             task: prompt.to_string(),
             spawned_at: now_rfc3339(),
@@ -259,6 +267,7 @@ impl WorkStatus {
             state: WorkState::Running,
             progress: None,
             finish: None,
+            parent_session_id: None,
         };
         status.write()?;
         Ok(status)
@@ -283,6 +292,7 @@ impl WorkStatus {
             state: WorkState::Running,
             progress: None,
             finish: None,
+            parent_session_id: None,
         });
         status.state = if exit.success {
             WorkState::Completed
@@ -410,6 +420,25 @@ impl WorkStatus {
         }
         ids.sort();
         Ok(ids)
+    }
+
+    /// Find a sub-agent status whose **child** session is `session_id` and
+    /// whose outcome is not yet decided (#110).
+    ///
+    /// The boot-resume path uses this to recognize a revived sub-agent
+    /// session: its result must go to the spawning session, not to the
+    /// recorded channel. `Interrupted` files qualify on purpose — upstream
+    /// reconciliation marks the file at boot, before the resumed session
+    /// finishes — as do `Running`/`Pending`/`AwaitingInput`. `None` for
+    /// unknown, outcome-terminal (`Completed`/`Failed`), or non-agent work —
+    /// those keep the existing resume behavior.
+    pub fn find_agent_by_session(session_id: &str) -> Option<WorkStatus> {
+        let ids = Self::list_all().ok()?;
+        ids.into_iter().filter_map(|id| Self::read(&id)).find(|s| {
+            matches!(s.kind, WorkKind::Agent)
+                && s.session_id == session_id
+                && !matches!(s.state, WorkState::Completed | WorkState::Failed)
+        })
     }
 }
 

--- a/src/brain/tools/subagent/spawn.rs
+++ b/src/brain/tools/subagent/spawn.rs
@@ -486,12 +486,17 @@ impl Tool for SpawnAgentTool {
 
         // Create the status file in Pending state before spawning. new()
         // writes the file; we don't need the returned handle, but we do
-        // propagate any write error.
+        // propagate any write error. The parent session is captured before
+        // the first write so the file is born with the binding (#110): if
+        // the daemon restarts mid-run, boot-resume can route the revived
+        // result back to the session that is waiting on it.
+        let parent_session_for_status = context.session_id.to_string();
         let _ = WorkStatus::new_agent(
             &agent_id,
             &label,
             &child_session_id.to_string(),
             &full_prompt,
+            Some(&parent_session_for_status),
         )
         .map_err(|e| ToolError::Execution(format!("Failed to create status file: {e}")))?;
 
@@ -518,6 +523,7 @@ impl Tool for SpawnAgentTool {
                     &label_clone,
                     &child_session_id.to_string(),
                     &prompt_clone,
+                    None,
                 )
                 .expect("status file")
             });

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -1476,6 +1476,15 @@ async fn cmd_chat_inner(
                                         response.content.len()
                                     );
                                     boot_report::record_delivered();
+                                    // A revived sub-agent session (#110): its
+                                    // result belongs to the session that spawned
+                                    // it, not to the surface-less default — route
+                                    // it to the parent, finalize the status file,
+                                    // and skip the surface event nobody reads.
+                                    if let Some(mut agent_status) = crate::brain::agent::service::work_status::WorkStatus::find_agent_by_session(&session_id.to_string()) {
+                                        crate::brain::agent::service::restart_recovery::deliver_revived_agent_outcome(&mut agent_status, Ok(&response.content));
+                                        return;
+                                    }
                                     match channel.as_str() {
                                         "tui" => {
                                             let _ = ev_tx.send(
@@ -1554,6 +1563,14 @@ async fn cmd_chat_inner(
                                         e
                                     );
                                     boot_report::record_failed();
+                                    // A revived sub-agent session whose resume
+                                    // failed (#110): the parent is waiting on
+                                    // this outcome either way — report and
+                                    // finalize instead of dropping it.
+                                    if let Some(mut agent_status) = crate::brain::agent::service::work_status::WorkStatus::find_agent_by_session(&session_id.to_string()) {
+                                        crate::brain::agent::service::restart_recovery::deliver_revived_agent_outcome(&mut agent_status, Err(&e.to_string()));
+                                        return;
+                                    }
                                     if channel == "tui" {
                                         let _ = ev_tx.send(crate::tui::events::TuiEvent::Error {
                                             session_id,

--- a/src/tests/brain_agent_service_work_status_test.rs
+++ b/src/tests/brain_agent_service_work_status_test.rs
@@ -37,7 +37,7 @@ fn status_path_ends_with_json() {
 #[test]
 fn new_agent_is_pending() {
     isolate("new_pending");
-    let s = WorkStatus::new_agent("test-1", "test", "sess-1", "do things").unwrap();
+    let s = WorkStatus::new_agent("test-1", "test", "sess-1", "do things", None).unwrap();
     assert_eq!(s.state, WorkState::Pending);
     assert_eq!(s.kind, WorkKind::Agent);
     assert_eq!(s.id, "test-1");
@@ -48,7 +48,7 @@ fn new_agent_is_pending() {
 #[test]
 fn agent_transitions_to_running() {
     isolate("running");
-    let mut s = WorkStatus::new_agent("test-2", "test", "sess-1", "do things").unwrap();
+    let mut s = WorkStatus::new_agent("test-2", "test", "sess-1", "do things", None).unwrap();
     s.mark_running().unwrap();
     assert_eq!(s.state, WorkState::Running);
 }
@@ -60,7 +60,7 @@ fn agent_parks_as_awaiting_input_and_flips_back() {
     // already finished. The parked state is distinct, not terminal, and
     // round-trips through the file so external readers see it too.
     isolate("awaiting_input");
-    let mut s = WorkStatus::new_agent("test-7", "test", "sess-1", "do things").unwrap();
+    let mut s = WorkStatus::new_agent("test-7", "test", "sess-1", "do things", None).unwrap();
     s.mark_running().unwrap();
     s.mark_awaiting_input().unwrap();
     assert_eq!(s.state, WorkState::AwaitingInput);
@@ -80,7 +80,7 @@ fn agent_parks_as_awaiting_input_and_flips_back() {
 #[test]
 fn agent_progress_snapshot() {
     isolate("progress");
-    let mut s = WorkStatus::new_agent("test-3", "test", "sess-1", "do things").unwrap();
+    let mut s = WorkStatus::new_agent("test-3", "test", "sess-1", "do things", None).unwrap();
     s.mark_running().unwrap();
     s.update_progress(1, Some("bash".into()), Some("cargo check ok".into()))
         .unwrap();
@@ -94,7 +94,7 @@ fn agent_progress_snapshot() {
 #[test]
 fn agent_completed_sets_finish() {
     isolate("completed");
-    let mut s = WorkStatus::new_agent("test-4", "test", "sess-1", "do things").unwrap();
+    let mut s = WorkStatus::new_agent("test-4", "test", "sess-1", "do things", None).unwrap();
     s.mark_completed("done".into()).unwrap();
     assert_eq!(s.state, WorkState::Completed);
     let finish = s.finish.as_ref().expect("completed stamps a finish");
@@ -105,7 +105,7 @@ fn agent_completed_sets_finish() {
 #[test]
 fn agent_failed_sets_error() {
     isolate("failed");
-    let mut s = WorkStatus::new_agent("test-5", "test", "sess-1", "do things").unwrap();
+    let mut s = WorkStatus::new_agent("test-5", "test", "sess-1", "do things", None).unwrap();
     s.mark_failed("something broke".into()).unwrap();
     assert_eq!(s.state, WorkState::Failed);
     let finish = s.finish.as_ref().expect("failed stamps a finish");
@@ -116,7 +116,7 @@ fn agent_failed_sets_error() {
 #[test]
 fn agent_read_roundtrip() {
     isolate("roundtrip");
-    let mut s = WorkStatus::new_agent("test-6", "test", "sess-1", "do things").unwrap();
+    let mut s = WorkStatus::new_agent("test-6", "test", "sess-1", "do things", None).unwrap();
     s.mark_running().unwrap();
     s.update_progress(2, Some("write_file".into()), None)
         .unwrap();
@@ -221,7 +221,7 @@ fn interrupted_error_text_is_kind_aware() {
     // Agents keep the exact pre-#26 sentence; commands get the same
     // sentence about a command.
     isolate("interrupted_text");
-    let mut agent = WorkStatus::new_agent("agt-i", "a", "sess-1", "p").unwrap();
+    let mut agent = WorkStatus::new_agent("agt-i", "a", "sess-1", "p", None).unwrap();
     agent.mark_interrupted().unwrap();
     let mut command = WorkStatus::new_command("cmd-i", "sess-1", "c", "sleep 9").unwrap();
     command.mark_interrupted().unwrap();
@@ -243,7 +243,7 @@ fn interrupted_error_text_is_kind_aware() {
 #[test]
 fn cleanup_removes_old_files() {
     isolate("cleanup");
-    let mut s = WorkStatus::new_agent("old-1", "old", "sess", "task").unwrap();
+    let mut s = WorkStatus::new_agent("old-1", "old", "sess", "task", None).unwrap();
     s.mark_completed("done".into()).unwrap();
 
     let old_ts = chrono::Utc::now()

--- a/src/tests/brain_tools_subagent_reconcile_test.rs
+++ b/src/tests/brain_tools_subagent_reconcile_test.rs
@@ -25,7 +25,7 @@ fn isolate(tag: &str) {
 #[test]
 fn a_running_agent_becomes_interrupted() {
     isolate("running");
-    let mut s = WorkStatus::new_agent("agent-1", "build docs", "sess-a", "do things").unwrap();
+    let mut s = WorkStatus::new_agent("agent-1", "build docs", "sess-a", "do things", None).unwrap();
     s.mark_running().unwrap();
 
     let orphans = reconcile_orphaned_agents();
@@ -43,7 +43,7 @@ fn a_running_agent_becomes_interrupted() {
 fn a_pending_agent_becomes_interrupted() {
     // Killed between the status file being written and the task starting.
     isolate("pending");
-    WorkStatus::new_agent("agent-2", "lint", "sess-b", "do things").unwrap();
+    WorkStatus::new_agent("agent-2", "lint", "sess-b", "do things", None).unwrap();
 
     let orphans = reconcile_orphaned_agents();
 
@@ -58,7 +58,7 @@ fn a_parked_agent_becomes_interrupted() {
     // existed such a file read `Running` and was swept by the same rule, and
     // the new variant must not slip through it.
     isolate("parked");
-    let mut s = WorkStatus::new_agent("agent-4", "audit", "sess-d", "do things").unwrap();
+    let mut s = WorkStatus::new_agent("agent-4", "audit", "sess-d", "do things", None).unwrap();
     s.mark_running().unwrap();
     s.mark_awaiting_input().unwrap();
 
@@ -76,7 +76,7 @@ fn interrupted_carries_a_reason_and_a_completion_stamp() {
     // stamp lets the file age out on the same schedule as any other
     // terminal state.
     isolate("reason");
-    let mut s = WorkStatus::new_agent("agent-3", "test", "sess-c", "do things").unwrap();
+    let mut s = WorkStatus::new_agent("agent-3", "test", "sess-c", "do things", None).unwrap();
     s.mark_running().unwrap();
 
     let orphans = reconcile_orphaned_agents();
@@ -96,9 +96,9 @@ fn interrupted_carries_a_reason_and_a_completion_stamp() {
 #[test]
 fn terminal_agents_are_left_alone() {
     isolate("terminal");
-    let mut done = WorkStatus::new_agent("agent-done", "a", "sess-d", "p").unwrap();
+    let mut done = WorkStatus::new_agent("agent-done", "a", "sess-d", "p", None).unwrap();
     done.mark_completed("output".to_string()).unwrap();
-    let mut failed = WorkStatus::new_agent("agent-failed", "b", "sess-d", "p").unwrap();
+    let mut failed = WorkStatus::new_agent("agent-failed", "b", "sess-d", "p", None).unwrap();
     failed.mark_failed("boom".to_string()).unwrap();
 
     let orphans = reconcile_orphaned_agents();
@@ -119,7 +119,7 @@ fn the_parent_session_survives_so_the_report_can_be_routed() {
     // The whole point of returning the statuses: the caller needs to know
     // which session to tell.
     isolate("parent");
-    let mut s = WorkStatus::new_agent("agent-4", "deploy", "sess-parent", "p").unwrap();
+    let mut s = WorkStatus::new_agent("agent-4", "deploy", "sess-parent", "p", None).unwrap();
     s.mark_running().unwrap();
 
     let orphans = reconcile_orphaned_agents();
@@ -131,7 +131,7 @@ fn the_parent_session_survives_so_the_report_can_be_routed() {
 fn reconciling_is_idempotent() {
     // A second startup must not re-report an agent already accounted for.
     isolate("idempotent");
-    let mut s = WorkStatus::new_agent("agent-5", "x", "sess-e", "p").unwrap();
+    let mut s = WorkStatus::new_agent("agent-5", "x", "sess-e", "p", None).unwrap();
     s.mark_running().unwrap();
 
     assert_eq!(reconcile_orphaned_agents().len(), 1);
@@ -149,7 +149,7 @@ fn unparseable_files_do_not_abort_the_pass() {
     isolate("corrupt");
     ensure_dir().unwrap();
     fs::write(status_dir().join("garbage.json"), "not json at all").unwrap();
-    let mut s = WorkStatus::new_agent("agent-6", "y", "sess-f", "p").unwrap();
+    let mut s = WorkStatus::new_agent("agent-6", "y", "sess-f", "p", None).unwrap();
     s.mark_running().unwrap();
 
     let orphans = reconcile_orphaned_agents();
@@ -191,7 +191,7 @@ fn a_running_command_is_interrupted_on_disk_but_not_reported() {
 #[test]
 fn mixed_kinds_report_only_the_agents() {
     isolate("mixed");
-    let mut agent = WorkStatus::new_agent("agent-m", "docs", "sess-m", "p").unwrap();
+    let mut agent = WorkStatus::new_agent("agent-m", "docs", "sess-m", "p", None).unwrap();
     agent.mark_running().unwrap();
     WorkStatus::new_command("cmd-m", "sess-m", "build", "make").unwrap();
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -66,6 +66,7 @@ pub mod brain_agent_context_test;
 pub mod brain_agent_service_phantom_lang_test;
 pub mod brain_agent_service_phantom_test;
 pub mod brain_agent_service_work_status_test;
+pub mod work_status_parent_binding_test;
 pub mod brain_commands_test;
 pub mod brain_file_generic_guard_test;
 pub mod brain_file_safety_test;

--- a/src/tests/work_status_parent_binding_test.rs
+++ b/src/tests/work_status_parent_binding_test.rs
@@ -1,0 +1,153 @@
+//! Parent-binding tests for the boot-resume path (#110).
+//!
+//! A revived sub-agent session must be recognizable from its status file and
+//! the file must carry the spawning session: without that binding the
+//! resumed result routes to the surface-less default and vanishes.
+
+use crate::brain::agent::service::work_status::{WorkKind, WorkState, WorkStatus};
+use uuid::Uuid;
+
+fn temp_status_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "oc-ws-parent-test-{tag}-{}-{}",
+        std::process::id(),
+        Uuid::new_v4().simple()
+    ));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    crate::brain::agent::service::work_status::test_override::set(dir.clone());
+    dir
+}
+
+fn drop_status_dir(dir: std::path::PathBuf) {
+    crate::brain::agent::service::work_status::test_override::clear();
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn status_file_carries_parent_and_lookup_finds_child() {
+    let dir = temp_status_dir("carry");
+    let child = Uuid::new_v4();
+    let parent = Uuid::new_v4();
+
+    WorkStatus::new_agent(
+        "agent-carry",
+        "review lens",
+        &child.to_string(),
+        "do the review",
+        Some(&parent.to_string()),
+    )
+    .expect("write status");
+
+    // Round-trip: the parent survives the disk write.
+    let status = WorkStatus::read("agent-carry").expect("status exists");
+    assert_eq!(
+        status.parent_session_id.as_deref(),
+        Some(parent.to_string().as_str())
+    );
+    assert_eq!(status.session_id, child.to_string());
+    assert!(!status.state.is_terminal());
+
+    // The resume path's detector: found by child session, non-terminal.
+    let found = WorkStatus::find_agent_by_session(&child.to_string()).expect("found");
+    assert_eq!(found.id, "agent-carry");
+    assert_eq!(
+        found.parent_session_id.as_deref(),
+        Some(parent.to_string().as_str())
+    );
+
+    // Unknown session: no hit, no panic.
+    assert!(WorkStatus::find_agent_by_session(&Uuid::new_v4().to_string()).is_none());
+
+    drop_status_dir(dir);
+}
+
+#[test]
+fn interrupted_file_is_still_detected_after_reconcile() {
+    let dir = temp_status_dir("interrupted");
+    let child = Uuid::new_v4();
+    let parent = Uuid::new_v4();
+
+    let mut agent = WorkStatus::new_agent(
+        "agent-int",
+        "restarted lens",
+        &child.to_string(),
+        "task",
+        Some(&parent.to_string()),
+    )
+    .expect("write status");
+
+    // Upstream reconciliation marks the file Interrupted at boot, before
+    // the resumed session finishes — the detector must still find it.
+    agent.mark_interrupted().expect("mark interrupted");
+    assert!(agent.state.is_terminal());
+    let found = WorkStatus::find_agent_by_session(&child.to_string()).expect("found");
+    assert_eq!(found.id, "agent-int");
+    assert_eq!(
+        found.parent_session_id.as_deref(),
+        Some(parent.to_string().as_str())
+    );
+
+    drop_status_dir(dir);
+}
+
+#[test]
+fn legacy_file_without_parent_deserializes_and_is_skipped_by_nothing() {
+    let dir = temp_status_dir("legacy");
+    let child = Uuid::new_v4();
+    let path = crate::brain::agent::service::work_status::status_path("agent-legacy");
+    let body = format!(
+        r#"{{"id":"agent-legacy","kind":"agent","session_id":"{child}","label":"old","task":"p","spawned_at":"2026-01-01T00:00:00Z","state":"Running"}}"#
+    );
+    std::fs::write(&path, body).expect("write legacy file");
+
+    let status = WorkStatus::read("agent-legacy").expect("legacy parses");
+    assert!(
+        status.parent_session_id.is_none(),
+        "legacy file has no parent"
+    );
+    assert_eq!(status.session_id, child.to_string());
+    // Still detected as a revived agent (so its result at least finalizes the
+    // file), but with no parent to route to.
+    assert!(WorkStatus::find_agent_by_session(&child.to_string()).is_some());
+
+    drop_status_dir(dir);
+}
+
+#[test]
+fn lookup_skips_commands_and_outcome_terminal_agents() {
+    let dir = temp_status_dir("skip");
+    let child = Uuid::new_v4();
+
+    // A detached command sharing the session id must not look like an agent.
+    WorkStatus::new_command("cmd-1", &child.to_string(), "a command", "ls")
+        .expect("write command status");
+    assert!(WorkStatus::find_agent_by_session(&child.to_string()).is_none());
+
+    // An outcome-terminal agent must not look revivable.
+    let mut agent = WorkStatus::new_agent(
+        "agent-done",
+        "finished lens",
+        &child.to_string(),
+        "task",
+        None,
+    )
+    .expect("write agent status");
+    agent.mark_completed("done".to_string()).expect("finalize");
+    assert!(matches!(agent.state, WorkState::Completed));
+    assert_eq!(agent.kind, WorkKind::Agent);
+    assert!(WorkStatus::find_agent_by_session(&child.to_string()).is_none());
+
+    // A failed agent is equally final.
+    let mut agent = WorkStatus::new_agent(
+        "agent-fail",
+        "failed lens",
+        &child.to_string(),
+        "task",
+        None,
+    )
+    .expect("write agent status");
+    agent.mark_failed("boom".to_string()).expect("finalize");
+    assert!(WorkStatus::find_agent_by_session(&child.to_string()).is_none());
+
+    drop_status_dir(dir);
+}

--- a/src/tui/onboarding/fetch.rs
+++ b/src/tui/onboarding/fetch.rs
@@ -381,6 +381,12 @@ pub async fn fetch_provider_models(
             .and_then(|c| c.providers.xiaomi.clone())
             .map(|p| p.models)
             .unwrap_or_default();
+        if api_models.is_empty() {
+            // Live fetch failed (401 / offline) — fall back to the binary
+            // baseline so the picker is never empty (#1419). Mirrors the
+            // MiniMax fallback above.
+            return merge_minimax_baseline(xiaomi_baseline_models(), user_models);
+        }
         return merge_minimax_baseline(api_models, user_models);
     }
 
@@ -759,6 +765,22 @@ fn minimax_baseline_models() -> Vec<String> {
         "MiniMax-M2.1".to_string(),
         "MiniMax-M2.1-highspeed".to_string(),
         "MiniMax-M2".to_string(),
+    ]
+}
+
+/// Binary's known Xiaomi MiMo models, used as fallback when the live
+/// /models fetch fails — the endpoint is keyless but geo/credential
+/// sensitive (401 on some CI runners, #1419). Newest first so the
+/// picker highlights the current model. Live fetch is the primary
+/// source — this only covers offline / unreachable-API scenarios.
+fn xiaomi_baseline_models() -> Vec<String> {
+    vec![
+        "mimo-v2.5-pro".to_string(),
+        "mimo-v2-pro".to_string(),
+        "mimo-v2-omni".to_string(),
+        "mimo-v2-flash".to_string(),
+        "mimo-v2-pro-free".to_string(),
+        "mimo-v2-omni-free".to_string(),
     ]
 }
 


### PR DESCRIPTION
## Revived sub-agent's result is lost — bind sub-agent status to the spawning session

### Problem

Upstream (as of v0.5.0) has a gap in sub-agent restart recovery:

1. `spawn.rs` writes the **child's own session id** into `WorkStatus.session_id`, while `restart_recovery.rs` routes the boot-time interruption report to that same field **assuming it is the parent** ("routing interruption reports by the pre-#26 parent_session_id value" per its own comments). The report therefore goes to the dead child session, not to the parent that is waiting for the result.
2. If the child's session *is* resumed by boot-resume and completes, the completion outcome is routed to the recorded surface (default `tui`) — nobody receives it. The parent never learns the agent finished, and the status file is left non-terminal.

Observed live on a production fork deployment: a revived sub-agent finished its work, the parent received nothing, and the status file zombied at `Running`.

### Fix (mirrors a fix proven in production on a fork deployment)

- `work_status.rs`: `WorkStatus` gains `parent_session_id: Option<String>`, stamped at spawn (before the first status write). New helper `find_agent_by_session` finds a non-outcome-terminal agent (`Pending`/`Running`/`Interrupted`/`AwaitingInput`) by its session id — `Interrupted` is included because reconcile marks the file at boot *before* the resumed child completes.
- `spawn.rs`: passes the spawning session at both construction sites.
- `restart_recovery.rs`: interruption reports route to the parent when the child session carries a parent binding (falls back to prior behavior when absent); new `deliver_revived_agent_outcome` delivers the resumed child's outcome to the parent and finalizes the status file.
- `cli/ui.rs`: both resume-completion arms check `find_agent_by_session` and route via `deliver_revived_agent_outcome`, skipping the phantom-surface path.
- `work_status_parent_binding_test.rs`: 5 tests (parent round-trip, lookup hit/miss/skip, legacy files without the field parse as `None`).

`parent_session_id` is `Option` + `skip_serializing_if`, so existing on-disk status files parse unchanged.

### Compatibility

The xiaomi baseline-fallback commit (`14693733`) is included only because fork CI runners get a 401 from the keyless Xiaomi `/models` endpoint (upstream runners get 200); it is unrelated to the parent-binding change and can be dropped if preferred. All other commits touch only the parent-binding change plus its required test call-site updates.

### Verification

- Fork CI on this exact tree: [run 34115588981](https://github.com/leshchenko1979/opencrabs/actions/runs/34115588981) (job name carries the full tested sha `14693733…`).
- Live-fire proof on the fork deployment: sacrificial sub-agent spawned → daemon bounced mid-run → boot-resume revived the child → **parent received the child's result verbatim**, status file finalized (`Completed` + `completed_at`). Same scenario pre-fix: result lost to the `tui` surface, status zombied.

Related fork issues: [leshchenko1979/opencrabs#110](https://github.com/leshchenko1979/opencrabs/issues/110) (defect + live-fire evidence), [leshchenko1979/opencrabs#113](https://github.com/leshchenko1979/opencrabs/issues/113) (v0.5.0 delta analysis).
