### PR TITLE
fix(telegram): parse standard HTML style tags in rich inlines (b/strong, i/em, u, s/del)

### DIFF
--- a/src/channels/telegram/rich/ast.rs
+++ b/src/channels/telegram/rich/ast.rs
@@ -118,6 +118,10 @@ pub enum Inline {
     /// the content. Parsed as a node rather than left as text so a lone
     /// `<sub>` in prose still escapes to visible characters.
     Sub(Vec<Inline>),
+    /// `<u>` underline (classic Telegram HTML supports it natively; the rich
+    /// dialect renders it natively too). Parsed as a node so producers of
+    /// classic HTML don't escape into visible `&lt;u&gt;` (#106).
+    Underline(Vec<Inline>),
     /// Inline `code` — content is literal, never re-parsed.
     Code(String),
     /// Inline `$math$` — content is literal, never re-parsed.

--- a/src/channels/telegram/rich/inline.rs
+++ b/src/channels/telegram/rich/inline.rs
@@ -8,10 +8,13 @@
 
 use super::ast::Inline;
 
+/// Factory producing the [`Inline`] styling node for a matched HTML tag.
+type StyleNodeFactory = fn(Vec<Inline>) -> Inline;
+
 /// Standard HTML styling tags mapped onto [`Inline`] variants by
 /// [`parse_inlines`] (#106). Order matters only for overlaps — none exist
 /// between these tags, so table order is read order.
-const HTML_STYLE_TAGS: &[(&str, fn(Vec<Inline>) -> Inline)] = &[
+const HTML_STYLE_TAGS: &[(&str, StyleNodeFactory)] = &[
     ("b", Inline::Bold),
     ("strong", Inline::Bold),
     ("i", Inline::Italic),

--- a/src/channels/telegram/rich/inline.rs
+++ b/src/channels/telegram/rich/inline.rs
@@ -28,7 +28,6 @@ pub(super) fn parse_inlines(input: &str) -> Vec<Inline> {
     let mut i = 0;
 
     while i < input.len() {
-        'outer: {
         let rest = &input[i..];
 
         // Literal spans first: their contents are never re-parsed.
@@ -77,13 +76,11 @@ pub(super) fn parse_inlines(input: &str) -> Vec<Inline> {
         // relayed markup) renders real styling instead of escaping into
         // visible `&lt;b&gt;` text (#106). Well-formed pairs only; an
         // unmatched opener stays literal, same law as `<sub>` above.
-        for (tag, make) in HTML_STYLE_TAGS {
-            if let Some(span) = tag_paired(rest, tag) {
-                flush(&mut text, &mut out);
-                out.push(make(parse_inlines(span)));
-                i += span.len() + tag.len() * 2 + 5;
-                continue 'outer;
-            }
+        if let Some((used, node)) = try_html_style_tag(rest) {
+            flush(&mut text, &mut out);
+            out.push(node);
+            i += used;
+            continue;
         }
         if let Some(span) = tag_paired(rest, "sub") {
             flush(&mut text, &mut out);
@@ -128,7 +125,6 @@ pub(super) fn parse_inlines(input: &str) -> Vec<Inline> {
         let ch = rest.chars().next().unwrap();
         text.push(ch);
         i += ch.len_utf8();
-        } // 'outer
     }
 
     flush(&mut text, &mut out);
@@ -190,6 +186,19 @@ fn tag_paired<'a>(rest: &'a str, tag: &str) -> Option<&'a str> {
     Some(&after[..close])
 }
 
+/// Try each standard HTML styling tag (see [`HTML_STYLE_TAGS`]) at the start
+/// of `rest`. Returns `(bytes_consumed, parsed_node)` on the first
+/// well-formed pair, `None` otherwise (#106).
+fn try_html_style_tag(rest: &str) -> Option<(usize, Inline)> {
+    for (tag, make) in HTML_STYLE_TAGS {
+        if let Some(span) = tag_paired(rest, tag) {
+            let used = span.len() + tag.len() * 2 + 5; // <t>SPAN</t>
+            return Some((used, make(parse_inlines(span))));
+        }
+    }
+    None
+}
+
 /// Parse `[text](url)` at the start of `rest`. Returns the link text, the url,
 /// and the total bytes consumed.
 fn parse_link(rest: &str) -> Option<(&str, &str, usize)> {
@@ -225,26 +234,21 @@ mod tests {
     }
 
     fn text_of(input: &str) -> String {
-        let mut out = String::new();
-        for i in parse_inlines(input) {
-            match i {
-                Inline::Text(t) | Inline::Code(t) | Inline::Math(t) => out.push_str(&t),
-                Inline::Bold(c) | Inline::Italic(c) | Inline::Underline(c) | Inline::Strike(c)
-                | Inline::Sub(c) => {
-                    out.push_str(&text_of(&c.iter().map(|x| match x {
-                        Inline::Text(t) => t.clone(),
-                        _ => String::new(),
-                    }).collect::<Vec<_>>().join("")));
-                }
-                Inline::Link { content, .. } => {
-                    for x in content {
-                        if let Inline::Text(t) = x {
-                            out.push_str(t);
-                        }
-                    }
+        fn flatten(inlines: &[Inline], out: &mut String) {
+            for i in inlines {
+                match i {
+                    Inline::Text(t) | Inline::Code(t) | Inline::Math(t) => out.push_str(t),
+                    Inline::Bold(c)
+                    | Inline::Italic(c)
+                    | Inline::Underline(c)
+                    | Inline::Strike(c)
+                    | Inline::Sub(c) => flatten(c, out),
+                    Inline::Link { content, .. } => flatten(content, out),
                 }
             }
         }
+        let mut out = String::new();
+        flatten(&parse_inlines(input), &mut out);
         out
     }
 

--- a/src/channels/telegram/rich/inline.rs
+++ b/src/channels/telegram/rich/inline.rs
@@ -278,8 +278,9 @@ mod tests {
         // No closer → whole thing is literal text, escaped downstream.
         assert_eq!(kinds("<b>unclosed"), vec!["text"]);
         assert_eq!(text_of("<b>unclosed"), "<b>unclosed");
-        // Empty body → literal, same law as `**` pairs.
-        assert_eq!(kinds("<b></b>"), vec!["text", "text"]);
+        // Empty body → tag_paired returns None → whole string falls through
+        // to the text accumulator as ONE literal span (same law as `**` pairs).
+        assert_eq!(kinds("<b></b>"), vec!["text"]);
     }
 
     #[test]

--- a/src/channels/telegram/rich/inline.rs
+++ b/src/channels/telegram/rich/inline.rs
@@ -8,6 +8,19 @@
 
 use super::ast::Inline;
 
+/// Standard HTML styling tags mapped onto [`Inline`] variants by
+/// [`parse_inlines`] (#106). Order matters only for overlaps — none exist
+/// between these tags, so table order is read order.
+const HTML_STYLE_TAGS: &[(&str, fn(Vec<Inline>) -> Inline)] = &[
+    ("b", Inline::Bold),
+    ("strong", Inline::Bold),
+    ("i", Inline::Italic),
+    ("em", Inline::Italic),
+    ("u", Inline::Underline),
+    ("s", Inline::Strike),
+    ("del", Inline::Strike),
+];
+
 /// Parse a single line / cell of markdown into inline spans.
 pub(super) fn parse_inlines(input: &str) -> Vec<Inline> {
     let mut out = Vec::new();
@@ -15,6 +28,7 @@ pub(super) fn parse_inlines(input: &str) -> Vec<Inline> {
     let mut i = 0;
 
     while i < input.len() {
+        'outer: {
         let rest = &input[i..];
 
         // Literal spans first: their contents are never re-parsed.
@@ -57,6 +71,20 @@ pub(super) fn parse_inlines(input: &str) -> Vec<Inline> {
         // `<sub>` small text, emitted by the flow and result cards for their
         // summary lines. Recognised here so the HTML renderer can drop the
         // tag instead of escaping it into visible `&lt;sub&gt;`.
+        // Standard HTML styling tags — `<b>/<strong>`, `<i>/<em>`, `<u>`,
+        // `<s>/<del>` — mapped onto the markdown-styling variants so any
+        // producer of classic Telegram HTML (card builders, degrade paths,
+        // relayed markup) renders real styling instead of escaping into
+        // visible `&lt;b&gt;` text (#106). Well-formed pairs only; an
+        // unmatched opener stays literal, same law as `<sub>` above.
+        for (tag, make) in HTML_STYLE_TAGS {
+            if let Some(span) = tag_paired(rest, tag) {
+                flush(&mut text, &mut out);
+                out.push(make(parse_inlines(span)));
+                i += span.len() + tag.len() * 2 + 5;
+                continue 'outer;
+            }
+        }
         if let Some(span) = tag_paired(rest, "sub") {
             flush(&mut text, &mut out);
             out.push(Inline::Sub(parse_inlines(span)));
@@ -100,6 +128,7 @@ pub(super) fn parse_inlines(input: &str) -> Vec<Inline> {
         let ch = rest.chars().next().unwrap();
         text.push(ch);
         i += ch.len_utf8();
+        } // 'outer
     }
 
     flush(&mut text, &mut out);
@@ -172,4 +201,84 @@ fn parse_link(rest: &str) -> Option<(&str, &str, usize)> {
         return None;
     }
     Some((text, url, mid + 2 + end + 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(input: &str) -> Vec<String> {
+        parse_inlines(input)
+            .iter()
+            .map(|i| match i {
+                Inline::Text(_) => "text".into(),
+                Inline::Bold(_) => "bold".into(),
+                Inline::Italic(_) => "italic".into(),
+                Inline::Underline(_) => "underline".into(),
+                Inline::Strike(_) => "strike".into(),
+                Inline::Sub(_) => "sub".into(),
+                Inline::Code(_) => "code".into(),
+                Inline::Math(_) => "math".into(),
+                Inline::Link { .. } => "link".into(),
+            })
+            .collect()
+    }
+
+    fn text_of(input: &str) -> String {
+        let mut out = String::new();
+        for i in parse_inlines(input) {
+            match i {
+                Inline::Text(t) | Inline::Code(t) | Inline::Math(t) => out.push_str(&t),
+                Inline::Bold(c) | Inline::Italic(c) | Inline::Underline(c) | Inline::Strike(c)
+                | Inline::Sub(c) => {
+                    out.push_str(&text_of(&c.iter().map(|x| match x {
+                        Inline::Text(t) => t.clone(),
+                        _ => String::new(),
+                    }).collect::<Vec<_>>().join("")));
+                }
+                Inline::Link { content, .. } => {
+                    for x in content {
+                        if let Inline::Text(t) = x {
+                            out.push_str(t);
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn html_style_tags_map_to_inline_variants() {
+        assert_eq!(kinds("<b>hi</b>"), vec!["bold"]);
+        assert_eq!(kinds("<strong>hi</strong>"), vec!["bold"]);
+        assert_eq!(kinds("<i>hi</i>"), vec!["italic"]);
+        assert_eq!(kinds("<em>hi</em>"), vec!["italic"]);
+        assert_eq!(kinds("<u>hi</u>"), vec!["underline"]);
+        assert_eq!(kinds("<s>hi</s>"), vec!["strike"]);
+        assert_eq!(kinds("<del>hi</del>"), vec!["strike"]);
+    }
+
+    #[test]
+    fn html_tags_recurse_and_mix_with_markdown() {
+        assert_eq!(kinds("<b>a *b* c</b>"), vec!["bold"]);
+        assert_eq!(kinds("x<b>y</b>z"), vec!["text", "bold", "text"]);
+        assert_eq!(kinds("**a** <i>b</i>"), vec!["bold", "text", "italic"]);
+    }
+
+    #[test]
+    fn unmatched_openers_stay_literal() {
+        // No closer → whole thing is literal text, escaped downstream.
+        assert_eq!(kinds("<b>unclosed"), vec!["text"]);
+        assert_eq!(text_of("<b>unclosed"), "<b>unclosed");
+        // Empty body → literal, same law as `**` pairs.
+        assert_eq!(kinds("<b></b>"), vec!["text", "text"]);
+    }
+
+    #[test]
+    fn summary_b_renders_as_bold_not_escape() {
+        // The #106 live shape: `<b>▸ summary</b>` from a degraded Details.
+        assert_eq!(kinds("<b>Summary text</b>"), vec!["bold"]);
+        assert_eq!(text_of("<b>Summary text</b>"), "Summary text");
+    }
 }

--- a/src/channels/telegram/rich/render_html.rs
+++ b/src/channels/telegram/rich/render_html.rs
@@ -311,6 +311,7 @@ fn render_inline(inline: &Inline, s: &mut String, wrap_p: bool) {
         }
         Inline::Bold(c) => wrap(s, "<b>", c, "</b>", wrap_p),
         Inline::Italic(c) => wrap(s, "<i>", c, "</i>", wrap_p),
+        Inline::Underline(c) => wrap(s, "<u>", c, "</u>", wrap_p),
         Inline::Strike(c) => wrap(s, "<s>", c, "</s>", wrap_p),
         // Classic Telegram HTML has no <sub>; keep the content and drop the
         // tag so a downgraded rich message never shows its own markup.
@@ -359,7 +360,8 @@ fn plain(inlines: &[Inline]) -> String {
 fn plain_one(inline: &Inline, s: &mut String) {
     match inline {
         Inline::Text(t) | Inline::Code(t) | Inline::Math(t) => s.push_str(t),
-        Inline::Bold(c) | Inline::Italic(c) | Inline::Strike(c) | Inline::Sub(c) => {
+        Inline::Bold(c) | Inline::Italic(c) | Inline::Underline(c) | Inline::Strike(c)
+        | Inline::Sub(c) => {
             for x in c {
                 plain_one(x, s);
             }

--- a/src/channels/telegram/rich/render_json.rs
+++ b/src/channels/telegram/rich/render_json.rs
@@ -127,6 +127,9 @@ pub(crate) fn render_inline(inline: &Inline) -> Value {
         Inline::Text(text) => json!({ "type": "text", "text": text }),
         Inline::Bold(content) => json!({ "type": "bold", "content": render_inlines(content) }),
         Inline::Italic(content) => json!({ "type": "italic", "content": render_inlines(content) }),
+        Inline::Underline(content) => {
+            json!({ "type": "underline", "content": render_inlines(content) })
+        }
         Inline::Strike(content) => json!({
             "type": "strikethrough",
             "content": render_inlines(content),


### PR DESCRIPTION
## Summary
Extends the rich-message inline parser (`parse_inlines`) to recognize the standard HTML style tags Telegram allows in HTML-mode messages, mapping them onto existing `Inline` variants: `<b>/<strong>` → Bold, `<i>/<em>` → Italic, `<u>` → Underline (new `Inline::Underline` variant), `<s>/<del>` → Strike. Previously only `<sub>` was handled; all other paired tags fell through to literal text, so degraded/HTML-mode rich messages containing `<b>` rendered raw tags to the user.

Context (defect 2 of fork issue): the degraded Details summary escaped `<b>` as literal text because the parser had no HTML style-tag arm. Defect 1 (429 retry_after handling) was already fixed upstream in 991dd984; this PR covers the remaining defect.

## Testing
- 4 new parser unit tests in `src/channels/telegram/rich/inline.rs` (bold/strong family, italic/em family, underline new variant, strike/del family, unmatched openers stay literal)
- Full suite: 7949 tests passed on the harvest gate run (job `PR-lane gates (fff3f888)` = success)
- Live behavioral probe on the running fork binary: `<b>` → Bold, `<s>/<del>` → Strike, `<u>` → Underline parsed; unmatched orphan tags stayed literal

Issue reference (fork tracker): https://github.com/leshchenko1979/opencrabs/issues/106