### PR TITLE
fix(telegram): auto-evict stale topic on "message thread not found" and retry unthreaded

### DIFF
--- a/src/brain/tools/telegram_send.rs
+++ b/src/brain/tools/telegram_send.rs
@@ -165,6 +165,17 @@ pub(crate) async fn resolve_thread_id(
     if let Some(tid) = state.session_topic(session_id).await
         && state.session_chat(session_id).await == Some(chat_id)
     {
+        // Returns even when the boundary yields None: a session bound to
+        // General has a KNOWN address (no thread), so falling through to the
+        // chat-wide lookup below would post into whichever topic spoke last
+        // (#1319).
+        //
+        // A remembered topic can outlive its existence on Telegram's side
+        // (deleted while we were away). Its first hard evidence is the send
+        // itself failing with `message thread not found` (#116) — handled at
+        // the send seams (rich + HTML ladder), which evict chat-scoped and
+        // retry unthreaded. Here we just resolve the address; the map
+        // re-registers on the chat's next inbound topic message.
         return crate::channels::telegram::session_resolve::delivery_thread_id(Some(tid));
     }
     crate::channels::telegram::send::latest_thread_id_for_chat(chat_id).await

--- a/src/channels/telegram/send.rs
+++ b/src/channels/telegram/send.rs
@@ -355,14 +355,12 @@ pub async fn best_effort_note<C>(
 pub(crate) async fn send_markdown_outbox(
     bot: &Bot,
     chat_id: ChatId,
-    thread_id: Option<ThreadId>,
+    mut thread_id: Option<ThreadId>,
     markdown: &str,
     origin: &str,
     origin_detail: &str,
     reply_to: Option<i32>,
 ) -> std::result::Result<Vec<(i32, String)>, String> {
-    let thread = thread_id.map(|t| t.0.0);
-
     // 1. Native rich, as a whole message. `post_rich` owns the telemetry
     // line for this send (with origin + detail threaded through), so the
     // outbox does not double-log the rich success (review F3/F8).
@@ -381,14 +379,58 @@ pub(crate) async fn send_markdown_outbox(
         {
             Ok(id) => return Ok(vec![(id, markdown.to_string())]),
             Err(e) => {
-                tracing::warn!(
-                    "{origin}/{origin_detail}: native rich send failed ({e}) — falling back to HTML"
-                );
+                // Stale-topic auto-route (#116): a remembered topic that was
+                // deleted on Telegram's side makes EVERY thread-carrying send
+                // fail with 400 `message thread not found` — rich AND (before
+                // this fix) the plain fallback below, which re-used the same
+                // poisoned thread. Evict the dead address chat-scoped and
+                // retry this send ONCE unthreaded (General/DM = absence of a
+                // thread, #1319). Any other rich failure falls through to the
+                // HTML ladder with the thread intact.
+                if e.to_string().contains("message thread not found") && thread_id.is_some() {
+                    if let Some(tid) = thread_id {
+                        let evicted = evict_dead_topic(chat_id.0, tid.0.0).await;
+                        tracing::warn!(
+                            "{origin}/{origin_detail}: remembered topic {} is gone \
+                             (message thread not found) — evicted {evicted} rows, retrying unthreaded",
+                            tid.0.0
+                        );
+                    }
+                    thread_id = None;
+                    match super::rich::send_rich_with_mermaid_target_id(
+                        bot.api_url().as_str(),
+                        bot.token(),
+                        chat_id.0,
+                        None,
+                        reply_to,
+                        markdown,
+                        origin,
+                        origin_detail,
+                    )
+                    .await
+                    {
+                        Ok(id) => return Ok(vec![(id, markdown.to_string())]),
+                        Err(e2) => {
+                            tracing::warn!(
+                                "{origin}/{origin_detail}: native rich send failed after \
+                                 stale-topic fallback ({e2}) — falling back to HTML"
+                            );
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        "{origin}/{origin_detail}: native rich send failed ({e}) — falling back to HTML"
+                    );
+                }
             }
         }
     }
 
-    // 2. Universal HTML ladder, chunked to Telegram's limit.
+    // 2. Universal HTML ladder, chunked to Telegram's limit. When the
+    // stale-topic eviction above fired, `thread_id` is now None — the
+    // ladder (and its plain-text fallback, the #116 poisoning leg) is
+    // re-addressed to General/DM instead of the dead topic.
+    let thread = thread_id.map(|t| t.0.0);
     let html = super::handler::markdown_to_telegram_html(markdown);
     let chunks = super::handler::split_message(&html, 4096);
     let total = chunks.len();
@@ -415,6 +457,59 @@ pub(crate) async fn send_markdown_outbox(
                 sent.push((mid.0, chunk.to_string()));
             }
             Err(e) => {
+                // Plain-path leg of the #116 poisoning chain: a message that
+                // is NOT rich-shaped never entered the rich arm, so its first
+                // sight of the dead topic is here — the HTML ladder 400s and
+                // (pre-fix) the plain fallback re-used the same thread and
+                // 400'd too. Same medicine: evict chat-scoped, retry the
+                // chunk once unthreaded. Any other error is returned as
+                // before.
+                let es = e.to_string();
+                if es.contains("message thread not found") && thread_id.is_some() {
+                    if let Some(tid) = thread_id {
+                        let evicted = evict_dead_topic(chat_id.0, tid.0.0).await;
+                        tracing::warn!(
+                            "{origin}/{origin_detail}: HTML ladder hit dead topic {} \
+                             — evicted {evicted} rows, retrying chunk unthreaded",
+                            tid.0.0
+                        );
+                    }
+                    thread_id = None;
+                    match super::intermediates::send_html_or_plain(
+                        bot, chat_id, None, chunk, origin, reply_to,
+                    )
+                    .await
+                    {
+                        Ok(mid) => {
+                            super::telemetry::log_send_success(
+                                origin,
+                                origin_detail,
+                                "-",
+                                "outbox",
+                                "html_chunk_unthreaded",
+                                chat_id.0,
+                                None,
+                                mid.0,
+                                chunk.len(),
+                                &super::telemetry::content_hash8(chunk),
+                            );
+                            sent.push((mid.0, chunk.to_string()));
+                            continue;
+                        }
+                        Err(e2) => {
+                            let partial = if sent.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" ({} of {total} chunks already delivered)", sent.len())
+                            };
+                            return Err(format!(
+                                "{origin}/{origin_detail} chunk {}/{total} failed after \
+                                 stale-topic fallback{partial}: {e2}",
+                                i + 1
+                            ));
+                        }
+                    }
+                }
                 let partial = if sent.is_empty() {
                     String::new()
                 } else {
@@ -428,6 +523,31 @@ pub(crate) async fn send_markdown_outbox(
         }
     }
     Ok(sent)
+}
+
+/// Evict a dead forum-topic address chat-scoped (#116): clear the
+/// `thread_id` on `channel_messages` rows of THIS chat that carry it, so
+/// `latest_thread_id_for_chat` never serves the deleted topic again. The
+/// in-memory session-topic map self-heals on the chat's next inbound
+/// `is_topic_message` (re-registered on every event), so only the stored
+/// rows need clearing here.
+pub(crate) async fn evict_dead_topic(chat_id: i64, thread_id: i32) -> u64 {
+    let Some(pool) = crate::db::global_pool().cloned() else {
+        return 0;
+    };
+    let repo = crate::db::ChannelMessageRepository::new(pool);
+    match repo
+        .clear_thread_for_chat("telegram", &chat_id.to_string(), &thread_id.to_string())
+        .await
+    {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!(
+                "stale-topic eviction for chat {chat_id} thread {thread_id} failed: {e}"
+            );
+            0
+        }
+    }
 }
 
 /// Persist delivered outbox messages for reply recovery (#234, #1085 P1b

--- a/src/db/repository/channel_message.rs
+++ b/src/db/repository/channel_message.rs
@@ -101,6 +101,40 @@ impl ChannelMessageRepository {
             .context("Failed to update channel message content")
     }
 
+    /// Forum-topic dead-key eviction (#116): Telegram answered
+    /// `400 Bad Request: message thread not found` for `(channel, chat,
+    /// thread)` — the remembered topic no longer exists. Clear the
+    /// thread_id on every row of that chat carrying it, so the
+    /// auto-lookup (`latest_thread_id_for_chat`) and the topic listing
+    /// stop serving the dead address. Chat-scoped by design: a deleted
+    /// topic in one chat must never touch another chat's rows.
+    pub async fn clear_thread_for_chat(
+        &self,
+        channel: &str,
+        chat_id: &str,
+        thread_id: &str,
+    ) -> Result<u64> {
+        let ch = channel.to_string();
+        let cid = chat_id.to_string();
+        let tid = thread_id.to_string();
+        let updated = self
+            .pool
+            .get()
+            .await
+            .context("Failed to get connection")?
+            .interact(move |conn| {
+                conn.execute(
+                    "UPDATE channel_messages SET thread_id = NULL \
+                     WHERE channel = ?1 AND channel_chat_id = ?2 AND thread_id = ?3",
+                    params![ch, cid, tid],
+                )
+            })
+            .await
+            .map_err(interact_err)?
+            .context("Failed to clear dead forum topic thread_id")?;
+        Ok(updated as u64)
+    }
+
     /// Get recent messages for a specific chat, optionally filtered by thread_id.
     /// When `thread_id` is Some, only messages belonging to that forum topic are returned.
     pub async fn recent(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -382,7 +382,6 @@ pub mod telegram_details_fallback_render_test;
 #[cfg(feature = "telegram")]
 pub mod telegram_general_topic_delivery_test;
 #[cfg(feature = "telegram")]
-#[cfg(feature = "telegram")]
 pub mod telegram_mentions_other_bot_test;
 #[cfg(feature = "telegram")]
 pub mod telegram_menu_scope_test;
@@ -802,6 +801,8 @@ pub mod restart_recovery_test;
 pub mod restart_replay_context_test;
 pub mod shell_scan_test;
 pub mod slack_handler_test;
+#[cfg(feature = "telegram")]
+pub mod stale_topic_eviction_test;
 pub mod subagent_notify_test;
 mod telegram_acl_test;
 mod telegram_attachment_tmp_name_test;

--- a/src/tests/stale_topic_eviction_test.rs
+++ b/src/tests/stale_topic_eviction_test.rs
@@ -1,0 +1,203 @@
+//! Stale-topic auto-route eviction (#116).
+//!
+//! A remembered forum topic can be deleted on Telegram's side while we hold
+//! its address in `channel_messages` / the session-topic map. Every send
+//! routed to it then fails with `400 Bad Request: message thread not found`,
+//! and BEFORE the fix the plain fallback re-used the same poisoned thread and
+//! failed identically — a permanent failure loop for the chat. Measured on
+//! prod 2026-09-06 05:29Z (owner DM, thread 30134): rich 400 → HTML 400 →
+//! plain 400 → tool error.
+//!
+//! The contract under test:
+//! 1. `clear_thread_for_chat` clears ONLY that chat's rows carrying the dead
+//!    thread (chat-scoped, other chats untouched);
+//! 2. `send_markdown_outbox` on the thread-not-found error evicts the dead
+//!    address and retries the send ONCE unthreaded (General/DM = absence of a
+//!    thread, #1319) instead of dropping the message;
+//! 3. any other rich failure still falls through to the HTML ladder with the
+//!    thread intact (no eviction, no behavior change).
+
+use crate::db::Database;
+use crate::db::models::ChannelMessage;
+use crate::db::repository::ChannelMessageRepository;
+use teloxide::types::{ChatId, ThreadId};
+
+const CHAT: i64 = 133_526_395;
+const OTHER_CHAT: i64 = 999_111;
+const DEAD_TOPIC: i32 = 30_134;
+
+async fn seeded_repo() -> ChannelMessageRepository {
+    let db = Database::connect_in_memory().await.unwrap();
+    db.run_migrations().await.unwrap();
+    let repo = ChannelMessageRepository::new(db.pool().clone());
+    let mk = |chat: i64, mid: &str, thread: Option<i32>| {
+        let cm = ChannelMessage::new(
+            "telegram".into(),
+            chat.to_string(),
+            None,
+            "u1".into(),
+            "alice".into(),
+            format!("msg {mid}"),
+            "text".into(),
+            Some(mid.into()),
+        );
+        match thread {
+            Some(t) => cm.with_thread(Some(t.to_string()), None),
+            None => cm,
+        }
+    };
+    // The poisoned chat: two rows on the dead topic, one General row.
+    repo.insert(&mk(CHAT, "m-1", Some(DEAD_TOPIC)))
+        .await
+        .unwrap();
+    repo.insert(&mk(CHAT, "m-2", Some(DEAD_TOPIC)))
+        .await
+        .unwrap();
+    repo.insert(&mk(CHAT, "m-3", None)).await.unwrap();
+    // A different chat that happens to use the SAME topic id must stay
+    // untouched — eviction is chat-scoped, never global.
+    repo.insert(&mk(OTHER_CHAT, "m-4", Some(DEAD_TOPIC)))
+        .await
+        .unwrap();
+    repo
+}
+
+#[tokio::test]
+async fn eviction_clears_only_the_dead_chat_rows() {
+    let repo = seeded_repo().await;
+
+    let evicted = repo
+        .clear_thread_for_chat("telegram", &CHAT.to_string(), &DEAD_TOPIC.to_string())
+        .await
+        .expect("eviction");
+
+    assert_eq!(evicted, 2, "both dead-topic rows of the chat are cleared");
+
+    // The poisoned chat now resolves to its General row (no thread), never
+    // the dead topic again.
+    let rows = repo
+        .recent(Some("telegram"), &CHAT.to_string(), 10, None, None)
+        .await
+        .expect("recent after eviction");
+    assert!(
+        rows.iter().all(|r| r.thread_id.as_deref() != Some("30134")),
+        "no row of the chat may still carry the dead topic"
+    );
+
+    // The other chat using the same topic id is untouched.
+    let other = repo
+        .recent(
+            Some("telegram"),
+            &OTHER_CHAT.to_string(),
+            10,
+            Some(&DEAD_TOPIC.to_string()),
+            None,
+        )
+        .await
+        .expect("other chat rows");
+    assert_eq!(
+        other.len(),
+        1,
+        "a different chat using the same topic id must NOT be evicted"
+    );
+}
+
+#[tokio::test]
+async fn eviction_of_an_unknown_topic_is_a_noop() {
+    let repo = seeded_repo().await;
+    let evicted = repo
+        .clear_thread_for_chat("telegram", &CHAT.to_string(), "424242")
+        .await
+        .expect("eviction");
+    assert_eq!(evicted, 0, "an unknown topic clears nothing");
+}
+
+/// The seam contract end-to-end: rich fails with the thread-not-found
+/// signature on the FIRST call (threaded) and succeeds on the SECOND
+/// (unthreaded). The wire must show the unthreaded retry — not a drop, and
+/// not a second threaded attempt.
+#[tokio::test]
+async fn outbox_retries_unthreaded_after_thread_not_found() {
+    use crate::channels::telegram::send::send_markdown_outbox;
+
+    // Pin the process-wide config mirror for this test: the rich-arm choice
+    // reads Config::current(), and parallel tests in this binary leave the
+    // mirror in arbitrary states. Without the pin, the send may ride the
+    // HTML ladder (teloxide client) and the sendRichMessage mocks below see
+    // zero requests — a nondeterministic RED that has nothing to do with
+    // the eviction contract under test. Guard serializes the swap against
+    // the governor tests that mutate the same mirror.
+    let _guard = crate::channels::telegram::governor::test_support::registry_guard().await;
+    let mut pinned: crate::config::Config =
+        toml::from_str(include_str!("../../config.toml.example"))
+            .expect("embedded config.toml.example must parse");
+    // The example file ships rich_messages COMMENTED OUT (default false) —
+    // a pinned parse alone leaves the flag off and the send rides the HTML
+    // ladder, never reaching the sendRichMessage mocks below. Force the
+    // native-rich arm on; that is the path the eviction contract lives on.
+    pinned.channels.telegram.rich_messages = true;
+    crate::config::Config::set_current(pinned);
+
+    let mut server = mockito::Server::new_async().await;
+    // Register order matters. mockito 1.7 dispatches each request to the
+    // FIRST matching mock that still has unmet expected hits (creation
+    // order), not most-recent-first. So the selective `dead` mock is
+    // registered FIRST: it matches only while the request carries the dead
+    // thread id (PartialJson on message_thread_id). On the retry the thread
+    // key is OMITTED entirely (unthreaded address), so `dead` no longer
+    // matches and execution falls to the catch-all `healed` registered
+    // SECOND — the assert below only passes if the wire really went
+    // unthreaded.
+    let dead = server
+        .mock("POST", "/botTESTTOKEN/sendRichMessage")
+        .match_body(mockito::Matcher::PartialJson(
+            serde_json::json!({"message_thread_id": DEAD_TOPIC}),
+        ))
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"ok":false,"error_code":400,"description":"Bad Request: message thread not found"}"#,
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    // Catch-all registered SECOND: never reached while the dead mock still
+    // matches (first-match-with-missing-hits wins), so it only serves the
+    // unthreaded retry.
+    let healed = server
+        .mock("POST", "/botTESTTOKEN/sendRichMessage")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"ok":true,"result":{"message_id":77,"date":1757166400,"chat":{"id":133526395,"type":"private"},"text":"| a | b |\n|---|---|\n| 1 | 2 |"}}"#,
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let bot = teloxide::Bot::with_client(
+        "TESTTOKEN",
+        reqwest_teloxide::Client::builder().build().unwrap(),
+    )
+    .set_api_url(server.url().parse().unwrap());
+
+    // Table-shaped so the message takes the native rich arm.
+    let md = "| a | b |\n|---|---|\n| 1 | 2 |";
+    let sent = send_markdown_outbox(
+        &bot,
+        ChatId(CHAT),
+        Some(ThreadId(teloxide::types::MessageId(DEAD_TOPIC))),
+        md,
+        "tool",
+        "send",
+        None,
+    )
+    .await
+    .expect("the send must be healed by the unthreaded retry, not dropped");
+
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].0, 77);
+
+    dead.assert_async().await;
+    healed.assert_async().await;
+}


### PR DESCRIPTION
## Summary

When sending messages in forum-enabled Telegram chats (including forum-enabled DMs/supergroups), `telegram_send` remembers and auto-routes to the last known topic. If that topic is deleted on Telegram, subsequent sends to that chat hit:
`Bad Request: message thread not found` (HTTP 400).

Because the stale topic was previously retained in chat memory, subsequent plain-text fallbacks or future sends would re-attempt the dead topic ID in a permanent failure loop.

## Changes

1. **Auto-Eviction on 400**: When Telegram API returns `message thread not found`, call `evict_dead_topic` / `clear_thread_for_chat` to purge the dead topic from memory for that chat.
2. **Unthreaded Retry**: Clear the target `thread_id` in outbox delivery and retry delivery unthreaded immediately so the message still lands.
3. **Database Repository**: Added `clear_thread_for_chat(channel, chat_id, thread_id)` to selectively delete matching rows for only that chat/thread without collateral effect.
4. **Unit & Seam Tests**:
   - `eviction_clears_only_the_dead_chat_rows`
   - `eviction_of_an_unknown_topic_is_a_noop`
   - `outbox_retries_unthreaded_after_thread_not_found`

Ref: leshchenko1979/opencrabs#116