### PR TITLE
fix(config): write_key recursive JSON→toml_edit — objects/nested arrays survive, null+mixed arrays error

### DIFF
--- a/src/brain/tools/config_tool.rs
+++ b/src/brain/tools/config_tool.rs
@@ -190,8 +190,8 @@ impl ConfigTool {
         };
 
         match crate::config::Config::write_key(section, key, value) {
-            Ok(()) => Ok(ToolResult::success(format!(
-                "Set [{section}].{key} = \"{value}\" in config.toml"
+            Ok(written) => Ok(ToolResult::success(format!(
+                "Set [{section}].{key} = {written} in config.toml"
             ))),
             Err(e) => Ok(ToolResult::error(format!("Failed to write config: {}", e))),
         }

--- a/src/brain/tools/slash_command.rs
+++ b/src/brain/tools/slash_command.rs
@@ -529,7 +529,7 @@ impl SlashCommandTool {
         match policy {
             "approve-only" | "auto-session" | "auto-always" => {
                 match crate::config::Config::write_key("agent", "approval_policy", policy) {
-                    Ok(()) => Ok(ToolResult::success(format!(
+                    Ok(_written) => Ok(ToolResult::success(format!(
                         "Approval policy set to: {}",
                         policy
                     ))),
@@ -589,7 +589,7 @@ impl SlashCommandTool {
                 )));
             };
             return match crate::config::Config::write_key(&section, "default_model", &model) {
-                Ok(()) => Ok(ToolResult::success(format!(
+                Ok(_written) => Ok(ToolResult::success(format!(
                     "Model switched to '{model}' on provider '{provider_id}'. \
                      Config updated at [{section}].default_model. \
                      The change takes effect on the next request."

--- a/src/channels/commands.rs
+++ b/src/channels/commands.rs
@@ -2446,7 +2446,7 @@ pub(crate) async fn handle_redact(arg: &str) -> String {
         _ => return "⚠️ Scope must be one of: `global`, `group`, `dm`.".to_string(),
     };
     match Config::write_key("agent", key, if on { "true" } else { "false" }) {
-        Ok(()) => format!(
+        Ok(_written) => format!(
             "✅ Redaction for {} set to **{}**.",
             label,
             if on { "on" } else { "off" }

--- a/src/channels/telegram/cowork.rs
+++ b/src/channels/telegram/cowork.rs
@@ -158,6 +158,7 @@ pub fn set_group_open(chat_id: i64) -> Result<(), String> {
         "open",
         "true",
     )
+    .map(|_| ())
     .map_err(|e| format!("Failed to open group {chat_id}: {e}"))
 }
 

--- a/src/config/seed.rs
+++ b/src/config/seed.rs
@@ -109,7 +109,7 @@ pub fn enable_providers_with_keys(config: &Config) -> Vec<String> {
             continue;
         }
         match Config::write_key(meta.config_section, "enabled", "true") {
-            Ok(()) => written.push(meta.config_section.to_string()),
+            Ok(_) => written.push(meta.config_section.to_string()),
             Err(e) => tracing::warn!(
                 "Could not enable {} in the seeded config: {}",
                 meta.config_section,

--- a/src/config/types/loader.rs
+++ b/src/config/types/loader.rs
@@ -1030,36 +1030,25 @@ impl Config {
     /// `section` is a dotted path like "agent" or "providers.tts.local".
     /// `key` is the field name inside that section.
     /// `value` is the TOML-serialisable value.
-    pub fn write_key(section: &str, key: &str, value: &str) -> Result<()> {
+    ///
+    /// JSON arrays and objects convert faithfully — objects become inline
+    /// tables, arrays recurse (so arrays-of-tables like `memory.extra_paths`
+    /// survive instead of being silently dropped, #87). Values TOML cannot
+    /// represent (`null`, mixed-type arrays) hard-error BEFORE the file is
+    /// touched. On success the returned `String` is the TOML rendering of the
+    /// value actually written, so callers can echo reality, not the raw input.
+    pub fn write_key(section: &str, key: &str, value: &str) -> Result<String> {
         // Sanitize: trim whitespace/newlines that may leak from TUI input
         let value = value.trim();
 
-        // Parse the value — try JSON array, integer, float, bool, then fall back to string
-        let parsed: toml_edit::Item = if value.starts_with('[') && value.ends_with(']') {
-            // Try parsing as JSON array → TOML array
-            if let Ok(arr) = serde_json::from_str::<Vec<serde_json::Value>>(value) {
-                let mut toml_arr = toml_edit::Array::new();
-                for v in arr {
-                    match v {
-                        serde_json::Value::String(s) => {
-                            toml_arr.push(s);
-                        }
-                        serde_json::Value::Number(n) => {
-                            if let Some(i) = n.as_i64() {
-                                toml_arr.push(i);
-                            } else if let Some(f) = n.as_f64() {
-                                toml_arr.push(f);
-                            }
-                        }
-                        serde_json::Value::Bool(b) => {
-                            toml_arr.push(b);
-                        }
-                        _ => {}
-                    }
-                }
-                toml_edit::value(toml_arr)
-            } else {
-                toml_edit::value(value)
+        // Parse the value — try JSON array/object, integer, float, bool, then
+        // fall back to string.
+        let parsed: toml_edit::Item = if value.starts_with('[') || value.starts_with('{') {
+            match serde_json::from_str::<serde_json::Value>(value) {
+                Ok(json) => toml_edit::Item::Value(json_to_toml_value(&json)?),
+                // Bracketed but not valid JSON — a plain string that happens
+                // to start with '['/'{' stays a string (e.g. "[in progress]").
+                Err(_) => toml_edit::value(value),
             }
         } else if let Ok(v) = value.parse::<i64>() {
             toml_edit::value(v)
@@ -1071,7 +1060,9 @@ impl Config {
             toml_edit::value(value)
         };
 
-        Self::write_item(section, key, parsed)
+        let written = parsed.to_string();
+        Self::write_item(section, key, parsed)?;
+        Ok(written)
     }
 
     /// Write a config key as a TOML string, whatever the text looks like.
@@ -1727,6 +1718,80 @@ fn inject_into_agent_section(content: &str, comment_block: &str) -> Result<Strin
     out.push_str(comment_block);
     out.push_str(&content[section_end..]);
     Ok(out)
+}
+
+/// Recursively convert a JSON value into a `toml_edit::Value`.
+///
+/// Faithful for every JSON shape TOML can represent: strings, integers,
+/// floats, booleans, arrays (recursively) and objects → inline tables. Two
+/// shapes hard-error BEFORE any file access because TOML cannot represent
+/// them without silent loss (#87):
+/// - `null` — TOML has no null;
+/// - mixed-type arrays — TOML v1.0 arrays must be homogeneous; integer and
+///   float count as one family (`[0.1, 1, 2]` is legal TOML), but e.g. a
+///   string next to a table would have to be dropped or stringified.
+fn json_to_toml_value(json: &serde_json::Value) -> Result<toml_edit::Value> {
+    use serde_json::Value as J;
+    let v = match json {
+        J::Null => {
+            anyhow::bail!("null is not representable in TOML — the value was NOT written");
+        }
+        J::String(s) => toml_edit::Value::from(s.clone()),
+        J::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                toml_edit::Value::from(i)
+            } else if let Some(f) = n.as_f64() {
+                toml_edit::Value::from(f)
+            } else {
+                anyhow::bail!(
+                    "number `{n}` is not representable as a TOML integer or float — \
+                     the value was NOT written"
+                );
+            }
+        }
+        J::Bool(b) => toml_edit::Value::from(*b),
+        J::Array(items) => {
+            let mut arr = toml_edit::Array::new();
+            let mut family: Option<&'static str> = None;
+            for item in items {
+                let value = json_to_toml_value(item)?;
+                let fam = toml_family(&value);
+                if let Some(prev) = family {
+                    if prev != fam {
+                        anyhow::bail!(
+                            "array mixes types `{prev}` and `{fam}` — TOML arrays must be \
+                             homogeneous (#87). The value was NOT written."
+                        );
+                    }
+                } else {
+                    family = Some(fam);
+                }
+                arr.push(value);
+            }
+            toml_edit::Value::from(arr)
+        }
+        J::Object(map) => {
+            let mut tbl = toml_edit::InlineTable::new();
+            for (k, v) in map {
+                tbl.insert(k.clone(), json_to_toml_value(v)?);
+            }
+            toml_edit::Value::from(tbl)
+        }
+    };
+    Ok(v)
+}
+
+/// The TOML type family of a value, used for the array-homogeneity check.
+/// Integer and float share one family (`[0.1, 1, 2]` is legal TOML #87).
+fn toml_family(v: &toml_edit::Value) -> &'static str {
+    match v {
+        toml_edit::Value::Integer(_) | toml_edit::Value::Float(_) => "number",
+        toml_edit::Value::String(_) => "string",
+        toml_edit::Value::Boolean(_) => "boolean",
+        toml_edit::Value::Array(_) => "array",
+        toml_edit::Value::InlineTable(_) => "table",
+        toml_edit::Value::Datetime(_) => "datetime",
+    }
 }
 
 /// Resolve provider display name and model from config.

--- a/src/tests/config_write_types_test.rs
+++ b/src/tests/config_write_types_test.rs
@@ -1,0 +1,167 @@
+//! End-to-end coverage for recursive `Config::write_key` value handling
+//! (leshchenko1979/opencrabs#87): arrays-of-tables and objects survive as
+//! real TOML structures, never silently dropped or stringified;
+//! unrepresentable values (null, mixed-type arrays) are hard errors raised
+//! BEFORE the file is touched, so config.toml keeps its exact bytes.
+//!
+//! Ported standalone for the upstream contribution: the fork's twin coverage
+//! lives in `config_write_existing_section_test.rs` (fork-only write-guard
+//! feature, shipped separately).
+
+use std::path::{Path, PathBuf};
+
+use crate::config::Config;
+use crate::config::profile::with_home_override;
+
+/// A tempdir laid out as an `.opencrabs` home holding a seeded config.toml
+/// with a real `[memory]` section.
+fn seeded_home() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let opencrabs = dir.path().join(".opencrabs");
+    std::fs::create_dir_all(&opencrabs).expect("create .opencrabs");
+    std::fs::write(
+        opencrabs.join("config.toml"),
+        "[memory]\nvector_enabled = false\n",
+    )
+    .expect("write config");
+    std::fs::write(opencrabs.join("keys.toml"), b"").expect("write keys");
+    (dir, opencrabs)
+}
+
+fn config_content(home: &Path) -> String {
+    std::fs::read_to_string(home.join("config.toml")).expect("config.toml readable")
+}
+
+/// The #87 incident case: `extra_paths` is an array-of-tables. The old
+/// write_key dropped non-scalar array elements silently (the file ended up
+/// with `extra_paths = []`); now each object survives as an inline table and
+/// `Config::load()` sees the real path/pattern pair.
+#[test]
+fn array_of_tables_round_trips_the_87_incident_case() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let written = Config::write_key(
+            "memory",
+            "extra_paths",
+            r#"[{"path": "/root/opencrabs/src", "pattern": "**/*.rs"}]"#,
+        )
+        .expect("array-of-tables writes");
+        assert!(
+            written.contains("path = \"/root/opencrabs/src\""),
+            "echo shows the object actually written: {written}"
+        );
+
+        let doc: toml_edit::DocumentMut = config_content(&home).parse().expect("valid TOML");
+        let arr = doc["memory"]["extra_paths"]
+            .as_array()
+            .expect("array written");
+        assert_eq!(arr.len(), 1);
+        let entry = arr
+            .get(0)
+            .and_then(|v| v.as_inline_table())
+            .expect("array-of-tables element is an inline table");
+        assert_eq!(
+            entry.get("path").and_then(|v| v.as_str()),
+            Some("/root/opencrabs/src")
+        );
+        assert_eq!(
+            entry.get("pattern").and_then(|v| v.as_str()),
+            Some("**/*.rs")
+        );
+
+        let cfg = Config::load().expect("config still loads after the write");
+        let paths = &cfg.memory.extra_paths;
+        assert_eq!(paths.len(), 1);
+        match &paths[0] {
+            crate::config::ExtraPath::WithPattern { path, pattern } => {
+                assert_eq!(path, "/root/opencrabs/src");
+                assert_eq!(pattern, "**/*.rs");
+            }
+            other => panic!("expected WithPattern entry, got {other:?}"),
+        }
+    });
+}
+
+/// Object-shaped input becomes a real inline table, never a string literal
+/// (the old `{...}` coerce-to-string behaviour, #87). Uses struct-known
+/// fields (`url`, `model`) so the schema guard passes — `provider` is not an
+/// `EmbeddingConfig` field.
+#[test]
+fn object_input_writes_an_inline_table() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let written = Config::write_key(
+            "memory",
+            "embedding",
+            r#"{"url": "https://api.openai.com/v1", "model": "text-embedding-3-small"}"#,
+        )
+        .expect("object writes");
+        assert!(
+            written.contains("model = \"text-embedding-3-small\""),
+            "{written}"
+        );
+
+        let doc: toml_edit::DocumentMut = config_content(&home).parse().expect("valid TOML");
+        let tbl = doc["memory"]["embedding"]
+            .as_inline_table()
+            .expect("object written as inline table");
+        assert_eq!(
+            tbl.get("url").and_then(|v| v.as_str()),
+            Some("https://api.openai.com/v1")
+        );
+        assert_eq!(
+            tbl.get("model").and_then(|v| v.as_str()),
+            Some("text-embedding-3-small")
+        );
+    });
+}
+
+/// Scalar control: the plain integer path still lands as a real TOML integer.
+#[test]
+fn scalar_control_round_trips() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let written =
+            Config::write_key("memory", "sweep_interval_secs", "300").expect("integer writes");
+        assert_eq!(written, "300");
+
+        let doc: toml_edit::DocumentMut = config_content(&home).parse().expect("valid TOML");
+        assert_eq!(doc["memory"]["sweep_interval_secs"].as_integer(), Some(300));
+    });
+}
+
+/// `null` has no TOML representation — a hard error BEFORE the file is
+/// touched: the conversion fails inside write_key, write_item never runs,
+/// and config.toml keeps its exact bytes.
+#[test]
+fn null_value_is_a_hard_error_and_file_untouched() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let err = Config::write_key("memory", "extra_paths", "[null]")
+            .expect_err("null must be a hard error");
+        assert!(!err.to_string().is_empty(), "error carries a message");
+        assert!(err.to_string().contains("null"), "{}", err);
+        assert_eq!(
+            config_content(&home),
+            "[memory]\nvector_enabled = false\n",
+            "failed write must leave the file byte-identical"
+        );
+    });
+}
+
+/// TOML v1.0 arrays must be homogeneous; a JSON array mixing a number and a
+/// string is unrepresentable — hard error, file untouched.
+#[test]
+fn mixed_type_array_is_a_hard_error_and_file_untouched() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let err = Config::write_key("memory", "extra_paths", r#"[1, "x"]"#)
+            .expect_err("mixed-type array must be a hard error");
+        assert!(err.to_string().contains("mixes types"), "{}", err);
+        assert_eq!(
+            config_content(&home),
+            "[memory]\nvector_enabled = false\n",
+            "failed write must leave the file byte-identical"
+        );
+    });
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -203,6 +203,7 @@ pub mod config_update_test;
 pub mod config_voice_migration_test;
 pub mod config_watcher_test;
 pub mod config_write_path_test;
+pub mod config_write_types_test;
 pub mod content_vectors_heal_test;
 pub mod context_provider_anchor_test;
 pub mod context_store_concurrent_save_test;

--- a/src/utils/approval.rs
+++ b/src/utils/approval.rs
@@ -44,7 +44,7 @@ pub fn check_approval_policy() -> Option<(bool, bool)> {
 /// Persist "auto-session" approval policy to config.toml (single source of truth).
 pub fn persist_auto_session_policy() {
     match crate::config::Config::write_key("agent", "approval_policy", "auto-session") {
-        Ok(_) => tracing::info!("Persisted approval_policy = auto-session to config.toml"),
+        Ok(_written) => tracing::info!("Persisted approval_policy = auto-session to config.toml"),
         Err(e) => tracing::error!("Failed to persist approval_policy to config.toml: {}", e),
     }
 }
@@ -52,7 +52,7 @@ pub fn persist_auto_session_policy() {
 /// Persist "auto-always" (YOLO) approval policy to config.toml — permanent, survives restarts.
 pub fn persist_auto_always_policy() {
     match crate::config::Config::write_key("agent", "approval_policy", "auto-always") {
-        Ok(_) => tracing::info!("Persisted approval_policy = auto-always to config.toml"),
+        Ok(_written) => tracing::info!("Persisted approval_policy = auto-always to config.toml"),
         Err(e) => tracing::error!("Failed to persist approval_policy to config.toml: {}", e),
     }
 }


### PR DESCRIPTION
## Problem

`Config::write_key` accepted object- and array-shaped values but silently destroyed them:

- **Objects inside arrays were dropped**: the JSON→TOML conversion branch handled only `String`/`Number`/`Bool` elements; anything else hit `_ => {}` and was skipped. Writing `memory.extra_paths = [{ path = "...", pattern = "**/*.rs" }]` produced `extra_paths = []` — **with a success report and no error** (silent data loss).
- **Object-shaped values were written as string literals** (`"{...}"`), producing a config that never deserialized into the target field.
- **Mixed-type arrays were accepted**, but TOML v1.0 forbids them — the next config load would fail to parse.

## Fix

`write_key` now performs a **total recursive JSON→toml_edit conversion**:

- arrays of objects → arrays of inline tables, nested objects/arrays recurse;
- values TOML cannot represent (`null`, mixed-type arrays) → **hard error before the file is touched** (fail-closed, original file guaranteed intact);
- the return type changed `Result<()>` → `Result<String>` so the success message echoes the value actually written;
- call-site ripples updated (`commands.rs`, `approval.rs`, `cowork.rs`, `seed.rs`).

New test module `src/tests/config_write_types_test.rs`: array-of-tables round-trip, nested object round-trip, scalar round-trip, null rejection, mixed-type-array rejection (home-override isolated, no live-config writes).

Original issue: leshchenko1979/opencrabs#87
