### PR TITLE
feat(telegram): suggest options Go! tier + restored numbered fold (#119)

### DIFF
--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -363,10 +363,14 @@ const GO_TIER_VERB: &str = "Go";
 /// in markup here: the rich plane escapes+formats via `go_tier_lines_rich`;
 /// the markdown plane takes the raw line.
 pub(crate) fn go_tier_line(label: &str) -> String {
-    let starts_with_verb = label
+    // Verb match is whole-first-word, not a character prefix: "go fast"
+    // qualifies, "Gossip about it" does not (CI r2, E-test 139).
+    let first_word = label
         .trim_start()
-        .get(..GO_TIER_VERB.len())
-        .is_some_and(|first| first.eq_ignore_ascii_case(GO_TIER_VERB));
+        .split_whitespace()
+        .next()
+        .unwrap_or_default();
+    let starts_with_verb = first_word.eq_ignore_ascii_case(GO_TIER_VERB);
     if starts_with_verb {
         format!("{label}?")
     } else {

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -21,6 +21,12 @@ use super::TelegramState;
 /// Callback-data prefix for a tapped follow-up suggestion: `followup:<session>:<idx>`.
 pub(crate) const FOLLOWUP_PREFIX: &str = "followup:";
 
+/// Cross-turn glue staleness window (#91): the conversation's last rich-md
+/// answer only wears fresh controls while it is still "now" — older answers
+/// fall back to the standalone bubble, because options glued onto a stale
+/// shell read as fresh, answerable questions (the exact #1226 confusion).
+const CROSS_TURN_GLUE_MAX_AGE_SECS: i64 = 900;
+
 /// Body for the standalone fallback bubble (#1226 item 4). Prose mode keeps
 /// just the folded list (it has no buttons, nothing can expire); button
 /// modes carry the bare lamp plus an expiry marker — this fallback fires
@@ -30,7 +36,9 @@ pub(crate) const FOLLOWUP_PREFIX: &str = "followup:";
 /// minutes after its choices were consumed).
 pub(crate) fn standalone_fallback_body(layout: &SuggestLayout, options: &[String]) -> String {
     if *layout == SuggestLayout::NumberedProse {
-        folded_list_html(options).trim_start().to_string()
+        // #119 fold tier: the Go lines carry the questions; nothing else
+        // needed — no lamp, no list.
+        go_tier_lines_rich(options)
     } else {
         String::from("\u{1f4a1} <i>(choices may have expired)</i>")
     }
@@ -263,7 +271,7 @@ pub(crate) const SHARED_ROW_TOTAL_UNITS: usize = 20;
 /// the message body, so 12 keeps a safety margin under the worst bubble
 /// while doubling information per row vs the old 8.
 pub(crate) const SHARED_ROW_MAX_CHARS: usize = 12;
-/// Tap ergonomics (Alexey, 2026-08-25): numbered buttons never pack more
+/// Tap ergonomics (Alexey, 2026-08-25): #119 Go! buttons never pack more
 /// than 4 per row, so every target stays big enough for a finger.
 pub(crate) const MAX_NUMBERS_PER_ROW: usize = 4;
 
@@ -275,53 +283,84 @@ pub(crate) enum SuggestLayout {
     SharedRow,
     /// Every label fits a full-width button: one button per row.
     Column,
-    /// Some label too long even full-width: texts fold into the message
-    /// body as a numbered list, buttons collapse to bare numbers packed
+    /// Some label too long even full-width (#119 owner design): the fold
+    /// tier splits by set size (owner order 2026-09-09): n=1 = one bold
+    /// `Go: <label>?` body line + one `Go!` button; n>=2 = the ORIGINAL
+    /// plain numbered list `1. <label>` + plain digit buttons packed
     /// [`MAX_NUMBERS_PER_ROW`] per row.
     NumberedProse,
 }
 
+/// THE budget verdict — sole authority on whether one button row ships
+/// byte-identical or folds (#119 refactor, option A). Both consumers call
+/// THIS: `pick_layout` at the emitter and `enforce_button_fit` at the
+/// rich/api.rs funnel. Before this function, the two sites carried
+/// divergent copies of the budgets — the funnel re-folded full-width
+/// single-button rows the emitter had just approved, which is exactly
+/// the live #119 regression. One verdict = the divergence class is
+/// structurally impossible.
+///
+/// Row shapes:
+/// - ONE button renders FULL-WIDTH, so it gets the solo budget
+///   [`SINGLE_BUTTON_MAX_UNITS`] (30) — sized below every measured cut
+///   datapoint (32 wide-glyph native, 40-44 rich-plane — see #79) while
+///   clearing confirm-style labels (27 units) that the 20-unit shared
+///   gate wrongly folded.
+/// - Multi-button rows share keyboard width, so every label must fit
+///   [`SHARED_ROW_MAX_CHARS`] and the row total [`SHARED_ROW_TOTAL_UNITS`].
+///
+/// Width is the raw character count of the (already escaped) label text;
+/// entities overcount display width, which errs safe.
+pub(crate) fn row_fits(labels: &[&str]) -> bool {
+    if labels.len() == 1 {
+        labels[0].chars().count() <= SINGLE_BUTTON_MAX_UNITS
+    } else {
+        let total: usize = labels.iter().map(|l| l.chars().count()).sum();
+        labels
+            .iter()
+            .all(|l| l.chars().count() <= SHARED_ROW_MAX_CHARS)
+            && total <= SHARED_ROW_TOTAL_UNITS
+    }
+}
+
 pub(crate) fn pick_layout(options: &[String]) -> SuggestLayout {
     let width = |o: &String| o.chars().count();
-    let total: usize = options.iter().map(&width).sum();
-    if options.len() <= MAX_NUMBERS_PER_ROW
-        && options.iter().all(|o| width(o) <= SHARED_ROW_MAX_CHARS)
-        && total <= SHARED_ROW_TOTAL_UNITS
-    {
+    let refs: Vec<&str> = options.iter().map(|o| o.as_str()).collect();
+    if options.len() > 1 && options.len() <= MAX_NUMBERS_PER_ROW && row_fits(&refs) {
         SuggestLayout::SharedRow
-    } else if options.len() == 1 {
-        // Single-option set (#119): the fold tier's premise — cramming
-        // many long labels into shared rows — never applies at n=1, and
-        // a lone option folded into "1. <label>" prose plus a bare "1"
-        // button renders absurdly. One option rides a full-width button
-        // under its own clip point; only a label too wide even for a
-        // dedicated row folds. The budget sits below every measured cut
-        // datapoint (32 wide-glyph native, 40-44 rich-plane — see #79)
-        // while clearing confirm-style labels ("Smoke OK — ack both
-        // units", 27) that the 20-unit shared-row gate wrongly folded.
-        if width(&options[0]) <= SINGLE_BUTTON_MAX_UNITS {
-            SuggestLayout::Column
-        } else {
-            SuggestLayout::NumberedProse
-        }
-    } else if options.iter().all(|o| width(o) <= BUTTON_LABEL_MAX_UNITS) {
+    } else if options.iter().all(|o| width(o) <= BUTTON_LABEL_MAX_UNITS)
+        || (options.len() == 1 && width(&options[0]) <= SINGLE_BUTTON_MAX_UNITS)
+    {
+        // n=1 with a label past the shared 20-unit cap still rides
+        // full-width up to the solo budget (#119) — row_fits's solo arm.
         SuggestLayout::Column
     } else {
         SuggestLayout::NumberedProse
     }
 }
 
-/// The folded option list as rich HTML. REUSES the canonical inline
-/// primitives from `super::markdown` — `escape_html` → `format_inline`,
-/// the exact pair the outbound renderer's default line branch applies —
-/// instead of a private formatter. Options are independent ONE-line texts,
-/// so they deliberately skip document-level interpretation (a stray `|`
-/// must not turn the list into a table); inline markup (`code`, bold) and
-/// HTML escaping behave identically to every other Telegram surface.
-/// No "Suggested next" header — the list rides directly under the answer
-/// text in the same bubble (#tg-suggest-merge), so the label would only
-/// duplicate what the buttons already say.
-pub(crate) fn folded_list_html(options: &[String]) -> String {
+/// The folded option list as rich HTML (#119 fold tier). Set-size split
+/// (owner order 2026-09-09, "back to the way the numbered lists were
+/// before the Go button introduction"):
+/// n=1 keeps the confirmed Go! tier — one bold `Go: <label>?` line through
+/// the canonical inline primitives (`escape_html` → `format_inline`);
+/// n>=2 reverts to the ORIGINAL plain numbered list (`1. <label>` — no
+/// `Go:` prefix, no `?` mutation, no bold), byte-identical semantics to
+/// the pre-`c92873b1` `folded_list_html`. Options are independent ONE-line
+/// texts, so they deliberately skip document-level interpretation (a
+/// stray `|` must not turn the line into a table). No "Suggested next"
+/// header — the lines ride directly under the answer text in the same
+/// bubble (#tg-suggest-merge).
+pub(crate) fn go_tier_lines_rich(options: &[String]) -> String {
+    if options.len() == 1 {
+        return options
+            .iter()
+            .map(|opt| {
+                super::markdown::format_inline(&super::markdown::escape_html(&go_tier_line(opt)))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
     options
         .iter()
         .enumerate()
@@ -336,39 +375,34 @@ pub(crate) fn folded_list_html(options: &[String]) -> String {
         .join("\n")
 }
 
-/// NumberedProse fold for the markdown plane (#79 piece 4): a plain
-/// numbered list — the server's markdown render keeps the numbering and
-/// the line breaks, no `<p>` wrapping needed on this plane.
-pub(crate) fn folded_list_markdown(options: &[String]) -> String {
-    options
-        .iter()
-        .enumerate()
-        .map(|(i, opt)| format!("{}. {}", i + 1, opt))
-        .collect::<Vec<_>>()
-        .join("\n")
+/// The fold-tier button label for one option — set-size split (owner
+/// order 2026-09-09): n>=2 = the ORIGINAL plain digit (`1`, `2`, …),
+/// pairing with the restored `1. <label>` body lines; n=1 = the single
+/// `Go!` button of the confirmed Go! tier. `number` is 1-based.
+pub(crate) fn go_button_label(number: usize, is_single: bool) -> String {
+    if is_single {
+        String::from("Go!")
+    } else {
+        number.to_string()
+    }
 }
 
-/// The label of every NumberedProse-tier button after the #119 owner
-/// redesign: the option text moves into the body, the button just says Go!.
-pub(crate) const GO_BUTTON_LABEL: &str = "Go!";
-
-/// The verb the #119 fold tier names options with — the first word of the
-/// `Go: <label>?` body line and the GO_BUTTON_LABEL button minus its bang.
+/// The verb the #119 fold tier names options with — the word the numbered
+/// `N. Go: <label>?` body line prefixes the label with.
 const GO_TIER_VERB: &str = "Go";
 
-/// One #119 fold-tier body line for one option (owner design 06:42Z +
-/// verb-repeat amendment 06:46Z): the label verbatim + `?` when it already
-/// starts with the verb (`Go — implement #98…?`), `<Verb>: <label>?`
-/// otherwise (`Go: Smoke OK — ack both units?`). The label is NOT re-wrapped
-/// in markup here: the rich plane escapes+formats via `go_tier_lines_rich`;
-/// the markdown plane takes the raw line.
+/// One #119 single-option fold-tier body line (n=1 ONLY — owner design
+/// 06:42Z + verb-repeat amendment 06:46Z, render corrections 2026-09-09):
+/// `Go: <label>?` — label verbatim + `?` unless it already ends one
+/// (`Go — implement #98…?`), `Go: <label>?` otherwise (`Go: Smoke OK —
+/// ack both units?`). The label is NOT re-wrapped in markup here: the
+/// rich plane escapes+formats via `go_tier_lines_rich`; the markdown
+/// plane takes the raw line. For n>=2 the fold is the plain numbered
+/// list (owner order 2026-09-09) — this Go! line never fires there.
 pub(crate) fn go_tier_line(label: &str) -> String {
     // Verb match is whole-first-word, not a character prefix: "go fast"
     // qualifies, "Gossip about it" does not (CI r2, E-test 139).
-    let first_word = label
-        .split_whitespace()
-        .next()
-        .unwrap_or_default();
+    let first_word = label.split_whitespace().next().unwrap_or_default();
     let starts_with_verb = first_word.eq_ignore_ascii_case(GO_TIER_VERB);
     // Owner render correction 2026-09-09: a label that already ends with a
     // question mark must not get a second one; the whole line renders bold
@@ -381,12 +415,20 @@ pub(crate) fn go_tier_line(label: &str) -> String {
     }
 }
 
-/// The #119 fold-tier body block: one go_tier_line per option, one line
-/// each, in order.
+/// The #119 fold-tier body block. Set-size split (owner order 2026-09-09,
+/// "back to the way the numbered lists were before the Go button
+/// introduction"): n=1 = one bold `go_tier_line`; n>=2 = the ORIGINAL
+/// plain numbered list `1. <label>` (markdown plane) — byte-identical to
+/// the pre-`c92873b1` `folded_list_markdown`. The n>=2 buttons are digit
+/// buttons whose labels already pair with these lines.
 pub(crate) fn go_tier_lines(options: &[String]) -> String {
+    if options.len() == 1 {
+        return go_tier_line(&options[0]);
+    }
     options
         .iter()
-        .map(|o| go_tier_line(o))
+        .enumerate()
+        .map(|(i, o)| format!("{}. {}", i + 1, o))
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -422,27 +464,29 @@ pub(crate) fn empty_keyboard() -> teloxide::types::InlineKeyboardMarkup {
 /// controls passes through here on send and edit (the `rich/api.rs`
 /// funnel), so hand-authored button rows from any lane get the same
 /// measured fit rule the suggestion cards enforce at their own emitter —
-/// the n8n-card cut class. If every label fits [`BUTTON_LABEL_MAX_UNITS`]
-/// and every row's total fits [`SHARED_ROW_TOTAL_UNITS`], the body ships
-/// byte-identical. Otherwise the whole set folds to the NumberedProse
-/// shape (proven cut-free twice in #79): buttons keep their attributes —
-/// callback data and URL routing are untouched — but render their 1-based
-/// index, and the original labels move into an `<ol>` after the last row.
-/// Idempotent: a folded body's digit labels never re-trigger the fold.
-/// Width is the raw character count of the (already escaped) label text;
-/// entities overcount display width, which errs safe.
+/// the n8n-card cut class. Row verdicts go through [`row_fits`] — the
+/// single budget authority (#119 option A): one-button rows ride the
+/// solo budget, shared rows the per-label + row-total caps. If every
+/// row fits, the body ships byte-identical. Otherwise the whole set
+/// folds to the NumberedProse shape (proven cut-free twice in #79):
+/// buttons keep their attributes — callback data and URL routing are
+/// untouched — but render their 1-based index, and the original labels
+/// move into an `<ol>` after the last row. Idempotent: a folded body's
+/// digit labels never re-trigger the fold.
 pub(crate) fn enforce_button_fit(html: &str) -> String {
     const ROW_OPEN: &str = "<tg-button-row>";
     const ROW_CLOSE: &str = "</tg-button-row>";
     const BTN_OPEN: &str = "<tg-button";
     const BTN_CLOSE: &str = "</tg-button>";
 
-    let width = |s: &str| s.chars().count();
-
     // Pass 1 — collect row spans, per-row open tags, and all labels.
+    // Per-row verdicts go through row_fits — THE single budget authority
+    // (#119 option A): the funnel no longer carries its own cap copies,
+    // so it can never re-fold a row the emitter legitimately approved.
     let mut rows: Vec<(usize, usize)> = Vec::new();
     let mut open_tags: Vec<Vec<&str>> = Vec::new();
     let mut labels: Vec<&str> = Vec::new();
+    let mut row_labels: Vec<&str> = Vec::new();
     let mut fits = true;
     let mut scan_from = 0usize;
     while let Some(rel) = html[scan_from..].find(ROW_OPEN) {
@@ -452,8 +496,8 @@ pub(crate) fn enforce_button_fit(html: &str) -> String {
         };
         let row_end = row_start + crel + ROW_CLOSE.len();
         let block = &html[row_start + ROW_OPEN.len()..row_end - ROW_CLOSE.len()];
-        let mut row_total = 0usize;
         let mut tags_in_row: Vec<&str> = Vec::new();
+        row_labels.clear();
         let mut bscan = 0usize;
         while let Some(brel) = block[bscan..].find(BTN_OPEN) {
             let bstart = bscan + brel;
@@ -472,13 +516,12 @@ pub(crate) fn enforce_button_fit(html: &str) -> String {
                 break;
             };
             let label = &block[label_start..label_start + lrel];
-            row_total += width(label);
-            fits &= width(label) <= BUTTON_LABEL_MAX_UNITS;
+            row_labels.push(label);
             tags_in_row.push(open_tag);
             labels.push(label);
             bscan = label_start + lrel + BTN_CLOSE.len();
         }
-        fits &= row_total <= SHARED_ROW_TOTAL_UNITS;
+        fits &= row_fits(&row_labels);
         rows.push((row_start, row_end));
         open_tags.push(tags_in_row);
         scan_from = row_end;
@@ -545,13 +588,13 @@ pub(crate) fn append_rows_and_trailer_md(
     trailer: Option<&str>,
 ) {
     if prose {
-        // Markdown plane, #119 fold tier: one `Go: <label>?` line per
-        // option (label verbatim when it starts with the verb) — never a
-        // numbered list. Raw lines: the markdown plane renders them
-        // plainly, no html primitives needed. Blank line before the block:
-        // owner correction 2026-09-09 — a single \n glued the Go: line to
-        // the body's last line (Telegram rich renderer needs a paragraph
-        // break there).
+        // Markdown plane, #119 fold tier (set-size split, owner order
+        // 2026-09-09): n=1 = one bold `Go: <label>?` line; n>=2 = the
+        // original plain numbered list. Raw lines: the markdown plane
+        // renders them plainly, no html primitives needed. Blank line
+        // before the block: owner correction 2026-09-09 — a single \n
+        // glued the fold block to the body's last line (Telegram rich
+        // renderer needs a paragraph break there).
         push_blank_line(md);
         md.push_str(&go_tier_lines(options));
     }
@@ -592,7 +635,7 @@ pub(crate) fn suggestion_rows_rich_html(options: &[String], token: &str) -> Stri
             .collect::<Vec<_>>()
             .join("\n"),
         SuggestLayout::NumberedProse => (0..options.len())
-            .map(|i| btn(i, &(i + 1).to_string()))
+            .map(|i| btn(i, &go_button_label(i + 1, options.len() == 1)))
             .collect::<Vec<_>>()
             .chunks(MAX_NUMBERS_PER_ROW)
             .map(|c| format!("<tg-button-row>{}</tg-button-row>", c.concat()))
@@ -621,6 +664,12 @@ pub(crate) async fn render_suggestions(
     // shape: its own bubble after placement — content, not chrome, so it
     // ships even when the buttons die.
     trailer: Option<String>,
+    // #91 cross-turn glue: the channel-message repo, when the surface has
+    // one. When this turn captured no merge host, the glue rung looks up the
+    // conversation's last rich-markdown answer and hangs the controls off
+    // THAT bubble instead of posting the bare standalone fallback. None =
+    // glue unavailable (no db surface / tests), standalone as before.
+    glue_repo: Option<crate::db::repository::ChannelMessageRepository>,
 ) {
     if options.is_empty() {
         // Stash cleared between delivery and render (mid-turn tap, newer
@@ -643,16 +692,15 @@ pub(crate) async fn render_suggestions(
     // and SINGLE_BUTTON_MAX_UNITS): short labels share one row, medium
     // labels get a full-width row each, a lone option rides one
     // full-width button up to its own clip point (#119), and anything
-    // longer folds into the body as a numbered list with compact
-    // number buttons (<=4 per row). The absolute index is encoded in the
+    // longer folds into the body (set-size split, owner order 2026-09-09):
+    // n=1 = bold `Go: <label>?` + a Go! button; n>=2 = the original plain
+    // numbered list with digit buttons (<=4 per row). The absolute index
+    // is encoded in the
     // callback data; the option text itself can exceed Telegram's 64-byte
     // callback-data limit, so we never put it there.
     let layout = pick_layout(&options);
     let text_btn = |i: usize, opt: &str| {
         InlineKeyboardButton::callback(opt.to_string(), format!("{FOLLOWUP_PREFIX}{token}:{i}"))
-    };
-    let num_btn = |i: usize| {
-        InlineKeyboardButton::callback((i + 1).to_string(), format!("{FOLLOWUP_PREFIX}{token}:{i}"))
     };
     let rows: Vec<Vec<InlineKeyboardButton>> = match layout {
         SuggestLayout::SharedRow => vec![
@@ -668,7 +716,14 @@ pub(crate) async fn render_suggestions(
             .map(|(i, opt)| vec![text_btn(i, opt)])
             .collect(),
         SuggestLayout::NumberedProse => {
-            let all: Vec<InlineKeyboardButton> = (0..options.len()).map(num_btn).collect();
+            let all: Vec<InlineKeyboardButton> = (0..options.len())
+                .map(|i| {
+                    InlineKeyboardButton::callback(
+                        go_button_label(i + 1, options.len() == 1),
+                        format!("{FOLLOWUP_PREFIX}{token}:{i}"),
+                    )
+                })
+                .collect();
             all.chunks(MAX_NUMBERS_PER_ROW)
                 .map(|c| c.to_vec())
                 .collect()
@@ -678,7 +733,8 @@ pub(crate) async fn render_suggestions(
     let keyboard = InlineKeyboardMarkup::new(rows);
 
     // Primary path: MERGE onto the answer bubble (#tg-suggest-merge). Prose
-    // mode appends the numbered list under the answer text; button modes add
+    // mode appends the `Go: <label>?` lines under the answer text (#119
+    // fold tier); button modes add
     // nothing on the classic surface (the buttons carry everything). Rich
     // bubbles additionally get native <tg-button-row> controls INSIDE the
     // message body. Both placement payloads are built ONCE — before the first
@@ -697,10 +753,12 @@ pub(crate) async fn render_suggestions(
                 let mut body = html;
                 if layout == SuggestLayout::NumberedProse {
                     // Classic hosts preserve the raw newline join via
-                    // go_tier_lines_rich (#119 fold tier: Go: label? lines,
-                    // never a numbered list). Paragraph break before the
-                    // block — owner correction 2026-09-09: a single \n
-                    // glued the Go: line to the body's last line.
+                    // go_tier_lines_rich (#119 fold tier: n=1 = bold
+                    // `Go: <label>?`; n>=2 = the original plain numbered
+                    // list — owner order 2026-09-09). Paragraph break
+                    // before the block — owner correction 2026-09-09: a
+                    // single \n glued the fold block to the body's last
+                    // line.
                     if !body.ends_with('\n') {
                         body.push('\n');
                     }
@@ -737,13 +795,46 @@ pub(crate) async fn render_suggestions(
             new_html,
             rich,
             new_markdown,
+            glue: false,
         }
     });
 
-    // Standalone fallback (no merge candidate, or the edit lost a race / grew
-    // too old): the header sentence is still gone per #tg-suggest-merge —
-    // prose mode shows just the numbered list, button modes need SOME text
-    // for the Bot API to accept the message, so they degrade to the bare 💡.
+    // #91 cross-turn glue: when this turn produced no bubble of its own, the
+    // glue rung looks up the conversation's LAST rich-markdown answer and
+    // hangs the controls off THAT bubble — one message instead of the bare
+    // standalone fallback. Guards live in the lookup (staleness window,
+    // thread match) and in the target check (no live keyboard may already
+    // ride the target — ours would clobber it, and a #59 strip would later
+    // rip the fresh buttons off). Computed ONCE, like the merge payload, so
+    // a Retry-After deferral re-sends byte-identical content.
+    let placement_payload = if merge_payload.is_none() {
+        match glue_repo.as_ref() {
+            Some(repo) => {
+                cross_turn_glue(
+                    state,
+                    repo,
+                    chat_id,
+                    thread_id,
+                    &token,
+                    &layout,
+                    &options,
+                    trailer.as_ref(),
+                )
+                .await
+            }
+            None => None,
+        }
+    } else {
+        None
+    };
+    let placement_payload = placement_payload.or(merge_payload);
+
+    // Standalone fallback (no merge candidate, no glue target, or the edit
+    // lost a race / grew too old): the header sentence is still gone per
+    // #tg-suggest-merge — prose mode shows just the `Go: <label>?` lines
+    // (#119 fold tier; they ARE the questions), button
+    // modes need SOME text for the Bot API to accept the message, so they
+    // degrade to the bare 💡.
     let standalone_body = standalone_fallback_body(&layout, &options);
 
     let option_count = options.len();
@@ -755,7 +846,7 @@ pub(crate) async fn render_suggestions(
         &token,
         option_count,
         &keyboard,
-        merge_payload.as_ref(),
+        placement_payload.as_ref(),
         &standalone_body,
     )
     .await
@@ -812,7 +903,7 @@ pub(crate) async fn render_suggestions(
                         &token,
                         option_count,
                         &keyboard,
-                        merge_payload.as_ref(),
+                        placement_payload.as_ref(),
                         &standalone_body,
                     )
                     .await
@@ -862,8 +953,79 @@ pub(crate) async fn render_suggestions(
     }
 }
 
+/// #91 cross-turn glue: build a placement payload that hangs this turn's
+/// controls off the conversation's LAST rich-markdown answer, or `None` when
+/// no legal target exists (no recent answer, wrong plane, or a live keyboard
+/// already riding it — the standalone bubble fires instead). Same-thread and
+/// staleness guards live in the repo lookup; the clobber guard runs here
+/// against the in-memory registries.
+#[allow(clippy::too_many_arguments)]
+async fn cross_turn_glue(
+    state: &Arc<TelegramState>,
+    repo: &crate::db::repository::ChannelMessageRepository,
+    chat_id: ChatId,
+    thread_id: Option<ThreadId>,
+    token: &str,
+    layout: &SuggestLayout,
+    options: &[String],
+    trailer: Option<&String>,
+) -> Option<MergePayload> {
+    let target = repo
+        .last_bot_rich_md(
+            "telegram",
+            &chat_id.0.to_string(),
+            thread_id.map(|t| t.0.to_string()).as_deref(),
+            CROSS_TURN_GLUE_MAX_AGE_SECS,
+        )
+        .await
+        .ok()
+        .flatten()?;
+    let mid = MessageId(target.0.parse().ok()?);
+    if state.message_hosts_live_keyboard(mid).await {
+        tracing::info!(
+            "Telegram suggest_options: cross-turn glue skipped — msg {} already \
+             hosts a keyboard (#91)",
+            mid.0
+        );
+        return None;
+    }
+    // Payload mirrors the markdown-merge arm exactly (#79 piece 4): stored
+    // markdown + folded list (prose mode) + in-body button rows + trailer,
+    // with the html conversion kept only as the strip source.
+    let mut new_md = target.1;
+    if *layout == SuggestLayout::NumberedProse {
+        // #119 fold tier: Go lines replace the numbered list (mirrors the
+        // markdown-merge arm byte-for-byte in construction). Paragraph
+        // break before the block — owner correction 2026-09-09: a single
+        // \n glued the Go: line to the body's last line.
+        push_blank_line(&mut new_md);
+        new_md.push_str(&go_tier_lines(options));
+    }
+    new_md.push('\n');
+    new_md.push_str(&suggestion_rows_rich_html(options, token));
+    if let Some(t) = trailer {
+        new_md.push('\n');
+        new_md.push_str(t);
+    }
+    let strip_source = super::rich::markdown_to_html_p(&new_md);
+    tracing::info!(
+        "Telegram suggest_options: cross-turn glue target msg {} (token {token}, \
+         {} options)",
+        mid.0,
+        options.len()
+    );
+    Some(MergePayload {
+        message_id: mid,
+        new_html: strip_source,
+        rich: true,
+        new_markdown: Some(new_md),
+        glue: true,
+    })
+}
+
 /// Pre-built merge-edit payload (#30): computed ONCE per suggestion block so
 /// a deferred re-placement after a Retry-After re-sends byte-identical
+/// content. `rich` picks the wire: rich bubbles edit via the rich API with
 /// in-body button rows, classic bubbles via editMessageText + reply_markup.
 #[derive(Clone)]
 struct MergePayload {
@@ -874,6 +1036,12 @@ struct MergePayload {
     /// every later redraw ride `edit_rich_markdown`; `new_html` then only
     /// feeds the host record's strip source.
     new_markdown: Option<String>,
+    /// #91 cross-turn glue: the controls hang off the PREVIOUS turn's
+    /// bubble (its last rich-md answer) instead of this turn's answer.
+    /// Wording-only today — the wire path is identical to a markdown merge —
+    /// but the log lines name the arm, so a tap on a glued keyboard maps
+    /// back to the rung that placed it.
+    glue: bool,
 }
 
 /// Placement error class (#30): decides whether the stash survives the
@@ -1071,10 +1239,13 @@ async fn place_once(
         match outcome {
             Ok(()) => {
                 // Name the arm, the host message and the token so any tap can
-                // be mapped back to its panel from logs alone.
+                // be mapped back to its panel from logs alone. Glue (#91)
+                // names its rung: the controls hang off the previous turn's
+                // bubble, not this turn's answer.
                 tracing::info!(
-                    "Telegram suggest_options: keyboard merged onto msg {mid} \
+                    "Telegram suggest_options: keyboard {} msg {mid} \
                      ({} host, token {token}, {option_count} options)",
+                    if mp.glue { "glued onto" } else { "merged onto" },
                     if mp.new_markdown.is_some() {
                         "rich-md"
                     } else if mp.rich {

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -370,10 +370,14 @@ pub(crate) fn go_tier_line(label: &str) -> String {
         .next()
         .unwrap_or_default();
     let starts_with_verb = first_word.eq_ignore_ascii_case(GO_TIER_VERB);
+    // Owner render correction 2026-09-09: a label that already ends with a
+    // question mark must not get a second one; the whole line renders bold
+    // (`**` survives escape_html, format_inline/native md both turn it <b>).
+    let terminator = if label.ends_with('?') { "" } else { "?" };
     if starts_with_verb {
-        format!("{label}?")
+        format!("**{label}{terminator}**")
     } else {
-        format!("{GO_TIER_VERB}: {label}?")
+        format!("**{GO_TIER_VERB}: {label}{terminator}**")
     }
 }
 
@@ -541,10 +545,15 @@ pub(crate) fn append_rows_and_trailer_md(
     trailer: Option<&str>,
 ) {
     if prose {
-        // Markdown plane: plain numbered list — the server's
-        // markdown render keeps numbering and line breaks.
-        md.push('\n');
-        md.push_str(&folded_list_markdown(options));
+        // Markdown plane, #119 fold tier: one `Go: <label>?` line per
+        // option (label verbatim when it starts with the verb) — never a
+        // numbered list. Raw lines: the markdown plane renders them
+        // plainly, no html primitives needed. Blank line before the block:
+        // owner correction 2026-09-09 — a single \n glued the Go: line to
+        // the body's last line (Telegram rich renderer needs a paragraph
+        // break there).
+        push_blank_line(md);
+        md.push_str(&go_tier_lines(options));
     }
     push_blank_line(md);
     md.push_str(&suggestion_rows_rich_html(options, token));
@@ -688,9 +697,15 @@ pub(crate) async fn render_suggestions(
                 let mut body = html;
                 if layout == SuggestLayout::NumberedProse {
                     // Classic hosts preserve the raw newline join via
-                    // folded_list_html.
+                    // go_tier_lines_rich (#119 fold tier: Go: label? lines,
+                    // never a numbered list). Paragraph break before the
+                    // block — owner correction 2026-09-09: a single \n
+                    // glued the Go: line to the body's last line.
+                    if !body.ends_with('\n') {
+                        body.push('\n');
+                    }
                     body.push('\n');
-                    body.push_str(folded_list_html(&options).trim_start());
+                    body.push_str(&go_tier_lines_rich(&options));
                 }
                 (body, false, None)
             }
@@ -849,7 +864,6 @@ pub(crate) async fn render_suggestions(
 
 /// Pre-built merge-edit payload (#30): computed ONCE per suggestion block so
 /// a deferred re-placement after a Retry-After re-sends byte-identical
-/// content. `rich` picks the wire: rich bubbles edit via the rich API with
 /// in-body button rows, classic bubbles via editMessageText + reply_markup.
 #[derive(Clone)]
 struct MergePayload {

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -242,6 +242,15 @@ pub(crate) fn mark_picked_button(html: &str, picked_idx: usize) -> String {
 /// display width; plain `chars().count()` overcounts slim-glyph labels,
 /// which errs safe.
 pub(crate) const BUTTON_LABEL_MAX_UNITS: usize = 20;
+/// Full-width clip point for a SINGLE-option button (#119). One button on
+/// its own row carries more than a shared-row label — the old pre-#79
+/// 50-char budget rode this shape — but not unlimited: cuts were measured
+/// at 32 (wide-glyph native) and 40-44 (rich-plane), so 30 keeps a margin
+/// under every datapoint while clearing the 27-char live-smoke label the
+/// 20-unit shared-row gate wrongly folded. One label is also the only
+/// place the owner reads the full text against a single control — the
+/// fold tier's cramming premise never applies at n=1.
+pub(crate) const SINGLE_BUTTON_MAX_UNITS: usize = 30;
 /// Total width one row of buttons may carry before the set folds (issue
 /// #79: 3x12=36 shared-row cut, 4x12=43 cut; only a 24 slim-tail pair
 /// held — same conservative-by-design rule as [`BUTTON_LABEL_MAX_UNITS`]).
@@ -280,6 +289,19 @@ pub(crate) fn pick_layout(options: &[String]) -> SuggestLayout {
         && total <= SHARED_ROW_TOTAL_UNITS
     {
         SuggestLayout::SharedRow
+    } else if options.len() == 1 {
+        // Single-option set (#119): the fold tier's premise — cramming
+        // many long labels into shared rows — never applies at n=1, and
+        // a lone option folded into "1. <label>" prose plus a bare "1"
+        // button renders absurdly. One option rides a full-width button
+        // under its own clip point; only a label too wide even for a
+        // dedicated row folds. The budget sits below every measured cut
+        // datapoint (32 wide-glyph native, 40-44 rich-plane — see #79)
+        // while clearing confirm-style labels ("Smoke OK — ack both
+        // units", 27) that the 20-unit shared-row gate wrongly folded.
+        (width(&options[0]) <= SINGLE_BUTTON_MAX_UNITS)
+            .then_some(SuggestLayout::Column)
+            .unwrap_or(SuggestLayout::NumberedProse)
     } else if options.iter().all(|o| width(o) <= BUTTON_LABEL_MAX_UNITS) {
         SuggestLayout::Column
     } else {
@@ -567,10 +589,11 @@ pub(crate) async fn render_suggestions(
         .register_pending_followups(session_id, options.clone())
         .await;
 
-    // Layout tiers are measured, not guessed (see BUTTON_LABEL_MAX_UNITS):
-    // short
-    // labels share one row, medium labels get a full-width row each, and
-    // anything longer folds into the body as a numbered list with compact
+    // Layout tiers are measured, not guessed (see BUTTON_LABEL_MAX_UNITS
+    // and SINGLE_BUTTON_MAX_UNITS): short labels share one row, medium
+    // labels get a full-width row each, a lone option rides one
+    // full-width button up to its own clip point (#119), and anything
+    // longer folds into the body as a numbered list with compact
     // number buttons (<=4 per row). The absolute index is encoded in the
     // callback data; the option text itself can exceed Telegram's 64-byte
     // callback-data limit, so we never put it there.

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -21,12 +21,6 @@ use super::TelegramState;
 /// Callback-data prefix for a tapped follow-up suggestion: `followup:<session>:<idx>`.
 pub(crate) const FOLLOWUP_PREFIX: &str = "followup:";
 
-/// Cross-turn glue staleness window (#91): the conversation's last rich-md
-/// answer only wears fresh controls while it is still "now" — older answers
-/// fall back to the standalone bubble, because options glued onto a stale
-/// shell read as fresh, answerable questions (the exact #1226 confusion).
-const CROSS_TURN_GLUE_MAX_AGE_SECS: i64 = 900;
-
 /// Body for the standalone fallback bubble (#1226 item 4). Prose mode keeps
 /// just the folded list (it has no buttons, nothing can expire); button
 /// modes carry the bare lamp plus an expiry marker — this fallback fires
@@ -664,12 +658,6 @@ pub(crate) async fn render_suggestions(
     // shape: its own bubble after placement — content, not chrome, so it
     // ships even when the buttons die.
     trailer: Option<String>,
-    // #91 cross-turn glue: the channel-message repo, when the surface has
-    // one. When this turn captured no merge host, the glue rung looks up the
-    // conversation's last rich-markdown answer and hangs the controls off
-    // THAT bubble instead of posting the bare standalone fallback. None =
-    // glue unavailable (no db surface / tests), standalone as before.
-    glue_repo: Option<crate::db::repository::ChannelMessageRepository>,
 ) {
     if options.is_empty() {
         // Stash cleared between delivery and render (mid-turn tap, newer
@@ -795,41 +783,12 @@ pub(crate) async fn render_suggestions(
             new_html,
             rich,
             new_markdown,
-            glue: false,
         }
     });
 
-    // #91 cross-turn glue: when this turn produced no bubble of its own, the
-    // glue rung looks up the conversation's LAST rich-markdown answer and
-    // hangs the controls off THAT bubble — one message instead of the bare
-    // standalone fallback. Guards live in the lookup (staleness window,
-    // thread match) and in the target check (no live keyboard may already
-    // ride the target — ours would clobber it, and a #59 strip would later
-    // rip the fresh buttons off). Computed ONCE, like the merge payload, so
-    // a Retry-After deferral re-sends byte-identical content.
-    let placement_payload = if merge_payload.is_none() {
-        match glue_repo.as_ref() {
-            Some(repo) => {
-                cross_turn_glue(
-                    state,
-                    repo,
-                    chat_id,
-                    thread_id,
-                    &token,
-                    &layout,
-                    &options,
-                    trailer.as_ref(),
-                )
-                .await
-            }
-            None => None,
-        }
-    } else {
-        None
-    };
-    let placement_payload = placement_payload.or(merge_payload);
+    let placement_payload = merge_payload;
 
-    // Standalone fallback (no merge candidate, no glue target, or the edit
+    // Standalone fallback (no merge candidate, or the edit
     // lost a race / grew too old): the header sentence is still gone per
     // #tg-suggest-merge — prose mode shows just the `Go: <label>?` lines
     // (#119 fold tier; they ARE the questions), button
@@ -953,76 +912,6 @@ pub(crate) async fn render_suggestions(
     }
 }
 
-/// #91 cross-turn glue: build a placement payload that hangs this turn's
-/// controls off the conversation's LAST rich-markdown answer, or `None` when
-/// no legal target exists (no recent answer, wrong plane, or a live keyboard
-/// already riding it — the standalone bubble fires instead). Same-thread and
-/// staleness guards live in the repo lookup; the clobber guard runs here
-/// against the in-memory registries.
-#[allow(clippy::too_many_arguments)]
-async fn cross_turn_glue(
-    state: &Arc<TelegramState>,
-    repo: &crate::db::repository::ChannelMessageRepository,
-    chat_id: ChatId,
-    thread_id: Option<ThreadId>,
-    token: &str,
-    layout: &SuggestLayout,
-    options: &[String],
-    trailer: Option<&String>,
-) -> Option<MergePayload> {
-    let target = repo
-        .last_bot_rich_md(
-            "telegram",
-            &chat_id.0.to_string(),
-            thread_id.map(|t| t.0.to_string()).as_deref(),
-            CROSS_TURN_GLUE_MAX_AGE_SECS,
-        )
-        .await
-        .ok()
-        .flatten()?;
-    let mid = MessageId(target.0.parse().ok()?);
-    if state.message_hosts_live_keyboard(mid).await {
-        tracing::info!(
-            "Telegram suggest_options: cross-turn glue skipped — msg {} already \
-             hosts a keyboard (#91)",
-            mid.0
-        );
-        return None;
-    }
-    // Payload mirrors the markdown-merge arm exactly (#79 piece 4): stored
-    // markdown + folded list (prose mode) + in-body button rows + trailer,
-    // with the html conversion kept only as the strip source.
-    let mut new_md = target.1;
-    if *layout == SuggestLayout::NumberedProse {
-        // #119 fold tier: Go lines replace the numbered list (mirrors the
-        // markdown-merge arm byte-for-byte in construction). Paragraph
-        // break before the block — owner correction 2026-09-09: a single
-        // \n glued the Go: line to the body's last line.
-        push_blank_line(&mut new_md);
-        new_md.push_str(&go_tier_lines(options));
-    }
-    new_md.push('\n');
-    new_md.push_str(&suggestion_rows_rich_html(options, token));
-    if let Some(t) = trailer {
-        new_md.push('\n');
-        new_md.push_str(t);
-    }
-    let strip_source = super::rich::markdown_to_html_p(&new_md);
-    tracing::info!(
-        "Telegram suggest_options: cross-turn glue target msg {} (token {token}, \
-         {} options)",
-        mid.0,
-        options.len()
-    );
-    Some(MergePayload {
-        message_id: mid,
-        new_html: strip_source,
-        rich: true,
-        new_markdown: Some(new_md),
-        glue: true,
-    })
-}
-
 /// Pre-built merge-edit payload (#30): computed ONCE per suggestion block so
 /// a deferred re-placement after a Retry-After re-sends byte-identical
 /// content. `rich` picks the wire: rich bubbles edit via the rich API with
@@ -1036,12 +925,6 @@ struct MergePayload {
     /// every later redraw ride `edit_rich_markdown`; `new_html` then only
     /// feeds the host record's strip source.
     new_markdown: Option<String>,
-    /// #91 cross-turn glue: the controls hang off the PREVIOUS turn's
-    /// bubble (its last rich-md answer) instead of this turn's answer.
-    /// Wording-only today — the wire path is identical to a markdown merge —
-    /// but the log lines name the arm, so a tap on a glued keyboard maps
-    /// back to the rung that placed it.
-    glue: bool,
 }
 
 /// Placement error class (#30): decides whether the stash survives the
@@ -1238,14 +1121,9 @@ async fn place_once(
         };
         match outcome {
             Ok(()) => {
-                // Name the arm, the host message and the token so any tap can
-                // be mapped back to its panel from logs alone. Glue (#91)
-                // names its rung: the controls hang off the previous turn's
-                // bubble, not this turn's answer.
                 tracing::info!(
-                    "Telegram suggest_options: keyboard {} msg {mid} \
+                    "Telegram suggest_options: keyboard merged onto msg {mid} \
                      ({} host, token {token}, {option_count} options)",
-                    if mp.glue { "glued onto" } else { "merged onto" },
                     if mp.new_markdown.is_some() {
                         "rich-md"
                     } else if mp.rich {

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -299,9 +299,11 @@ pub(crate) fn pick_layout(options: &[String]) -> SuggestLayout {
         // datapoint (32 wide-glyph native, 40-44 rich-plane — see #79)
         // while clearing confirm-style labels ("Smoke OK — ack both
         // units", 27) that the 20-unit shared-row gate wrongly folded.
-        (width(&options[0]) <= SINGLE_BUTTON_MAX_UNITS)
-            .then_some(SuggestLayout::Column)
-            .unwrap_or(SuggestLayout::NumberedProse)
+        if width(&options[0]) <= SINGLE_BUTTON_MAX_UNITS {
+            SuggestLayout::Column
+        } else {
+            SuggestLayout::NumberedProse
+        }
     } else if options.iter().all(|o| width(o) <= BUTTON_LABEL_MAX_UNITS) {
         SuggestLayout::Column
     } else {

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -348,6 +348,42 @@ pub(crate) fn folded_list_markdown(options: &[String]) -> String {
         .join("\n")
 }
 
+/// The label of every NumberedProse-tier button after the #119 owner
+/// redesign: the option text moves into the body, the button just says Go!.
+pub(crate) const GO_BUTTON_LABEL: &str = "Go!";
+
+/// The verb the #119 fold tier names options with — the first word of the
+/// `Go: <label>?` body line and the GO_BUTTON_LABEL button minus its bang.
+const GO_TIER_VERB: &str = "Go";
+
+/// One #119 fold-tier body line for one option (owner design 06:42Z +
+/// verb-repeat amendment 06:46Z): the label verbatim + `?` when it already
+/// starts with the verb (`Go — implement #98…?`), `<Verb>: <label>?`
+/// otherwise (`Go: Smoke OK — ack both units?`). The label is NOT re-wrapped
+/// in markup here: the rich plane escapes+formats via `go_tier_lines_rich`;
+/// the markdown plane takes the raw line.
+pub(crate) fn go_tier_line(label: &str) -> String {
+    let starts_with_verb = label
+        .trim_start()
+        .get(..GO_TIER_VERB.len())
+        .is_some_and(|first| first.eq_ignore_ascii_case(GO_TIER_VERB));
+    if starts_with_verb {
+        format!("{label}?")
+    } else {
+        format!("{GO_TIER_VERB}: {label}?")
+    }
+}
+
+/// The #119 fold-tier body block: one go_tier_line per option, one line
+/// each, in order.
+pub(crate) fn go_tier_lines(options: &[String]) -> String {
+    options
+        .iter()
+        .map(|o| go_tier_line(o))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// host-aware stale-shell strip: the #597 clear killed the stash, but the
 /// buttons keep rendering inside the body until the body is rewritten clean.
 pub(crate) fn strip_button_rows(html: &str) -> String {

--- a/src/channels/telegram/suggest_options.rs
+++ b/src/channels/telegram/suggest_options.rs
@@ -366,7 +366,6 @@ pub(crate) fn go_tier_line(label: &str) -> String {
     // Verb match is whole-first-word, not a character prefix: "go fast"
     // qualifies, "Gossip about it" does not (CI r2, E-test 139).
     let first_word = label
-        .trim_start()
         .split_whitespace()
         .next()
         .unwrap_or_default();

--- a/src/tests/telegram_followup_pick_test.rs
+++ b/src/tests/telegram_followup_pick_test.rs
@@ -438,5 +438,5 @@ fn folded_list_markdown_numbers_each_option() {
 #[test]
 fn go_tier_lines_markdown_renders_119_lines() {
     let list = go_tier_lines(&["первый".to_string(), "второй|с таблицей".to_string()]);
-    assert_eq!(list, "Go: первый?\nGo: второй|с таблицей?");
+    assert_eq!(list, "**Go: первый?**\n**Go: второй|с таблицей?**");
 }

--- a/src/tests/telegram_followup_pick_test.rs
+++ b/src/tests/telegram_followup_pick_test.rs
@@ -18,8 +18,8 @@ use teloxide::types::MessageId;
 
 use crate::channels::telegram::state::{MergedHost, TelegramState};
 use crate::channels::telegram::suggest_options::{
-    PickRewrite, echo_fallback, folded_list_markdown, go_tier_lines, mark_picked_button,
-    pick_rewrite, picked_block, suggestion_rows_rich_html,
+    PickRewrite, echo_fallback, go_tier_lines, mark_picked_button, pick_rewrite, picked_block,
+    suggestion_rows_rich_html,
 };
 
 const CHOICE: &str = "Update the SKILL.md with the new callback routing";
@@ -430,13 +430,13 @@ fn md_plane_appends_plain_markdown_pick_record() {
 }
 
 #[test]
-fn folded_list_markdown_numbers_each_option() {
-    let list = folded_list_markdown(&["первый".to_string(), "второй|с таблицей".to_string()]);
-    assert_eq!(list, "1. первый\n2. второй|с таблицей");
-}
-
-#[test]
 fn go_tier_lines_markdown_renders_119_lines() {
+    // Set-size split (owner order 2026-09-09): n>=2 = the original plain
+    // numbered list — Cyrillic and `|` stay verbatim (document-level
+    // interpretation deliberately skipped).
     let list = go_tier_lines(&["первый".to_string(), "второй|с таблицей".to_string()]);
-    assert_eq!(list, "**Go: первый?**\n**Go: второй|с таблицей?**");
+    assert_eq!(list, "1. первый\n2. второй|с таблицей");
+    // n=1 = the bold Go! tier line.
+    let single = go_tier_lines(&["первый".to_string()]);
+    assert_eq!(single, "**Go: первый?**");
 }

--- a/src/tests/telegram_followup_pick_test.rs
+++ b/src/tests/telegram_followup_pick_test.rs
@@ -18,8 +18,8 @@ use teloxide::types::MessageId;
 
 use crate::channels::telegram::state::{MergedHost, TelegramState};
 use crate::channels::telegram::suggest_options::{
-    PickRewrite, echo_fallback, folded_list_markdown, mark_picked_button, pick_rewrite,
-    picked_block, suggestion_rows_rich_html,
+    PickRewrite, echo_fallback, folded_list_markdown, go_tier_lines, mark_picked_button,
+    pick_rewrite, picked_block, suggestion_rows_rich_html,
 };
 
 const CHOICE: &str = "Update the SKILL.md with the new callback routing";
@@ -433,4 +433,10 @@ fn md_plane_appends_plain_markdown_pick_record() {
 fn folded_list_markdown_numbers_each_option() {
     let list = folded_list_markdown(&["первый".to_string(), "второй|с таблицей".to_string()]);
     assert_eq!(list, "1. первый\n2. второй|с таблицей");
+}
+
+#[test]
+fn go_tier_lines_markdown_renders_119_lines() {
+    let list = go_tier_lines(&["первый".to_string(), "второй|с таблицей".to_string()]);
+    assert_eq!(list, "Go: первый?\nGo: второй|с таблицей?");
 }

--- a/src/tests/telegram_suggest_merge_test.rs
+++ b/src/tests/telegram_suggest_merge_test.rs
@@ -10,8 +10,8 @@
 
 use crate::channels::telegram::suggest_options::{
     BUTTON_LABEL_MAX_UNITS, FOLLOWUP_PREFIX, MAX_NUMBERS_PER_ROW, SHARED_ROW_MAX_CHARS,
-    SuggestLayout, append_rows_and_trailer_md, enforce_button_fit, folded_list_html, pick_layout,
-    suggestion_rows_rich_html,
+    SINGLE_BUTTON_MAX_UNITS, SuggestLayout, append_rows_and_trailer_md, enforce_button_fit,
+    folded_list_html, pick_layout, suggestion_rows_rich_html,
 };
 
 fn opts(v: &[&str]) -> Vec<String> {
@@ -56,6 +56,36 @@ fn test_the_button_width_boundary_is_exclusive() {
     assert_eq!(
         pick_layout(&[
             "Ship it".to_string(),
+            "x".repeat(BUTTON_LABEL_MAX_UNITS + 1)
+        ]),
+        SuggestLayout::NumberedProse
+    );
+}
+
+#[test]
+fn test_single_option_rides_full_width_past_the_shared_budget() {
+    // #119: the fold tier's cramming premise never applies at n=1 — a
+    // lone option folded into "1. <label>" prose plus a bare "1" button
+    // renders absurdly (live smoke on ff234125: 27-char confirm label).
+    // One option rides a full-width button up to its own clip point.
+    let label = "Smoke OK — ack both units".to_string(); // 25 chars, > 20
+    assert!(label.chars().count() > BUTTON_LABEL_MAX_UNITS);
+    assert_eq!(pick_layout(&[label]), SuggestLayout::Column);
+    assert_eq!(
+        pick_layout(&["x".repeat(SINGLE_BUTTON_MAX_UNITS)]),
+        SuggestLayout::Column
+    );
+    // Past the single-button clip point the label still folds — but a
+    // lone option has nothing to share the prose list with, so the fold
+    // is the graceful degradation the issue accepts.
+    assert_eq!(
+        pick_layout(&["x".repeat(SINGLE_BUTTON_MAX_UNITS + 1)]),
+        SuggestLayout::NumberedProse
+    );
+    // n >= 2 behavior unchanged: long labels still fold the whole set.
+    assert_eq!(
+        pick_layout(&[
+            "ok".to_string(),
             "x".repeat(BUTTON_LABEL_MAX_UNITS + 1)
         ]),
         SuggestLayout::NumberedProse

--- a/src/tests/telegram_suggest_merge_test.rs
+++ b/src/tests/telegram_suggest_merge_test.rs
@@ -330,7 +330,7 @@ fn test_rows_and_trailer_start_a_fresh_markdown_block() {
         assert!(md.ends_with("Sign-off."));
         assert!(md.contains(&rows));
         if prose {
-            assert!(md.contains("1. One"));
+            assert!(md.contains("Go: One?"), "go-tier body line: {md}");
         }
     }
     // Body already ending in a newline must not grow a triple gap.

--- a/src/tests/telegram_suggest_merge_test.rs
+++ b/src/tests/telegram_suggest_merge_test.rs
@@ -9,9 +9,9 @@
 //! rule is that no source file carries a `#[cfg(test)] mod tests` block.
 
 use crate::channels::telegram::suggest_options::{
-    BUTTON_LABEL_MAX_UNITS, FOLLOWUP_PREFIX, GO_BUTTON_LABEL, MAX_NUMBERS_PER_ROW,
-    SHARED_ROW_MAX_CHARS, SINGLE_BUTTON_MAX_UNITS, SuggestLayout, append_rows_and_trailer_md,
-    enforce_button_fit, folded_list_html, go_tier_line, go_tier_lines_rich, pick_layout, row_fits,
+    BUTTON_LABEL_MAX_UNITS, FOLLOWUP_PREFIX, MAX_NUMBERS_PER_ROW, SHARED_ROW_MAX_CHARS,
+    SINGLE_BUTTON_MAX_UNITS, SuggestLayout, append_rows_and_trailer_md, enforce_button_fit,
+    go_button_label, go_tier_line, go_tier_lines_rich, pick_layout, row_fits,
     suggestion_rows_rich_html,
 };
 
@@ -85,10 +85,7 @@ fn test_single_option_rides_full_width_past_the_shared_budget() {
     );
     // n >= 2 behavior unchanged: long labels still fold the whole set.
     assert_eq!(
-        pick_layout(&[
-            "ok".to_string(),
-            "x".repeat(BUTTON_LABEL_MAX_UNITS + 1)
-        ]),
+        pick_layout(&["ok".to_string(), "x".repeat(BUTTON_LABEL_MAX_UNITS + 1)]),
         SuggestLayout::NumberedProse
     );
 }
@@ -106,74 +103,52 @@ fn test_shared_row_respects_the_total_budget() {
 }
 
 #[test]
-fn test_a_folded_list_carries_no_header_and_is_escaped() {
-    let body = folded_list_html(&opts(&["Ship it", "Review & merge"]));
-    assert!(
-        !body.contains("Suggested next"),
-        "#1204: the list rides under the answer, so it has no header of its own"
-    );
-    assert!(body.contains("1. Ship it"));
-    assert!(
-        body.contains("2. Review &amp; merge"),
-        "escaping proves the shared renderer ran, not a private one: {body}"
-    );
-}
-
-#[test]
-fn test_go_tier_buttons_carry_go_label_not_digits() {
-    // #119 owner design: buttons in the fold tier read `Go!`, never bare
-    // digits. Callback data still carries the absolute index.
-    let token = "ab12cd34";
-    let html = suggestion_rows_rich_html(&opts(&["Ship it", &"x".repeat(30)]), token);
-    assert!(html.contains(&format!(">{GO_BUTTON_LABEL}<")), "{html}");
-    assert!(!html.contains(">1</tg-button>"), "no digit buttons: {html}");
-    assert!(
-        html.contains(&format!("{FOLLOWUP_PREFIX}{token}:0")),
-        "callback data still routes by index: {html}"
-    );
-}
-
-#[test]
 fn test_go_tier_body_lines_carry_the_119_shape() {
-    // #119 owner design 06:42Z + render corrections 2026-09-09: the fold
-    // tier renders a BOLD `Go: <label>?` line per option, with a blank
-    // line before the block — never a numbered list.
+    // #119 set-size split (owner order 2026-09-09, "back to the way the
+    // numbered lists were before the Go button introduction"):
+    // n>=2 = the ORIGINAL plain numbered list — `1. <label>`, no Go
+    // prefix, no `?` mutation, no bold; n=1 keeps the confirmed Go! tier.
     let body = go_tier_lines_rich(&opts(&["Ship it", "Review & merge"]));
     assert!(
         !body.contains("Suggested next"),
         "#1204: the lines ride under the answer, no header of their own"
     );
     assert!(
-        body.contains("<b>Go: Ship it?</b>") && body.contains("<b>Go: Review &amp; merge?</b>"),
-        "one bold Go line per option, escaping via the shared renderer: {body}"
+        body.contains("1. Ship it") && body.contains("2. Review &amp; merge"),
+        "plain numbered list for n>=2, escaping via the shared renderer: {body}"
     );
     assert!(
-        !body.contains("1. Ship it") && !body.contains("<ol>"),
-        "the numbered-prose shape is gone, not renamed: {body}"
+        !body.contains("Go:") && !body.contains("<b>"),
+        "no Go-tier artifacts on the n>=2 fold: {body}"
     );
+    assert!(
+        !body.contains("<ol>"),
+        "no html <ol> — plain numbered prose: {body}"
+    );
+    // n=1 keeps the confirmed Go! tier (bold, deduped ?).
+    let single = go_tier_lines_rich(&opts(&["Ship it"]));
+    assert_eq!(single, "<b>Go: Ship it?</b>");
 }
 
 #[test]
 fn test_go_tier_dedupes_trailing_question_mark() {
     // Owner correction 2026-09-09: a label ending in '?' must not gain a
-    // second question mark.
+    // second question mark (n=1 Go! tier only).
     assert_eq!(go_tier_line("Confirm render?"), "**Go: Confirm render?**");
     assert_eq!(go_tier_line("Confirm render??"), "**Go: Confirm render??**");
 }
 
 #[test]
 fn test_go_tier_verb_repeat_rule() {
-    // #119 owner amendment 06:46Z: a label that already starts with the
-    // verb renders verbatim + `?` (deduped); otherwise the `Go:` prefix is
-    // added. Whole line is bold per the 2026-09-09 correction.
+    // #119 owner amendment 06:46Z (n=1 Go! tier): a label that already
+    // starts with the verb renders verbatim + `?` (deduped); otherwise
+    // the `Go:` prefix is added. Whole line is bold per the 2026-09-09
+    // correction.
     assert_eq!(
         go_tier_line("Go — implement #98 after the #96 gate lands"),
         "**Go — implement #98 after the #96 gate lands?**"
     );
-    assert_eq!(
-        go_tier_line("Smoke OK — ack both units"),
-        "**Go: Smoke OK — ack both units?**"
-    );
+    assert_eq!(go_tier_line("Smoke OK — ack both units"), "**Go: Smoke OK — ack both units?**");
     // Case-insensitive verb match (Go!/go both start the label).
     assert_eq!(go_tier_line("go fast"), "**go fast?**");
     // Prefix-verb must not false-positive mid-word.
@@ -181,49 +156,34 @@ fn test_go_tier_verb_repeat_rule() {
 }
 
 #[test]
-fn test_row_fits_solo_arm_grants_the_solo_budget() {
-    // One button renders full-width: it rides SINGLE_BUTTON_MAX_UNITS,
-    // NOT the 20-unit shared caps — the arm whose absence made the #79
-    // funnel re-fold full-width single-button rows the emitter approved.
-    let label = "x".repeat(SINGLE_BUTTON_MAX_UNITS);
-    assert!(row_fits(&[&label]));
-    assert!(!row_fits(&[&"x".repeat(SINGLE_BUTTON_MAX_UNITS + 1)]));
-    // A solo label past the SHARED caps but inside the solo budget:
-    // exactly the live-failure class (25-27 char confirm labels).
-    let confirm = "Smoke OK — ack both units".to_string();
-    assert!(confirm.chars().count() > BUTTON_LABEL_MAX_UNITS);
-    assert!(row_fits(&[&confirm]));
-}
-
-#[test]
-fn test_row_fits_shared_arm_keeps_the_79_caps() {
-    // Multi-button rows: per-label SHARED_ROW_MAX_CHARS AND row-total
-    // SHARED_ROW_TOTAL_UNITS — byte-identical to the pre-refactor rule.
-    let a = "x".repeat(SHARED_ROW_MAX_CHARS);
-    let b = "y".repeat(SHARED_ROW_MAX_CHARS);
-    // 2x12 = 24 total > 20: does not fit (folds, as before the refactor).
-    assert!(!row_fits(&[&a, &b]));
-    let short = "x".repeat(SHARED_ROW_MAX_CHARS - 4);
-    // 2x8 = 16 total, labels within per-label cap: fits.
-    assert!(row_fits(&[&short, &short]));
-    // One label past the per-label cap kills the row even under budget.
-    let long = "x".repeat(SHARED_ROW_MAX_CHARS + 1);
-    assert!(!row_fits(&[&short, &long]));
-}
-
-#[test]
-fn test_chokepoint_ships_solo_rows_the_emitter_approved() {
-    // THE #119 live regression, pinned at the funnel: a single-button row
-    // with a 25-char label used to be re-folded by enforce_button_fit
-    // (old inline caps) after pick_layout's Column tier approved it —
-    // owner saw "button 1 + 1. <label>" prose on ship ed0ae1d9. Under
-    // the single-verdict refactor the funnel ships it byte-identical.
-    let label = "Smoke OK — ack both units"; // 25 chars: > 20, <= 30
-    let body = format!(
-        "<tg-button-row><tg-button type=\"callback_data\" data=\"followup:tok:0\" \
-         style=\"primary\">{label}</tg-button></tg-button-row>"
+fn test_go_tier_buttons_carry_their_option_number() {
+    // #119 numbering restored 2026-09-09 (owner defect report), PLAIN
+    // digits per the owner order 2026-09-09: each n>=2 fold-tier button
+    // carries its bare 1-based option number (`1` `2` …), visually paired
+    // with its `1. <label>` body line. Callback data still carries the
+    // absolute index. n=1 folds to the single `Go!` button.
+    let token = "ab12cd34";
+    let html = suggestion_rows_rich_html(&opts(&["Ship it", &"x".repeat(30)]), token);
+    assert!(
+        html.contains(&format!(">{}</tg-button>", go_button_label(1, false)))
+            && html.contains(&format!(">{}</tg-button>", go_button_label(2, false))),
+        "one numbered button per option: {html}"
     );
-    assert_eq!(enforce_button_fit(&body), body);
+    assert!(
+        !html.contains(">Go!<"),
+        "no Go! buttons on the n>=2 fold: {html}"
+    );
+    assert!(
+        html.contains(&format!("{FOLLOWUP_PREFIX}{token}:0")),
+        "callback data still routes by index: {html}"
+    );
+    // n=1: the single Go! button.
+    assert_eq!(go_button_label(1, true), "Go!");
+    let single_html = suggestion_rows_rich_html(&opts(&[&"x".repeat(31)]), token);
+    assert!(
+        single_html.contains(">Go!</tg-button>"),
+        "single fold keeps the Go! button: {single_html}"
+    );
 }
 
 // ── Callback data ─────────────────────────────────────────────────────────
@@ -316,6 +276,54 @@ fn test_enforce_button_fit_folds_rows_over_the_total_budget() {
     assert!(out.contains("<li>Всё чётко!!!</li>"), "{out}");
 }
 
+// ── row_fits — the single budget verdict (#119 option A) ─────────────────
+
+#[test]
+fn test_row_fits_solo_arm_grants_the_solo_budget() {
+    // One button renders full-width: it rides SINGLE_BUTTON_MAX_UNITS,
+    // NOT the 20-unit shared caps — the arm whose absence made the #79
+    // funnel re-fold full-width single-button rows the emitter approved.
+    let label = "x".repeat(SINGLE_BUTTON_MAX_UNITS);
+    assert!(row_fits(&[&label]));
+    assert!(!row_fits(&[&"x".repeat(SINGLE_BUTTON_MAX_UNITS + 1)]));
+    // A solo label past the SHARED caps but inside the solo budget:
+    // exactly the live-failure class (25-27 char confirm labels).
+    let confirm = "Smoke OK — ack both units".to_string();
+    assert!(confirm.chars().count() > BUTTON_LABEL_MAX_UNITS);
+    assert!(row_fits(&[&confirm]));
+}
+
+#[test]
+fn test_row_fits_shared_arm_keeps_the_79_caps() {
+    // Multi-button rows: per-label SHARED_ROW_MAX_CHARS AND row-total
+    // SHARED_ROW_TOTAL_UNITS — byte-identical to the pre-refactor rule.
+    let a = "x".repeat(SHARED_ROW_MAX_CHARS);
+    let b = "y".repeat(SHARED_ROW_MAX_CHARS);
+    // 2x12 = 24 total > 20: does not fit (folds, as before the refactor).
+    assert!(!row_fits(&[&a, &b]));
+    let short = "x".repeat(SHARED_ROW_MAX_CHARS - 4);
+    // 2x8 = 16 total, labels within per-label cap: fits.
+    assert!(row_fits(&[&short, &short]));
+    // One label past the per-label cap kills the row even under budget.
+    let long = "x".repeat(SHARED_ROW_MAX_CHARS + 1);
+    assert!(!row_fits(&[&short, &long]));
+}
+
+#[test]
+fn test_chokepoint_ships_solo_rows_the_emitter_approved() {
+    // THE #119 live regression, pinned at the funnel: a single-button row
+    // with a 25-char label used to be re-folded by enforce_button_fit
+    // (old inline caps) after pick_layout's Column tier approved it —
+    // owner saw "button 1 + 1. <label>" prose on ship ed0ae1d9. Under
+    // the single-verdict refactor the funnel ships it byte-identical.
+    let label = "Smoke OK — ack both units"; // 25 chars: > 20, <= 30
+    let body = format!(
+        "<tg-button-row><tg-button type=\"callback_data\" data=\"followup:tok:0\" \
+         style=\"primary\">{label}</tg-button></tg-button-row>"
+    );
+    assert_eq!(enforce_button_fit(&body), body);
+}
+
 /// #108: the button rows and the trailer must start a FRESH markdown block.
 /// The old construction appended both after a single `\n`, so the server's
 /// parser fused the last text paragraph into the controls block and rendered
@@ -340,8 +348,11 @@ fn test_rows_and_trailer_start_a_fresh_markdown_block() {
         assert!(md.ends_with("Sign-off."));
         assert!(md.contains(&rows));
         if prose {
-            // 2026-09-09: bold Go line, blank-line-separated from the body.
-            assert!(md.contains("**Go: One?**"), "go-tier body line: {md}");
+            // 2026-09-09, owner order: n>=2 fold = the original PLAIN
+            // numbered list — no Go prefix, no bold. Blank-line-separated
+            // from the body.
+            assert!(md.contains("1. One"), "numbered fold body line: {md}");
+            assert!(!md.contains("Go:") && !md.contains("**"), "no Go-tier artifacts: {md}");
         }
     }
     // Body already ending in a newline must not grow a triple gap.

--- a/src/tests/telegram_suggest_merge_test.rs
+++ b/src/tests/telegram_suggest_merge_test.rs
@@ -135,16 +135,17 @@ fn test_go_tier_buttons_carry_go_label_not_digits() {
 
 #[test]
 fn test_go_tier_body_lines_carry_the_119_shape() {
-    // #119 owner design 06:42Z: the fold tier renders `Go: <label>?` in the
-    // body — never a numbered list.
+    // #119 owner design 06:42Z + render corrections 2026-09-09: the fold
+    // tier renders a BOLD `Go: <label>?` line per option, with a blank
+    // line before the block — never a numbered list.
     let body = go_tier_lines_rich(&opts(&["Ship it", "Review & merge"]));
     assert!(
         !body.contains("Suggested next"),
         "#1204: the lines ride under the answer, no header of their own"
     );
     assert!(
-        body.contains("Go: Ship it?") && body.contains("Go: Review &amp; merge?"),
-        "one Go line per option, escaping via the shared renderer: {body}"
+        body.contains("<b>Go: Ship it?</b>") && body.contains("<b>Go: Review &amp; merge?</b>"),
+        "one bold Go line per option, escaping via the shared renderer: {body}"
     );
     assert!(
         !body.contains("1. Ship it") && !body.contains("<ol>"),
@@ -153,21 +154,30 @@ fn test_go_tier_body_lines_carry_the_119_shape() {
 }
 
 #[test]
+fn test_go_tier_dedupes_trailing_question_mark() {
+    // Owner correction 2026-09-09: a label ending in '?' must not gain a
+    // second question mark.
+    assert_eq!(go_tier_line("Confirm render?"), "Go: Confirm render?");
+    assert_eq!(go_tier_line("Confirm render??"), "Go: Confirm render??");
+}
+
+#[test]
 fn test_go_tier_verb_repeat_rule() {
     // #119 owner amendment 06:46Z: a label that already starts with the
-    // verb renders verbatim + `?`; otherwise the `Go:` prefix is added.
+    // verb renders verbatim + `?` (deduped); otherwise the `Go:` prefix is
+    // added. Whole line is bold per the 2026-09-09 correction.
     assert_eq!(
         go_tier_line("Go — implement #98 after the #96 gate lands"),
-        "Go — implement #98 after the #96 gate lands?"
+        "**Go — implement #98 after the #96 gate lands?**"
     );
     assert_eq!(
         go_tier_line("Smoke OK — ack both units"),
-        "Go: Smoke OK — ack both units?"
+        "**Go: Smoke OK — ack both units?**"
     );
     // Case-insensitive verb match (Go!/go both start the label).
-    assert_eq!(go_tier_line("go fast"), "go fast?");
+    assert_eq!(go_tier_line("go fast"), "**go fast?**");
     // Prefix-verb must not false-positive mid-word.
-    assert_eq!(go_tier_line("Gossip about it"), "Go: Gossip about it?");
+    assert_eq!(go_tier_line("Gossip about it"), "**Go: Gossip about it?**");
 }
 
 #[test]
@@ -330,7 +340,8 @@ fn test_rows_and_trailer_start_a_fresh_markdown_block() {
         assert!(md.ends_with("Sign-off."));
         assert!(md.contains(&rows));
         if prose {
-            assert!(md.contains("Go: One?"), "go-tier body line: {md}");
+            // 2026-09-09: bold Go line, blank-line-separated from the body.
+            assert!(md.contains("<b>Go: One?</b>"), "go-tier body line: {md}");
         }
     }
     // Body already ending in a newline must not grow a triple gap.

--- a/src/tests/telegram_suggest_merge_test.rs
+++ b/src/tests/telegram_suggest_merge_test.rs
@@ -148,7 +148,10 @@ fn test_go_tier_verb_repeat_rule() {
         go_tier_line("Go — implement #98 after the #96 gate lands"),
         "**Go — implement #98 after the #96 gate lands?**"
     );
-    assert_eq!(go_tier_line("Smoke OK — ack both units"), "**Go: Smoke OK — ack both units?**");
+    assert_eq!(
+        go_tier_line("Smoke OK — ack both units"),
+        "**Go: Smoke OK — ack both units?**"
+    );
     // Case-insensitive verb match (Go!/go both start the label).
     assert_eq!(go_tier_line("go fast"), "**go fast?**");
     // Prefix-verb must not false-positive mid-word.
@@ -352,7 +355,10 @@ fn test_rows_and_trailer_start_a_fresh_markdown_block() {
             // numbered list — no Go prefix, no bold. Blank-line-separated
             // from the body.
             assert!(md.contains("1. One"), "numbered fold body line: {md}");
-            assert!(!md.contains("Go:") && !md.contains("**"), "no Go-tier artifacts: {md}");
+            assert!(
+                !md.contains("Go:") && !md.contains("**"),
+                "no Go-tier artifacts: {md}"
+            );
         }
     }
     // Body already ending in a newline must not grow a triple gap.

--- a/src/tests/telegram_suggest_merge_test.rs
+++ b/src/tests/telegram_suggest_merge_test.rs
@@ -9,9 +9,10 @@
 //! rule is that no source file carries a `#[cfg(test)] mod tests` block.
 
 use crate::channels::telegram::suggest_options::{
-    BUTTON_LABEL_MAX_UNITS, FOLLOWUP_PREFIX, MAX_NUMBERS_PER_ROW, SHARED_ROW_MAX_CHARS,
-    SINGLE_BUTTON_MAX_UNITS, SuggestLayout, append_rows_and_trailer_md, enforce_button_fit,
-    folded_list_html, pick_layout, suggestion_rows_rich_html,
+    BUTTON_LABEL_MAX_UNITS, FOLLOWUP_PREFIX, GO_BUTTON_LABEL, MAX_NUMBERS_PER_ROW,
+    SHARED_ROW_MAX_CHARS, SINGLE_BUTTON_MAX_UNITS, SuggestLayout, append_rows_and_trailer_md,
+    enforce_button_fit, folded_list_html, go_tier_line, go_tier_lines_rich, pick_layout, row_fits,
+    suggestion_rows_rich_html,
 };
 
 fn opts(v: &[&str]) -> Vec<String> {
@@ -116,6 +117,103 @@ fn test_a_folded_list_carries_no_header_and_is_escaped() {
         body.contains("2. Review &amp; merge"),
         "escaping proves the shared renderer ran, not a private one: {body}"
     );
+}
+
+#[test]
+fn test_go_tier_buttons_carry_go_label_not_digits() {
+    // #119 owner design: buttons in the fold tier read `Go!`, never bare
+    // digits. Callback data still carries the absolute index.
+    let token = "ab12cd34";
+    let html = suggestion_rows_rich_html(&opts(&["Ship it", &"x".repeat(30)]), token);
+    assert!(html.contains(&format!(">{GO_BUTTON_LABEL}<")), "{html}");
+    assert!(!html.contains(">1</tg-button>"), "no digit buttons: {html}");
+    assert!(
+        html.contains(&format!("{FOLLOWUP_PREFIX}{token}:0")),
+        "callback data still routes by index: {html}"
+    );
+}
+
+#[test]
+fn test_go_tier_body_lines_carry_the_119_shape() {
+    // #119 owner design 06:42Z: the fold tier renders `Go: <label>?` in the
+    // body — never a numbered list.
+    let body = go_tier_lines_rich(&opts(&["Ship it", "Review & merge"]));
+    assert!(
+        !body.contains("Suggested next"),
+        "#1204: the lines ride under the answer, no header of their own"
+    );
+    assert!(
+        body.contains("Go: Ship it?") && body.contains("Go: Review &amp; merge?"),
+        "one Go line per option, escaping via the shared renderer: {body}"
+    );
+    assert!(
+        !body.contains("1. Ship it") && !body.contains("<ol>"),
+        "the numbered-prose shape is gone, not renamed: {body}"
+    );
+}
+
+#[test]
+fn test_go_tier_verb_repeat_rule() {
+    // #119 owner amendment 06:46Z: a label that already starts with the
+    // verb renders verbatim + `?`; otherwise the `Go:` prefix is added.
+    assert_eq!(
+        go_tier_line("Go — implement #98 after the #96 gate lands"),
+        "Go — implement #98 after the #96 gate lands?"
+    );
+    assert_eq!(
+        go_tier_line("Smoke OK — ack both units"),
+        "Go: Smoke OK — ack both units?"
+    );
+    // Case-insensitive verb match (Go!/go both start the label).
+    assert_eq!(go_tier_line("go fast"), "go fast?");
+    // Prefix-verb must not false-positive mid-word.
+    assert_eq!(go_tier_line("Gossip about it"), "Go: Gossip about it?");
+}
+
+#[test]
+fn test_row_fits_solo_arm_grants_the_solo_budget() {
+    // One button renders full-width: it rides SINGLE_BUTTON_MAX_UNITS,
+    // NOT the 20-unit shared caps — the arm whose absence made the #79
+    // funnel re-fold full-width single-button rows the emitter approved.
+    let label = "x".repeat(SINGLE_BUTTON_MAX_UNITS);
+    assert!(row_fits(&[&label]));
+    assert!(!row_fits(&[&"x".repeat(SINGLE_BUTTON_MAX_UNITS + 1)]));
+    // A solo label past the SHARED caps but inside the solo budget:
+    // exactly the live-failure class (25-27 char confirm labels).
+    let confirm = "Smoke OK — ack both units".to_string();
+    assert!(confirm.chars().count() > BUTTON_LABEL_MAX_UNITS);
+    assert!(row_fits(&[&confirm]));
+}
+
+#[test]
+fn test_row_fits_shared_arm_keeps_the_79_caps() {
+    // Multi-button rows: per-label SHARED_ROW_MAX_CHARS AND row-total
+    // SHARED_ROW_TOTAL_UNITS — byte-identical to the pre-refactor rule.
+    let a = "x".repeat(SHARED_ROW_MAX_CHARS);
+    let b = "y".repeat(SHARED_ROW_MAX_CHARS);
+    // 2x12 = 24 total > 20: does not fit (folds, as before the refactor).
+    assert!(!row_fits(&[&a, &b]));
+    let short = "x".repeat(SHARED_ROW_MAX_CHARS - 4);
+    // 2x8 = 16 total, labels within per-label cap: fits.
+    assert!(row_fits(&[&short, &short]));
+    // One label past the per-label cap kills the row even under budget.
+    let long = "x".repeat(SHARED_ROW_MAX_CHARS + 1);
+    assert!(!row_fits(&[&short, &long]));
+}
+
+#[test]
+fn test_chokepoint_ships_solo_rows_the_emitter_approved() {
+    // THE #119 live regression, pinned at the funnel: a single-button row
+    // with a 25-char label used to be re-folded by enforce_button_fit
+    // (old inline caps) after pick_layout's Column tier approved it —
+    // owner saw "button 1 + 1. <label>" prose on ship ed0ae1d9. Under
+    // the single-verdict refactor the funnel ships it byte-identical.
+    let label = "Smoke OK — ack both units"; // 25 chars: > 20, <= 30
+    let body = format!(
+        "<tg-button-row><tg-button type=\"callback_data\" data=\"followup:tok:0\" \
+         style=\"primary\">{label}</tg-button></tg-button-row>"
+    );
+    assert_eq!(enforce_button_fit(&body), body);
 }
 
 // ── Callback data ─────────────────────────────────────────────────────────

--- a/src/tests/telegram_suggest_merge_test.rs
+++ b/src/tests/telegram_suggest_merge_test.rs
@@ -157,8 +157,8 @@ fn test_go_tier_body_lines_carry_the_119_shape() {
 fn test_go_tier_dedupes_trailing_question_mark() {
     // Owner correction 2026-09-09: a label ending in '?' must not gain a
     // second question mark.
-    assert_eq!(go_tier_line("Confirm render?"), "Go: Confirm render?");
-    assert_eq!(go_tier_line("Confirm render??"), "Go: Confirm render??");
+    assert_eq!(go_tier_line("Confirm render?"), "**Go: Confirm render?**");
+    assert_eq!(go_tier_line("Confirm render??"), "**Go: Confirm render??**");
 }
 
 #[test]
@@ -341,7 +341,7 @@ fn test_rows_and_trailer_start_a_fresh_markdown_block() {
         assert!(md.contains(&rows));
         if prose {
             // 2026-09-09: bold Go line, blank-line-separated from the body.
-            assert!(md.contains("<b>Go: One?</b>"), "go-tier body line: {md}");
+            assert!(md.contains("**Go: One?**"), "go-tier body line: {md}");
         }
     }
     // Body already ending in a newline must not grow a triple gap.


### PR DESCRIPTION
## Summary

Ports the completed #119 Go-tier / numbered-fold work from the l1979 fork (`leshchenko1979/opencrabs`, ship chain ending at `aa1c8db6`) onto a fresh `adolfousier/main` base (`7fcf430b`).

Two owner-confirmed behaviors:

1. **n=1 fold → full-width Go! tier.** A single option whose label exceeds the solo button budget no longer folds to the numbered prose list (owner saw a bare `1` button + `1. <label>` prose on ship `ed0ae1d9`). It now rides one full-width button up to its own clip point; past that, the body gains a bold `Go: <label>?` line (verb-repeat: a label already starting with "Go" renders verbatim; trailing `?` deduped) with a `Go!` button.
2. **n≥2 fold → plain numbered list restored.** Per owner order the fold tier for multiple options went back to the pre-`c92873b1` shape: plain `1. <label>` body lines with bare digit buttons — no Go prefix, no bold, no `?` mutation.

## Unifying judge

Both tiers now share one width judge, `row_fits(labels)` (solo budget 30 units, shared 12/label + 20 total, per-label cap 12) — the emitter (`pick_layout`) and the funnel (`enforce_button_fit`) previously held private width budgets that disagreed at the boundary (the original bug).

## Verification

- Fork CI gate on the equivalent chain: run `34415363179` GREEN pinning `aa1c8db6`; live smoke on the deployed binary — both tiers eye-confirmed by the owner ("Smoke passes").
- Upstream-base gate on this port: [PR-lane gates run 34430834742](https://github.com/leshchenko1979/opencrabs/actions/runs/34430834742) **success**, job name pins `f88890a2df90ecff73ab1d3e006ae0bf44eaa95f` (this branch tip).
- Final file state of `suggest_options.rs` is byte-identical to fork `aa1c8db6` (diff verified), minus the fork-only #91 cross-turn glue rung (depends on fork-only `last_bot_rich_md` / `message_hosts_live_keyboard`, absent on upstream main).

Original issue: leshchenko1979/opencrabs#119
