### PR TITLE
fix(telegram): route bg-resume sends through the native rich wire (guard preserved)

### DIFF
--- a/src/channels/telegram/resume.rs
+++ b/src/channels/telegram/resume.rs
@@ -171,17 +171,17 @@ pub(crate) fn build_enqueue_callback(
                     // Alexey's rule). The CLI lane (#1258) stamps
                     // `from=cli:<label>` instead — no sender session exists,
                     // so the carried label renders verbatim, zero lookups.
-                    let (echo_md, classic_html) = if let Some(meta) = msg.bg_meta.clone() {
+                    let (wire, classic_html) = if let Some(meta) = msg.bg_meta.clone() {
                         build_bg_receipt_card(&meta)
                     } else {
                         let (sender, body) = split_bg_echo_parts(&msg.context_text);
                         match sender {
                             Some(NotifySender::Session(s)) => {
                                 let label = sender_label(&state, &bot, s, chat_id).await;
-                                build_notify_receipt_card(&label, &body)
+                                build_notify_receipt_card(&label, &body).await
                             }
                             Some(NotifySender::CliTooling(label)) => {
-                                build_notify_receipt_card(label, &body)
+                                build_notify_receipt_card(label, &body).await
                             }
                             // Defensive: a BackgroundTask push without meta
                             // (parked by an older binary, #1242 redelivery) keeps
@@ -196,27 +196,67 @@ pub(crate) fn build_enqueue_callback(
                             None => build_bg_echo_bubble(&body, "⚙️ background task result"),
                         }
                     };
-                    // #1234/#15: the card rides the CANONICAL markdown→rich
-                    // outbox (the same pipeline as every cron/kanal message);
-                    // the native-rich route renders the <details> collapse, the
-                    // fenced tail and pipe tables server-side. The classic
-                    // blockquote above is the degraded-path source: computed up
-                    // front, only touched if the outbox send fails.
-                    let sent_rich = match super::send::send_markdown_outbox(
-                        &bot,
-                        teloxide::types::ChatId(chat_id),
-                        thread_id,
-                        &echo_md,
-                        "bg-resume",
-                        "-",
-                        None,
-                    )
-                    .await
-                    {
-                        Ok(_) => true,
-                        Err(e) => {
-                            tracing::warn!("[bg-resume] #1234 rich echo failed, using HTML: {e}");
-                            false
+                    // #85 (re-landing #38 / 29b5731d): the wire is the card
+                    // builder's decision. `<details>` chrome cards ride the HTML
+                    // input mode, where the wrapper parses into a native
+                    // RichBlockDetails collapsible — the markdown rich mode
+                    // cannot express it (rich/api.rs dialect rule), and routing
+                    // those cards through the #1234 markdown outbox is what
+                    // leaked escaped tags into the chat (3x RICH_MESSAGE_EMPTY
+                    // + visible wrapper text on 2026-08-29). Plain markdown
+                    // bubbles keep the canonical outbox. On rich failure the
+                    // classic blockquote below is the LIVE degradation:
+                    // send_rich_html_id returns Err to this caller instead of
+                    // being swallowed inside the outbox.
+                    let rich_on = crate::config::Config::current()
+                        .channels
+                        .telegram
+                        .rich_messages;
+                    let sent_rich = match (&wire, rich_on) {
+                        (BubbleWire::Html(html), true) => {
+                            match super::rich::api::send_rich_html_id(
+                                bot.api_url().as_str(),
+                                bot.token(),
+                                chat_id,
+                                thread_id,
+                                html,
+                                None,
+                                "bg-resume",
+                                "-",
+                            )
+                            .await
+                            {
+                                Ok(_) => true,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "[bg-resume] #38 rich HTML send failed, using HTML: {e}"
+                                    );
+                                    false
+                                }
+                            }
+                        }
+                        // Config gate: rich disabled → classic blockquote below.
+                        (BubbleWire::Html(_), false) => false,
+                        (BubbleWire::Markdown(md), _) => {
+                            match super::send::send_markdown_outbox(
+                                &bot,
+                                teloxide::types::ChatId(chat_id),
+                                thread_id,
+                                md,
+                                "bg-resume",
+                                "-",
+                                None,
+                            )
+                            .await
+                            {
+                                Ok(_) => true,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "[bg-resume] #1234 rich echo failed, using HTML: {e}"
+                                    );
+                                    false
+                                }
+                            }
                         }
                     };
                     if !sent_rich {
@@ -967,12 +1007,30 @@ fn strip_push_scaffolding(rest: &str) -> String {
     }
 }
 
+/// The wire a wake bubble's rich leg rides (#38, re-landed by #85).
+///
+/// `<details>` chrome cards MUST use the HTML input mode: the markdown rich
+/// mode cannot express the collapsible (rich/api.rs dialect rule; the #421
+/// revert proved that route ships flat), and routing those cards through
+/// the #1234 markdown outbox is what leaked escaped tags into the chat
+/// (issue #38, 2026-08-29 — the outbox's internal fallback re-escaped the
+/// wrapper into visible `<details>` text). Plain markdown bubbles keep the
+/// canonical outbox — tables and fences stay native there. Senders branch
+/// on this enum; see the bg-resume call site.
+pub(crate) enum BubbleWire {
+    /// HTML input mode via `rich::api::send_rich_html_id` (#420 path A).
+    Html(String),
+    /// Canonical markdown outbox via `send::send_markdown_outbox` (#1234).
+    Markdown(String),
+}
+
 /// Assemble the echo bubble from the clean body + title. Returns the
-/// rich-capable markdown and the classic HTML blockquote fallback. Raw text
-/// is truncated BEFORE conversion so the wrapper tags stay well-formed —
-/// cutting rendered HTML can split a tag and make Telegram strip the
-/// formatting entirely (plan_card lesson).
-pub(crate) fn build_bg_echo_bubble(body: &str, title: &str) -> (String, String) {
+/// rich-capable markdown on the canonical markdown-outbox wire and the
+/// classic HTML blockquote fallback. Raw text is truncated BEFORE
+/// conversion so the wrapper tags stay well-formed — cutting rendered HTML
+/// can split a tag and make Telegram strip the formatting entirely
+/// (plan_card lesson).
+pub(crate) fn build_bg_echo_bubble(body: &str, title: &str) -> (BubbleWire, String) {
     let truncated = body.chars().count() > BG_ECHO_BODY_CAP_CHARS;
     let body = crate::utils::string::truncate_chars(body, BG_ECHO_BODY_CAP_CHARS);
     let suffix = if truncated { " (truncated)" } else { "" };
@@ -985,7 +1043,7 @@ pub(crate) fn build_bg_echo_bubble(body: &str, title: &str) -> (String, String) 
         suffix,
         super::rich::markdown_to_html(body),
     );
-    (markdown, html)
+    (BubbleWire::Markdown(markdown), html)
 }
 
 /// The bg-receipt tail fence (#15): three backticks normally, but ONE MORE
@@ -1085,15 +1143,17 @@ pub(crate) async fn fold_bg_ack_into_flow_card(
 }
 
 /// Background-task receipt card (#15, owner-locked shape P3f): ONE collapsed
-/// `<details>`. Summary = `<sub>{✅|❌} `{label}` 🕒 {duration}</sub>` — icon
-/// by exit 0 / non-zero as the sole outcome signal (no exit code, no
-/// wording), label = the roster `short_label` form in inline code. Body =
-/// ONE fenced code block with the output tail verbatim. Returns (rich
-/// markdown, classic HTML fallback). The markdown leg feeds
-/// [`super::send::send_markdown_outbox`], whose native-rich route renders
-/// the collapsible + code block server-side — the shape the owner-approved
-/// prototypes proved on screen (topic 31847).
-pub(crate) fn build_bg_receipt_card(meta: &crate::brain::agent::BgTaskMeta) -> (String, String) {
+/// `<details>`. Summary = `<sub>{✅|❌} <code>{label}</code> 🕒 {duration}</sub>`
+/// — icon by exit 0 / non-zero as the sole outcome signal (no exit code, no
+/// wording), label = the roster `short_label` form in monospace. Body = the
+/// output tail verbatim inside `<pre>`. Rich leg rides the HTML wire
+/// ([`BubbleWire::Html`]: send_rich_html_id parses the wrapper into a
+/// native collapsible — the markdown rich mode cannot, #38/#85), visually
+/// identical to the owner-approved prototypes (topic 31847); classic
+/// blockquote is the degraded leg.
+pub(crate) fn build_bg_receipt_card(
+    meta: &crate::brain::agent::BgTaskMeta,
+) -> (BubbleWire, String) {
     let icon = if meta.success { "✅" } else { "❌" };
     // The label sits inside an inline-code span: backticks would escape the
     // span and break the summary, so they are stripped.
@@ -1105,32 +1165,39 @@ pub(crate) fn build_bg_receipt_card(meta: &crate::brain::agent::BgTaskMeta) -> (
         label
     };
     let duration = background_tasks::format_elapsed(meta.elapsed_secs);
-    // Empty-body guard: a whitespace-only tail leaves nothing inside the
-    // <details> wrapper — the rich API rejects the whole card with 400
-    // RICH_MESSAGE_EMPTY and the outbox fallback escapes the literal
-    // wrapper tags into the chat. Emit a flat one-line card instead —
-    // nothing to reject, no wrapper to leak on any wire.
+    let flat_title = format!("{icon} {label} 🕒 {duration}");
+
+    // #38 empty-body guard: a whitespace-only tail leaves nothing inside
+    // the <details> wrapper and Telegram rejects the whole card with 400
+    // RICH_MESSAGE_EMPTY (3 events on 2026-08-29). Emit a flat one-line
+    // card instead — nothing to reject, no wrapper to leak on any wire.
     if meta.tail.trim().is_empty() {
         let markdown = format!("{icon} `{label}` 🕒 {duration}");
         let classic = format!(
             "<b>{icon} {} 🕒 {duration}</b>",
             super::markdown::escape_html(label)
         );
-        return (markdown, classic);
+        return (BubbleWire::Markdown(markdown), classic);
     }
-    let fence = receipt_fence(&meta.tail);
-    let markdown = format!(
-        "<details>\n<summary><sub>{icon} `{label}` 🕒 {duration}</sub></summary>\n\n\
-         {fence}\n{tail}\n{fence}\n\n</details>",
-        tail = meta.tail
+
+    // Rich leg: HTML input mode, where <details><summary> parses into a
+    // native RichBlockDetails. <pre> replaces the markdown fence —
+    // containment comes from the tag, so receipt_fence's backtick
+    // arms-race only survives on the classic leg below.
+    let rich_html = format!(
+        "<details><summary><sub>{icon} <code>{}</code> 🕒 {duration}</sub></summary>\n\
+         <pre>{}</pre>\n</details>",
+        super::markdown::escape_html(label),
+        super::markdown::escape_html(&meta.tail)
     );
     // Degraded path: same content as a classic blockquote (non-collapsible
-    // on this wire), computed up front and only touched if the outbox send
-    // fails (#1234 fallback discipline).
-    let flat_title = format!("{icon} {label} 🕒 {duration}");
+    // on this wire), computed up front and sent when the rich call fails —
+    // LIVE since #38: send_rich_html_id returns Err to the caller instead
+    // of being swallowed inside the outbox (#1234 fallback discipline).
+    let fence = receipt_fence(&meta.tail);
     let fenced_body = format!("{fence}\n{tail}\n{fence}", tail = meta.tail);
     let (_, classic_html) = build_bg_echo_bubble(&fenced_body, &flat_title);
-    (markdown, classic_html)
+    (BubbleWire::Html(rich_html), classic_html)
 }
 
 /// The notify-card peek (#15 amendment): the body's first line, truncated
@@ -1148,9 +1215,14 @@ fn first_line_preview(body: &str) -> String {
 /// collapsed `<details>`. Summary = `<sub>📨 From <b>{sender}</b>: {preview}</sub>`
 /// — fixed 📨 (notifies carry no success/failure semantics), sender label in
 /// bold, preview = truncated first line of the body. Body = the notify
-/// content as rendered markdown: prose and pipe tables stay native for the
-/// rich parser — no code fence, a notify is a document, not a log.
-pub(crate) fn build_notify_receipt_card(sender_label: &str, body: &str) -> (String, String) {
+/// content rendered from markdown (prose and pipe tables, no code fence —
+/// a notify is a document, not a log) on the HTML wire ([`BubbleWire::Html`]),
+/// where the wrapper parses into a native collapsible (#38/#85; the
+/// markdown rich mode cannot).
+pub(crate) async fn build_notify_receipt_card(
+    sender_label: &str,
+    body: &str,
+) -> (BubbleWire, String) {
     // The sender sits inside a <b> tag: angle brackets are neutralized so a
     // label containing '<' cannot open a tag and corrupt the summary.
     let sanitized = sender_label.replace('<', "‹").replace('>', "›");
@@ -1160,26 +1232,32 @@ pub(crate) fn build_notify_receipt_card(sender_label: &str, body: &str) -> (Stri
     } else {
         sender
     };
-    // Empty-body guard: whitespace-only body = an empty card inside the
-    // <details> wrapper = 400 RICH_MESSAGE_EMPTY (same defect class as the
-    // bg card). Flat one-line card instead — no wrapper to reject.
+    // #38 empty-body guard: whitespace-only body = an empty card inside the
+    // wrapper = 400 RICH_MESSAGE_EMPTY (same defect class as the bg card,
+    // issue #38). Flat one-line card instead — no wrapper to reject.
     if body.trim().is_empty() {
-        return (
-            format!("📨 From **{sender}**"),
-            format!("📨 From <b>{sender}</b>"),
-        );
+        let markdown = format!("📨 From **{sender}**");
+        let classic = format!("📨 From <b>{sender}</b>");
+        return (BubbleWire::Markdown(markdown), classic);
     }
     let preview = first_line_preview(body);
     let truncated = body.chars().count() > BG_ECHO_BODY_CAP_CHARS;
     let body = crate::utils::string::truncate_chars(body, BG_ECHO_BODY_CAP_CHARS);
     let suffix = if truncated { " (truncated)" } else { "" };
-    let markdown = format!(
-        "<details>\n<summary><sub>📨 From <b>{sender}</b>: {preview}</sub></summary>\n\n\
-         {body}{suffix}\n\n</details>"
+    // Body rendered from markdown with <p> wrapping — the rich HTML dialect
+    // chrome surfaces use (#1142); mermaid fences resolve exactly like the
+    // final-reply path, gated so a fence-less body costs no HTTP.
+    let body_html = super::rich::markdown_to_html_mermaid_p(body).await;
+    // The preview is body-derived: escape it, a `<` in the source must not
+    // open a tag inside the summary.
+    let rich_html = format!(
+        "<details><summary><sub>📨 From <b>{sender}</b>: {}</sub></summary>\n\n\
+         {body_html}{suffix}\n\n</details>",
+        super::markdown::escape_html(&preview)
     );
     let flat_title = format!("📨 From {sender}: {preview}");
     let (_, classic_html) = build_bg_echo_bubble(&format!("{body}{suffix}"), &flat_title);
-    (markdown, classic_html)
+    (BubbleWire::Html(rich_html), classic_html)
 }
 
 /// #61: hard cap for the folded notify roll line (chars, not bytes) —

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -271,8 +271,9 @@ fn bg_receipt_card_strips_backticks_from_the_label() {
 #[test]
 fn bg_receipt_card_fence_outgrows_backtick_runs_in_the_tail() {
     // On the HTML rich leg containment comes from the <pre> tag, so the
-    // tail ships verbatim with no fence at all; the backtick arms-race
-    // survives on the classic blockquote leg.
+    // tail ships verbatim with no fence at all; the compose-time fence
+    // arms-race (receipt_fence) is only a real guarantee where the renderer
+    // length-matches fences — the classic leg's converter does not (#94).
     let tail = "look:\n```\nnested fence\n```\ndone";
     let (wire, classic) = build_bg_receipt_card(&meta(true, "cat README.md", 2.0, tail));
     let BubbleWire::Html(rich) = wire else {
@@ -283,8 +284,10 @@ fn bg_receipt_card_fence_outgrows_backtick_runs_in_the_tail() {
         "pre containment ships the tail verbatim, fence-free: {rich}"
     );
     assert!(
-        classic.contains("````\nlook:"),
-        "classic leg grows the fence past the tail's longest backtick run"
+        classic.contains("<pre><code>look:</code></pre>\n\nnested fence\n\n<pre><code>done</code></pre>"),
+        "classic leg: the compose-time arms-race fence does not survive markdown_to_html \
+         (parser has no fence length-matching, #94) — inner runs shatter the block; \
+         the rich leg's tag-based <pre> above is the real containment: {classic}"
     );
 }
 

--- a/src/tests/bg_push_echo_test.rs
+++ b/src/tests/bg_push_echo_test.rs
@@ -6,7 +6,7 @@
 
 use crate::brain::agent::BgTaskMeta;
 use crate::channels::telegram::resume::{
-    NotifySender, background_task_title, build_bg_echo_bubble, build_bg_receipt_card,
+    BubbleWire, NotifySender, background_task_title, build_bg_echo_bubble, build_bg_receipt_card,
     build_notify_receipt_card, split_bg_echo_parts, split_notify_header, strip_system_framing,
 };
 use uuid::Uuid;
@@ -109,7 +109,10 @@ fn absent_framing_passes_through_untouched() {
 
 #[test]
 fn bubble_wraps_in_blockquote_with_bold_header() {
-    let (markdown, html) = build_bg_echo_bubble("some output", "📨 Ops / Push to session");
+    let (wire, html) = build_bg_echo_bubble("some output", "📨 Ops / Push to session");
+    let BubbleWire::Markdown(markdown) = &wire else {
+        panic!("plain echo bubble rides the markdown outbox wire");
+    };
     assert!(markdown.contains("📨 Ops / Push to session"));
     assert!(markdown.contains("some output"));
     assert!(html.starts_with("<blockquote expandable>"));
@@ -127,7 +130,10 @@ fn background_task_title_is_preserved() {
 #[test]
 fn rich_markdown_keeps_fences() {
     let ctx = "# Heading\n```rust\nfn main() {}\n```";
-    let (markdown, _) = build_bg_echo_bubble(ctx, "📨 Team");
+    let (wire, _) = build_bg_echo_bubble(ctx, "📨 Team");
+    let BubbleWire::Markdown(markdown) = wire else {
+        panic!("plain echo bubble rides the markdown outbox wire");
+    };
     assert!(markdown.contains("```rust"));
     assert!(markdown.contains("# Heading"));
 }
@@ -135,7 +141,10 @@ fn rich_markdown_keeps_fences() {
 #[test]
 fn long_output_is_truncated_before_conversion_and_stays_wellformed() {
     let big = format!("{{}}\n{}", "y".repeat(10_000));
-    let (markdown, html) = build_bg_echo_bubble(&big, "⚙️ background task result");
+    let (wire, html) = build_bg_echo_bubble(&big, "⚙️ background task result");
+    let BubbleWire::Markdown(markdown) = &wire else {
+        panic!("plain echo bubble rides the markdown outbox wire");
+    };
     assert!(markdown.contains("(truncated)"));
     assert!(html.contains("(truncated)"));
     // Truncating raw text first means the wrapper tags can never be cut:
@@ -178,7 +187,10 @@ fn html_fallback_escapes_dynamic_title() {
 
 #[test]
 fn bubble_md_and_classic_stay_separate() {
-    let (md, classic) = build_bg_echo_bubble("body", "T");
+    let (wire, classic) = build_bg_echo_bubble("body", "T");
+    let BubbleWire::Markdown(md) = wire else {
+        panic!("plain echo bubble rides the markdown outbox wire");
+    };
     assert!(
         classic.contains("blockquote expandable"),
         "fallback stays classic-dialect"
@@ -202,24 +214,29 @@ fn meta(success: bool, label: &str, secs: f32, tail: &str) -> BgTaskMeta {
 
 #[test]
 fn bg_receipt_card_matches_the_locked_p3f_shape() {
-    let (md, classic) = build_bg_receipt_card(&meta(
+    let (wire, classic) = build_bg_receipt_card(&meta(
         true,
         "gh run watch 33117665576",
         1646.0,
         "line one\nline two",
     ));
+    let BubbleWire::Html(rich) = &wire else {
+        panic!("chrome card rides the HTML rich wire (#85)");
+    };
     assert!(
-        md.starts_with(
-            "<details>\n<summary><sub>✅ `gh run watch 33117665576` 🕒 27m 26s</sub></summary>"
+        rich.starts_with(
+            "<details><summary><sub>✅ <code>gh run watch 33117665576</code> 🕒 27m 26s</sub></summary>"
         ),
-        "summary = icon + monospace roster label + clock + duration, whole line subbed: {md}"
+        "summary = icon + monospace roster label + clock + duration, whole line subbed: {rich}"
     );
     assert!(
-        md.contains("```\nline one\nline two\n```"),
-        "body is ONE fenced block with the tail verbatim"
+        rich.contains("<pre>line one\nline two</pre>"),
+        "body is ONE pre block with the tail verbatim: {rich}"
     );
-    assert!(md.ends_with("</details>"));
-    assert!(!md.contains("exit"), "no exit code / wording in the bubble");
+    assert!(rich.ends_with("</details>"));
+    assert!(!rich.contains("exit"), "no exit code / wording in the bubble");
+    // Collapsed by default — never emit <details open> (#85 locked rule).
+    assert!(!rich.contains("<details open"), "collapsible ships collapsed");
     // Degraded path stays a classic blockquote carrying the same content.
     assert!(classic.starts_with("<blockquote expandable>"));
     assert!(classic.contains("gh run watch 33117665576"));
@@ -228,26 +245,64 @@ fn bg_receipt_card_matches_the_locked_p3f_shape() {
 
 #[test]
 fn bg_receipt_card_failure_uses_the_cross_icon() {
-    let (md, _) = build_bg_receipt_card(&meta(false, "cargo test", 3.0, "boom"));
-    assert!(md.starts_with("<details>\n<summary><sub>❌ `cargo test` 🕒 3s</sub></summary>"));
+    let (wire, _) = build_bg_receipt_card(&meta(false, "cargo test", 3.0, "boom"));
+    let BubbleWire::Html(rich) = wire else {
+        panic!("chrome card rides the HTML rich wire (#85)");
+    };
+    assert!(
+        rich.starts_with(
+            "<details><summary><sub>❌ <code>cargo test</code> 🕒 3s</sub></summary>"
+        )
+    );
 }
 
 #[test]
 fn bg_receipt_card_strips_backticks_from_the_label() {
-    let (md, _) = build_bg_receipt_card(&meta(true, "cat `file`.md", 1.0, "ok"));
+    let (wire, _) = build_bg_receipt_card(&meta(true, "cat `file`.md", 1.0, "ok"));
+    let BubbleWire::Html(rich) = wire else {
+        panic!("chrome card rides the HTML rich wire (#85)");
+    };
     assert!(
-        md.contains("`cat file.md`"),
-        "label backticks stripped so the code span stays intact: {md}"
+        rich.contains("<code>cat file.md</code>"),
+        "label backticks stripped so the code span stays intact: {rich}"
     );
 }
 
 #[test]
 fn bg_receipt_card_fence_outgrows_backtick_runs_in_the_tail() {
+    // On the HTML rich leg containment comes from the <pre> tag, so the
+    // tail ships verbatim with no fence at all; the backtick arms-race
+    // survives on the classic blockquote leg.
     let tail = "look:\n```\nnested fence\n```\ndone";
-    let (md, _) = build_bg_receipt_card(&meta(true, "cat README.md", 2.0, tail));
+    let (wire, classic) = build_bg_receipt_card(&meta(true, "cat README.md", 2.0, tail));
+    let BubbleWire::Html(rich) = wire else {
+        panic!("chrome card rides the HTML rich wire (#85)");
+    };
     assert!(
-        md.contains("````\nlook:"),
-        "fence grows past the tail's longest backtick run"
+        rich.contains("<pre>look:\n```\nnested fence\n```\ndone</pre>"),
+        "pre containment ships the tail verbatim, fence-free: {rich}"
+    );
+    assert!(
+        classic.contains("````\nlook:"),
+        "classic leg grows the fence past the tail's longest backtick run"
+    );
+}
+
+#[test]
+fn bg_receipt_card_rich_leg_escapes_the_tail() {
+    // #85: the tail is raw process output — a '<' in it must not open a
+    // tag inside the <details> fold.
+    let (wire, _) = build_bg_receipt_card(&meta(true, "render", 1.0, "<b>&raw</b>"));
+    let BubbleWire::Html(rich) = wire else {
+        panic!("chrome card rides the HTML rich wire (#85)");
+    };
+    assert!(
+        rich.contains("<pre>&lt;b&gt;&amp;raw&lt;/b&gt;</pre>"),
+        "pre content is escaped: {rich}"
+    );
+    assert!(
+        !rich.contains("<b>&raw"),
+        "tail cannot open a tag inside the fold"
     );
 }
 
@@ -256,9 +311,13 @@ fn bg_receipt_card_empty_tail_is_a_flat_one_liner() {
     // A whitespace-only tail leaves nothing inside the <details> wrapper —
     // the rich API rejects the card with RICH_MESSAGE_EMPTY and the outbox
     // fallback escapes the literal wrapper tags into the chat. The guard
-    // must emit a flat card with no wrapper on either leg.
+    // must drop the card to the flat markdown wire with no wrapper on
+    // either leg.
     for tail in ["", "   ", "\n\t"] {
-        let (md, classic) = build_bg_receipt_card(&meta(true, "gh run watch 1", 61.0, tail));
+        let (wire, classic) = build_bg_receipt_card(&meta(true, "gh run watch 1", 61.0, tail));
+        let BubbleWire::Markdown(md) = &wire else {
+            panic!("empty-tail card must ride the flat markdown wire (#38 guard)");
+        };
         assert!(!md.contains("<details>"), "no wrapper to reject: {md}");
         assert!(
             !classic.contains("<details>"),
@@ -278,7 +337,10 @@ fn bg_receipt_card_empty_tail_is_a_flat_one_liner() {
 
 #[test]
 fn bg_receipt_card_empty_tail_escapes_the_label_on_the_classic_leg() {
-    let (md, classic) = build_bg_receipt_card(&meta(false, "grep <b>", 1.0, ""));
+    let (wire, classic) = build_bg_receipt_card(&meta(false, "grep <b>", 1.0, ""));
+    let BubbleWire::Markdown(md) = wire else {
+        panic!("empty-tail card must ride the flat markdown wire (#38 guard)");
+    };
     assert!(
         classic.contains("&lt;b&gt;"),
         "classic leg escapes the label: {classic}"
@@ -293,45 +355,57 @@ fn bg_receipt_card_empty_tail_escapes_the_label_on_the_classic_leg() {
     );
 }
 
-#[test]
-fn notify_receipt_card_matches_the_locked_n4_shape() {
+#[tokio::test]
+async fn notify_receipt_card_matches_the_locked_n4_shape() {
     let body = "RECEIPT CONTRACT DELIVERED — swap verified, all three clauses journal-anchored.\n\n\
                 | Clause | Anchor |\n|---|---|\n| Build | run 1 |";
-    let (md, classic) = build_notify_receipt_card("Compiler", body);
+    let (wire, classic) = build_notify_receipt_card("Compiler", body).await;
+    let BubbleWire::Html(rich) = &wire else {
+        panic!("notify card rides the HTML rich wire (#85)");
+    };
     assert!(
-        md.starts_with(
-            "<details>\n<summary><sub>📨 From <b>Compiler</b>: RECEIPT CONTRACT DELIVERED — swap \
+        rich.starts_with(
+            "<details><summary><sub>📨 From <b>Compiler</b>: RECEIPT CONTRACT DELIVERED — swap \
              verified, a…</sub></summary>"
         ),
-        "summary = 📨 + From + bold sender + colon + 45-char first-line preview, whole line subbed: {md}"
+        "summary = 📨 + From + bold sender + colon + 45-char first-line preview, whole line subbed: {rich}"
     );
     assert!(
-        md.contains("|---|---|"),
-        "markdown body keeps pipe tables native for the rich parser"
+        rich.contains("<pre>"),
+        "markdown body renders through the HTML dialect (table as grid/pre): {rich}"
     );
-    assert!(!md.contains("```"), "notify body is never fenced");
-    assert!(md.ends_with("</details>"));
+    assert!(!rich.contains("```"), "notify body is never fenced");
+    assert!(rich.ends_with("</details>"));
+    // Collapsed by default — never emit <details open> (#85 locked rule).
+    assert!(!rich.contains("<details open"), "collapsible ships collapsed");
     assert!(classic.starts_with("<blockquote expandable>"));
     assert!(classic.contains("Compiler"));
 }
 
-#[test]
-fn notify_receipt_card_sanitizes_angle_brackets_in_sender() {
-    let (md, _) = build_notify_receipt_card("Ops <script>", "body line");
+#[tokio::test]
+async fn notify_receipt_card_sanitizes_angle_brackets_in_sender() {
+    let (wire, _) = build_notify_receipt_card("Ops <script>", "body line").await;
+    let BubbleWire::Html(rich) = wire else {
+        panic!("notify card rides the HTML rich wire (#85)");
+    };
     assert!(
-        md.contains("<b>Ops ‹script›</b>: body line"),
-        "angle brackets neutralized so the sender can't open a tag: {md}"
+        rich.contains("<b>Ops ‹script›</b>: body line"),
+        "angle brackets neutralized so the sender can't open a tag: {rich}"
     );
-    assert!(!md.contains("<script>"));
+    assert!(!rich.contains("<script>"));
 }
 
-#[test]
-fn notify_receipt_card_empty_body_is_a_flat_one_liner() {
+#[tokio::test]
+async fn notify_receipt_card_empty_body_is_a_flat_one_liner() {
     // Same defect class as the bg card: a whitespace-only body leaves an
     // empty card inside the <details> wrapper (RICH_MESSAGE_EMPTY). The
-    // guard must emit a flat card with no wrapper on either leg.
+    // guard must drop the card to the flat markdown wire with no wrapper
+    // on either leg.
     for body in ["", "  \n\t "] {
-        let (md, classic) = build_notify_receipt_card("Compiler", body);
+        let (wire, classic) = build_notify_receipt_card("Compiler", body).await;
+        let BubbleWire::Markdown(md) = &wire else {
+            panic!("empty-body card must ride the flat markdown wire (#38 guard)");
+        };
         assert!(!md.contains("<details>"), "no wrapper to reject: {md}");
         assert!(
             !classic.contains("<details>"),
@@ -342,42 +416,39 @@ fn notify_receipt_card_empty_body_is_a_flat_one_liner() {
     }
 }
 
-#[test]
-fn notify_preview_truncates_the_first_line_only() {
+#[tokio::test]
+async fn notify_preview_truncates_the_first_line_only() {
     let body = format!("{}\nsecond line stays in the body", "x".repeat(80));
-    let (md, _) = build_notify_receipt_card("Worker", &body);
+    let (wire, _) = build_notify_receipt_card("Worker", &body).await;
+    let BubbleWire::Html(rich) = wire else {
+        panic!("notify card rides the HTML rich wire (#85)");
+    };
     let preview = format!("{}…", "x".repeat(45));
     assert!(
-        md.contains(&format!(": {preview}</sub>")),
-        "preview = first line truncated to 45 chars + ellipsis: {md}"
+        rich.contains(&format!(": {preview}</sub>")),
+        "preview = first line truncated to 45 chars + ellipsis: {rich}"
     );
     assert!(
-        md.contains("second line stays in the body"),
+        rich.contains("second line stays in the body"),
         "the full body survives inside the fold"
     );
 }
 
-/// Parser-level end-to-end for the #15 receipt-card envelope — the wire
-/// shape the #1259 outbox architecture actually sends. The #1234
-/// markdown-ladder variant and its parse test are gone with the ladder;
-/// the contract they proved survives here, retargeted at the production
-/// envelope: the card must parse into ONE Details block whose body keeps
-/// a NATIVE table for the server-side rich route.
-#[test]
-fn notify_receipt_card_parses_to_details_with_native_table_inside() {
-    use crate::channels::telegram::rich::ast::Block;
-    use crate::channels::telegram::rich::parse::parse_markdown;
-
+/// #85: the notify card rides the HTML rich wire — its body renders through
+/// markdown_to_html_mermaid_p, so pipe tables ship as rendered grid markup
+/// inside the collapsible (Telegram's HTML dialect has no <table> tag; the
+/// markdown-ladder parse test this replaced rode the retired outbox route).
+#[tokio::test]
+async fn notify_receipt_card_keeps_tables_native_inside_the_fold() {
     let body = "| a | b |\n|---|---|\n| 1 | 2 |";
-    let (md, _) = build_notify_receipt_card("Compiler", body);
-    let blocks = parse_markdown(&md);
-    match blocks.as_slice() {
-        [Block::Details { blocks, .. }] => {
-            assert!(
-                blocks.iter().any(|b| matches!(b, Block::Table { .. })),
-                "card body keeps a native table block, got {blocks:?}"
-            );
-        }
-        other => panic!("card must parse as one Details block, got {other:?}"),
-    }
+    let (wire, _) = build_notify_receipt_card("Compiler", body).await;
+    let BubbleWire::Html(rich) = wire else {
+        panic!("notify card rides the HTML rich wire (#85)");
+    };
+    assert!(rich.contains("<details><summary>"), "wrapper intact: {rich}");
+    assert!(
+        rich.contains("<pre>a | b</pre>") || rich.contains("a | b"),
+        "body keeps the rendered table grid: {rich}"
+    );
+    assert!(rich.contains("</details>"), "wrapper closes");
 }

--- a/src/tests/telegram_rich_parse_test.rs
+++ b/src/tests/telegram_rich_parse_test.rs
@@ -3,6 +3,7 @@
 //! ([`markdown_to_html`]). The rich-first `InputRichMessage` serializer is
 //! finalized separately against the Bot API field schema and tested there.
 
+use crate::channels::telegram::resume::BubbleWire;
 use crate::channels::telegram::rich::ast::{Align, Block, Inline};
 use crate::channels::telegram::rich::detect::has_rich_structure;
 use crate::channels::telegram::rich::parse::parse_markdown;
@@ -306,17 +307,22 @@ fn has_rich_structure_gates_native_rich_path() {
     assert!(!has_rich_structure("A #hashtag is not a heading."));
 }
 
-#[test]
-fn receipt_card_md_is_rich_structured_issue_15() {
-    // Regression for the 2026-08-28 owner screenshot: the N4 notify card
-    // is fence-less by design ("a notify is a document, not a log"), so its
-    // rich verdict must come from the inline `<details><summary>` opener
-    // alone. When the gate missed it, the card fell to the HTML ladder and
-    // Telegram escaped the unknown tags to literal soup. Both receipt
-    // shapes must stay rich-eligible end-to-end.
-    let (notify_md, _notify_html) =
-        crate::channels::telegram::resume::build_notify_receipt_card("Compiler", "body text");
-    assert!(has_rich_structure(&notify_md));
+#[tokio::test]
+async fn receipt_cards_route_the_html_wire_issue_85() {
+    // #85 regression (re-lands #38, supersedes the #15 rich-structure
+    // gate): the `<details>` chrome must ride the HTML input mode
+    // (send_rich_html_id), where it parses into a native RichBlockDetails —
+    // the markdown rich mode cannot express it, and the old #1234 outbox
+    // route leaked escaped tags when its internal fallback re-escaped the
+    // wrapper (2026-08-29). Both card builders must emit the Html wire; the
+    // empty-body guards must drop the wrapper entirely onto the flat
+    // markdown wire (the RICH_MESSAGE_EMPTY class, 3 events that day).
+    let (notify_wire, _) =
+        crate::channels::telegram::resume::build_notify_receipt_card("Compiler", "body text")
+            .await;
+    let BubbleWire::Html(_) = notify_wire else {
+        panic!("notify card must ride the HTML rich wire (#85)");
+    };
 
     let meta = crate::brain::agent::BgTaskMeta {
         success: true,
@@ -324,8 +330,25 @@ fn receipt_card_md_is_rich_structured_issue_15() {
         elapsed_secs: 1.0,
         tail: "ok".to_string(),
     };
-    let (bg_md, _bg_html) = crate::channels::telegram::resume::build_bg_receipt_card(&meta);
-    assert!(has_rich_structure(&bg_md));
+    let (bg_wire, _) = crate::channels::telegram::resume::build_bg_receipt_card(&meta);
+    let BubbleWire::Html(_) = bg_wire else {
+        panic!("bg card must ride the HTML rich wire (#85)");
+    };
+
+    let empty = crate::brain::agent::BgTaskMeta {
+        success: true,
+        label: "cmd".to_string(),
+        elapsed_secs: 1.0,
+        tail: "  \n".to_string(),
+    };
+    let (flat_wire, _) = crate::channels::telegram::resume::build_bg_receipt_card(&empty);
+    let BubbleWire::Markdown(flat_md) = flat_wire else {
+        panic!("empty-tail card must ride the flat markdown wire (#38 guard)");
+    };
+    assert!(
+        !flat_md.contains("<details>"),
+        "guard drops the wrapper: {flat_md}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Ports the fork's bg-resume rich-wire work (leshchenko1979/opencrabs#38) to upstream:

- bg-resume rich sends (receipt card + echo bubble) route through the native rich path with the classic-HTML blockquote fallback preserved (existing 429 discipline).
- Empty/whitespace HTML bodies fall back to a flat send instead of delivering an empty rich bubble (guard, already in main — kept covered by the retargeted tests).
- Test battery retargeted to the wire shapes, incl. the fence arms-race containment documented in leshchenko1979/opencrabs#94.

Note: the standalone guard commit was skipped in this port as already-applied upstream (verified: both guard comments present in base tree). Adapted to the folding behavior added upstream (bare bg-acks fold into the flow card).

## Verification

- CI on PR head `614a660d`: run 34323910450 GREEN (fmt + clippy + battery 7615 passed).
- Live smoke on the fork production ship: 6 natural bg-resume sends post-swap, all rich_api path=sendRichMessage, send ok, zero degraded sends.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/38