### PR TITLE
feat(compaction): advisory skill-inventory stamp on post-compaction prompts

### DIFF
--- a/src/brain/agent/service/compaction_prompts.rs
+++ b/src/brain/agent/service/compaction_prompts.rs
@@ -141,6 +141,33 @@ pub fn build_continuation(
     text
 }
 
+/// Advisory skill-inventory stamp (#125): names the skills that were
+/// active (slash-invoked) in this session before the compaction, framed
+/// as CONSIDER-not-RELOAD — the session's focus may have shifted while
+/// the context was compacting, so the waking agent weighs each skill's
+/// relevance against the IMMEDIATE TASK instead of blindly re-reading
+/// bodies it may no longer need. An empty slice produces NO stamp at
+/// all: zero marginal tokens for sessions that never touched a skill.
+///
+/// The list rides the continuation prompt (mechanically composed from
+/// in-memory session state at build time), so it is immune to the
+/// summarizer's token-budget drops — the durable-state property the
+/// research phase identified as the gap.
+pub fn append_skill_stamp(mut text: String, active_skills: &[String]) -> String {
+    if active_skills.is_empty() {
+        return text;
+    }
+    let mut names: Vec<&str> = active_skills.iter().map(|s| s.as_str()).collect();
+    names.sort();
+    text.push_str(&format!(
+        "\n\nSKILLS LOADED PRE-COMPACTION: {}. Session focus may have \
+         shifted — consider whether each is still relevant to the \
+         IMMEDIATE TASK; reload only those that are.",
+        names.join(", ")
+    ));
+    text
+}
+
 fn fun_body(kind: CompactionKind) -> &'static str {
     match kind {
         CompactionKind::Regular => {

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -1195,11 +1195,17 @@ impl AgentService {
                     // auto-compaction behavior but uses a short sentence instead
                     // of the full POST-COMPACTION PROTOCOL. Persisted to DB so
                     // the next turn sees it.
-                    let cont_text = super::compaction_prompts::build_continuation(
-                        super::compaction_prompts::CompactionKind::Manual,
-                        self.silent_compaction,
-                        self.auto_approve_tools,
-                        super::compaction_prompts::PlanRecovery::for_session(session_id).await,
+                    let cont_text = super::compaction_prompts::append_skill_stamp(
+                        super::compaction_prompts::build_continuation(
+                            super::compaction_prompts::CompactionKind::Manual,
+                            self.silent_compaction,
+                            self.auto_approve_tools,
+                            super::compaction_prompts::PlanRecovery::for_session(session_id).await,
+                        ),
+                        &self
+                            .active_skills_for_session(session_id)
+                            .into_iter()
+                            .collect::<Vec<_>>(),
                     );
                     message_service
                         .create_message(session_id, "user".to_string(), cont_text.clone())
@@ -1308,11 +1314,17 @@ impl AgentService {
                 tracing::error!("Failed to persist compaction marker to DB: {}", e);
             }
 
-            let cont_text = super::compaction_prompts::build_continuation(
-                super::compaction_prompts::CompactionKind::Regular,
-                self.silent_compaction,
-                self.auto_approve_tools,
-                super::compaction_prompts::PlanRecovery::for_session(session_id).await,
+            let cont_text = super::compaction_prompts::append_skill_stamp(
+                super::compaction_prompts::build_continuation(
+                    super::compaction_prompts::CompactionKind::Regular,
+                    self.silent_compaction,
+                    self.auto_approve_tools,
+                    super::compaction_prompts::PlanRecovery::for_session(session_id).await,
+                ),
+                &self
+                    .active_skills_for_session(session_id)
+                    .into_iter()
+                    .collect::<Vec<_>>(),
             );
             context.add_message(Message::user(cont_text));
         }
@@ -1786,11 +1798,17 @@ impl AgentService {
                     tracing::error!("Failed to persist mid-loop compaction marker to DB: {}", e);
                 }
 
-                let cont_text = super::compaction_prompts::build_continuation(
-                    super::compaction_prompts::CompactionKind::MidLoop,
-                    self.silent_compaction,
-                    self.auto_approve_tools,
-                    super::compaction_prompts::PlanRecovery::for_session(session_id).await,
+                let cont_text = super::compaction_prompts::append_skill_stamp(
+                    super::compaction_prompts::build_continuation(
+                        super::compaction_prompts::CompactionKind::MidLoop,
+                        self.silent_compaction,
+                        self.auto_approve_tools,
+                        super::compaction_prompts::PlanRecovery::for_session(session_id).await,
+                    ),
+                    &self
+                        .active_skills_for_session(session_id)
+                        .into_iter()
+                        .collect::<Vec<_>>(),
                 );
                 context.add_message(Message::user(cont_text));
             }
@@ -2065,12 +2083,20 @@ impl AgentService {
                                 );
                             }
 
-                            let cont_text = super::compaction_prompts::build_continuation(
-                                super::compaction_prompts::CompactionKind::Emergency,
-                                self.silent_compaction,
-                                self.auto_approve_tools,
-                                super::compaction_prompts::PlanRecovery::for_session(session_id)
+                            let cont_text = super::compaction_prompts::append_skill_stamp(
+                                super::compaction_prompts::build_continuation(
+                                    super::compaction_prompts::CompactionKind::Emergency,
+                                    self.silent_compaction,
+                                    self.auto_approve_tools,
+                                    super::compaction_prompts::PlanRecovery::for_session(
+                                        session_id,
+                                    )
                                     .await,
+                                ),
+                                &self
+                                    .active_skills_for_session(session_id)
+                                    .into_iter()
+                                    .collect::<Vec<_>>(),
                             );
                             context.add_message(Message::user(cont_text));
 
@@ -7271,11 +7297,17 @@ impl AgentService {
                     tracing::error!("Failed to persist post-tool compaction marker to DB: {}", e);
                 }
 
-                let cont_text = super::compaction_prompts::build_continuation(
-                    super::compaction_prompts::CompactionKind::PostTool,
-                    self.silent_compaction,
-                    self.auto_approve_tools,
-                    super::compaction_prompts::PlanRecovery::for_session(session_id).await,
+                let cont_text = super::compaction_prompts::append_skill_stamp(
+                    super::compaction_prompts::build_continuation(
+                        super::compaction_prompts::CompactionKind::PostTool,
+                        self.silent_compaction,
+                        self.auto_approve_tools,
+                        super::compaction_prompts::PlanRecovery::for_session(session_id).await,
+                    ),
+                    &self
+                        .active_skills_for_session(session_id)
+                        .into_iter()
+                        .collect::<Vec<_>>(),
                 );
                 context.add_message(Message::user(cont_text));
             }

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -453,6 +453,30 @@ pub fn is_user_correction(msg: &str) -> bool {
 }
 
 impl AgentService {
+    /// Build the post-compaction continuation prompt for `kind` — the single
+    /// construction path shared by all five compaction sites (Regular,
+    /// MidLoop, Emergency, PostTool, Manual): continuation body + plan
+    /// recovery + advisory skill-inventory stamp (issue #125).
+    async fn continuation_prompt(
+        &self,
+        session_id: Uuid,
+        kind: super::compaction_prompts::CompactionKind,
+    ) -> String {
+        let skills = self
+            .active_skills_for_session(session_id)
+            .into_iter()
+            .collect::<Vec<_>>();
+        super::compaction_prompts::append_skill_stamp(
+            super::compaction_prompts::build_continuation(
+                kind,
+                self.silent_compaction,
+                self.auto_approve_tools,
+                super::compaction_prompts::PlanRecovery::for_session(session_id).await,
+            ),
+            &skills,
+        )
+    }
+
     /// Core tool-execution loop — called by all public shims.
     /// `override_approval_callback` and `override_progress_callback` take
     /// precedence over the service-level callbacks (used by Telegram, etc.)
@@ -1195,18 +1219,12 @@ impl AgentService {
                     // auto-compaction behavior but uses a short sentence instead
                     // of the full POST-COMPACTION PROTOCOL. Persisted to DB so
                     // the next turn sees it.
-                    let cont_text = super::compaction_prompts::append_skill_stamp(
-                        super::compaction_prompts::build_continuation(
+                    let cont_text = self
+                        .continuation_prompt(
+                            session_id,
                             super::compaction_prompts::CompactionKind::Manual,
-                            self.silent_compaction,
-                            self.auto_approve_tools,
-                            super::compaction_prompts::PlanRecovery::for_session(session_id).await,
-                        ),
-                        &self
-                            .active_skills_for_session(session_id)
-                            .into_iter()
-                            .collect::<Vec<_>>(),
-                    );
+                        )
+                        .await;
                     message_service
                         .create_message(session_id, "user".to_string(), cont_text.clone())
                         .await
@@ -1314,18 +1332,12 @@ impl AgentService {
                 tracing::error!("Failed to persist compaction marker to DB: {}", e);
             }
 
-            let cont_text = super::compaction_prompts::append_skill_stamp(
-                super::compaction_prompts::build_continuation(
+            let cont_text = self
+                .continuation_prompt(
+                    session_id,
                     super::compaction_prompts::CompactionKind::Regular,
-                    self.silent_compaction,
-                    self.auto_approve_tools,
-                    super::compaction_prompts::PlanRecovery::for_session(session_id).await,
-                ),
-                &self
-                    .active_skills_for_session(session_id)
-                    .into_iter()
-                    .collect::<Vec<_>>(),
-            );
+                )
+                .await;
             context.add_message(Message::user(cont_text));
         }
 
@@ -1798,18 +1810,12 @@ impl AgentService {
                     tracing::error!("Failed to persist mid-loop compaction marker to DB: {}", e);
                 }
 
-                let cont_text = super::compaction_prompts::append_skill_stamp(
-                    super::compaction_prompts::build_continuation(
+                let cont_text = self
+                    .continuation_prompt(
+                        session_id,
                         super::compaction_prompts::CompactionKind::MidLoop,
-                        self.silent_compaction,
-                        self.auto_approve_tools,
-                        super::compaction_prompts::PlanRecovery::for_session(session_id).await,
-                    ),
-                    &self
-                        .active_skills_for_session(session_id)
-                        .into_iter()
-                        .collect::<Vec<_>>(),
-                );
+                    )
+                    .await;
                 context.add_message(Message::user(cont_text));
             }
 
@@ -2083,21 +2089,12 @@ impl AgentService {
                                 );
                             }
 
-                            let cont_text = super::compaction_prompts::append_skill_stamp(
-                                super::compaction_prompts::build_continuation(
+                            let cont_text = self
+                                .continuation_prompt(
+                                    session_id,
                                     super::compaction_prompts::CompactionKind::Emergency,
-                                    self.silent_compaction,
-                                    self.auto_approve_tools,
-                                    super::compaction_prompts::PlanRecovery::for_session(
-                                        session_id,
-                                    )
-                                    .await,
-                                ),
-                                &self
-                                    .active_skills_for_session(session_id)
-                                    .into_iter()
-                                    .collect::<Vec<_>>(),
-                            );
+                                )
+                                .await;
                             context.add_message(Message::user(cont_text));
 
                             // Notify user about emergency compaction
@@ -7297,18 +7294,12 @@ impl AgentService {
                     tracing::error!("Failed to persist post-tool compaction marker to DB: {}", e);
                 }
 
-                let cont_text = super::compaction_prompts::append_skill_stamp(
-                    super::compaction_prompts::build_continuation(
+                let cont_text = self
+                    .continuation_prompt(
+                        session_id,
                         super::compaction_prompts::CompactionKind::PostTool,
-                        self.silent_compaction,
-                        self.auto_approve_tools,
-                        super::compaction_prompts::PlanRecovery::for_session(session_id).await,
-                    ),
-                    &self
-                        .active_skills_for_session(session_id)
-                        .into_iter()
-                        .collect::<Vec<_>>(),
-                );
+                    )
+                    .await;
                 context.add_message(Message::user(cont_text));
             }
 

--- a/src/tests/compaction_prompts_test.rs
+++ b/src/tests/compaction_prompts_test.rs
@@ -20,7 +20,7 @@
 //!   auto_approve=false.
 
 use crate::brain::agent::service::compaction_prompts::{
-    CompactionKind, PlanRecovery, build_continuation,
+    CompactionKind, PlanRecovery, append_skill_stamp, build_continuation,
 };
 
 const APPROVAL_TAIL: &str = "Tool approval is REQUIRED";
@@ -213,4 +213,93 @@ fn manual_compaction_is_brief() {
             "Manual compaction must still reference the IMMEDIATE TASK: {body}"
         );
     }
+}
+
+// ── #125: advisory skill-inventory stamp ────────────────────────────────────
+//
+// The stamp must: (1) carry the sorted skill list with the advisory
+// "consider, reload only those" framing, (2) be absent entirely when no
+// skills were active (zero marginal tokens), (3) ride EVERY compaction
+// kind in both fun and silent variants. String sentinels, same policy
+// as the rest of this file: exact wording may drift, these invariants
+// must not.
+
+const STAMP_HEADER: &str = "SKILLS LOADED PRE-COMPACTION:";
+const STAMP_ADVISORY: &str = "reload only those that are";
+
+#[test]
+fn skill_stamp_lists_active_skills_with_advisory_framing() {
+    let body = build_continuation(CompactionKind::Regular, false, true, PlanRecovery::Active);
+    let stamped = append_skill_stamp(body, &["opencrabs-dev".to_string(), "grafana".to_string()]);
+    assert!(
+        stamped.contains(STAMP_HEADER),
+        "stamp must carry the inventory header: {stamped}"
+    );
+    assert!(
+        stamped.contains("opencrabs-dev") && stamped.contains("grafana"),
+        "stamp must list every active skill: {stamped}"
+    );
+    assert!(
+        stamped.contains(STAMP_ADVISORY),
+        "stamp must be advisory (consider, reload selectively) not prescriptive: {stamped}"
+    );
+}
+
+#[test]
+fn skill_stamp_is_silent_when_no_skills_active() {
+    for kind in [
+        CompactionKind::Regular,
+        CompactionKind::MidLoop,
+        CompactionKind::Emergency,
+        CompactionKind::PostTool,
+        CompactionKind::Manual,
+    ] {
+        for silent in [false, true] {
+            let body = build_continuation(kind, silent, true, PlanRecovery::NoPlan);
+            let stamped = append_skill_stamp(body, &[]);
+            assert!(
+                !stamped.contains(STAMP_HEADER),
+                "{kind:?} silent={silent}: no skills → no stamp, zero marginal tokens: {stamped}"
+            );
+        }
+    }
+}
+
+#[test]
+fn skill_stamp_rides_all_kinds_and_variants() {
+    let skills = vec!["opencrabs-dev".to_string()];
+    for kind in [
+        CompactionKind::Regular,
+        CompactionKind::MidLoop,
+        CompactionKind::Emergency,
+        CompactionKind::PostTool,
+        CompactionKind::Manual,
+    ] {
+        for silent in [false, true] {
+            let body = build_continuation(kind, silent, true, PlanRecovery::Active);
+            let stamped = append_skill_stamp(body, &skills);
+            assert!(
+                stamped.contains(STAMP_HEADER) && stamped.contains(STAMP_ADVISORY),
+                "{kind:?} silent={silent}: stamp must ride every kind/variant: {stamped}"
+            );
+        }
+    }
+}
+
+#[test]
+fn skill_stamp_sorts_names_for_determinism() {
+    let body = build_continuation(CompactionKind::Regular, false, true, PlanRecovery::NoPlan);
+    let stamped = append_skill_stamp(
+        body,
+        &["zeta".to_string(), "alpha".to_string(), "mid".to_string()],
+    );
+    let header_pos = stamped.find(STAMP_HEADER).expect("stamp present");
+    let list = &stamped[header_pos..];
+    let alpha = list.find("alpha").expect("alpha present");
+    let mid = list.find("mid").expect("mid present");
+    let zeta = list.find("zeta").expect("zeta present");
+    assert!(
+        alpha < mid && mid < zeta,
+        "stamp list must be sorted for deterministic rendering: {list}"
+    );
 }


### PR DESCRIPTION
## Summary

Post-compaction continuation prompts now carry an **advisory skill-inventory stamp**: `SKILLS LOADED PRE-COMPACTION: <names>` + "consider whether each is still relevant; reload only those that are". Advisory, not prescriptive — session focus may have shifted after a compaction.

- Recording uses the existing `AgentService.active_skills` registry (#219) — peek, no new state; the map is never cleared so #219 body re-injection keeps working
- All 5 compaction kinds (Regular/MidLoop/Emergency/PostTool/Manual) × fun/silent variants
- Zero marginal LLM tokens: composed mechanically at prompt-build time; no stamp when zero skills were invoked
- Second commit: DRY — the five verbatim `build_continuation` call sites collapse into one `continuation_prompt()` helper (net −9 lines)

Original issue: leshchenko1979/opencrabs#125

## Test evidence

- Fork triad gate (fmt+clippy+tests, 7275 tests): https://github.com/leshchenko1979/opencrabs/actions/runs/34138907147 — GREEN on 5e0b7080 (identical diff to this branch's 6cfae040; upstream base was re-verified fresh 221d7423 at harvest time)
- 4 new unit tests: stamp framing, empty-set silence, all-kinds presence, sort determinism
- Live smoke: deployed binary 5e0b7080 — `SKILLS LOADED PRE-COMPACTION` string present in /proc exe, disk==proc verified
