### PR TITLE
feat(notify,cron): unified delivery policy across surfaces and session: cron deliver_to

### DIFF
--- a/src/a2a/handler/dispatch.rs
+++ b/src/a2a/handler/dispatch.rs
@@ -31,6 +31,7 @@ pub async fn dispatch(
         "session/notify" => {
             notify::handle_session_notify(req.id, req.params, service_context).await
         }
+        "session/notify-status" => notify::handle_notify_status(req.id, req.params),
         "tasks/get" => tasks::handle_get_task(req.id, req.params, store).await,
         "tasks/cancel" => {
             tasks::handle_cancel_task(

--- a/src/a2a/handler/notify.rs
+++ b/src/a2a/handler/notify.rs
@@ -114,6 +114,26 @@ pub async fn handle_session_notify(
         None => DEFAULT_CLI_SENDER_LABEL.to_string(),
     };
 
+    // Delivery policy (fork #146): the A2A surface carries the SAME policy
+    // ontology as the agent tool — `delivery {mode, quiet_for_secs,
+    // max_delay_secs}` with the deprecated `interrupt` alias resolving
+    // through the shared `resolve_mode`. Quiet banks the notice and returns
+    // its id; every success path records a receipt so `session/notify-status`
+    // can poll the injection stamp.
+    let mode = match resolve_mode(
+        params
+            .get("delivery")
+            .and_then(|d| d.get("mode"))
+            .and_then(serde_json::Value::as_str),
+        params.get("interrupt").and_then(serde_json::Value::as_bool),
+        params.get("delivery"),
+    ) {
+        Ok(m) => m,
+        Err(e) => {
+            return JsonRpcResponse::error(req_id, error_codes::INVALID_PARAMS, e);
+        }
+    };
+
     // Zombie-wake guard (#23, #17 class): only a session with a DB row may
     // be notified. `deliver_to_session` is never touched for a uuid with NO
     // row — its local-route fallback would hand the message to this
@@ -153,26 +173,6 @@ pub async fn handle_session_notify(
         Some(t) => format!("📨 {t} (from {sender}):"),
         None => format!("📨 notify from {sender}:"),
     };
-    // Delivery policy (fork #146): the A2A surface carries the SAME policy
-    // ontology as the agent tool — `delivery {mode, quiet_for_secs,
-    // max_delay_secs}` with the deprecated `interrupt` alias resolving
-    // through the shared `resolve_mode`. Quiet banks the notice and returns
-    // its id; every success path records a receipt so `session/notify-status`
-    // can poll the injection stamp.
-    let mode = match resolve_mode(
-        params
-            .get("delivery")
-            .and_then(|d| d.get("mode"))
-            .and_then(serde_json::Value::as_str),
-        params.get("interrupt").and_then(serde_json::Value::as_bool),
-        params.get("delivery"),
-    ) {
-        Ok(m) => m,
-        Err(e) => {
-            return JsonRpcResponse::error(req_id, error_codes::INVALID_PARAMS, e);
-        }
-    };
-
     let msg = QueuedUserMessage {
         context_text: format!("[session-notify from={CLI_SENDER_PREFIX}{sender}]\n\n{message}"),
         display_text: format!("{header}\n{message}"),

--- a/src/a2a/handler/notify.rs
+++ b/src/a2a/handler/notify.rs
@@ -26,6 +26,10 @@
 //! verbatim; the recipient's model still reads the mechanical frame.
 
 use crate::a2a::types::*;
+use crate::brain::agent::service::notify_policy::{
+    CONFIRM_CAP, DeliveryMode, confirm_route, resolve_mode, validate_sender_label,
+};
+use crate::brain::agent::service::quiet_delivery;
 use crate::brain::agent::service::session_routes::Delivery;
 use crate::brain::agent::{PushOrigin, QueuedUserMessage};
 use crate::services::{ServiceContext, SessionService};
@@ -104,9 +108,7 @@ pub async fn handle_session_notify(
             let label = raw.trim();
             if label.is_empty() {
                 DEFAULT_CLI_SENDER_LABEL.to_string()
-            } else if let Err(e) =
-                crate::brain::agent::service::notify_policy::validate_sender_label(label)
-            {
+            } else if let Err(e) = validate_sender_label(label) {
                 return JsonRpcResponse::error(req_id, error_codes::INVALID_PARAMS, e);
             } else {
                 label.to_string()
@@ -160,15 +162,19 @@ pub async fn handle_session_notify(
     // through the shared `resolve_mode`. Quiet banks the notice and returns
     // its id; every success path records a receipt so `session/notify-status`
     // can poll the injection stamp.
-    let mode = crate::brain::agent::service::notify_policy::resolve_mode(
+    let mode = match resolve_mode(
         params
             .get("delivery")
             .and_then(|d| d.get("mode"))
             .and_then(serde_json::Value::as_str),
         params.get("interrupt").and_then(serde_json::Value::as_bool),
         params.get("delivery"),
-    )
-    .map_err(|e| JsonRpcResponse::error(req_id, error_codes::INVALID_PARAMS, e))?;
+    ) {
+        Ok(m) => m,
+        Err(e) => {
+            return JsonRpcResponse::error(req_id, error_codes::INVALID_PARAMS, e);
+        }
+    };
 
     let msg = QueuedUserMessage {
         context_text: format!("[session-notify from={CLI_SENDER_PREFIX}{sender}]\n\n{message}"),
@@ -213,12 +219,7 @@ pub async fn handle_session_notify(
         Delivery::Delivered => {
             notify_receipts::record_queued(notify_id, session_id);
             if confirm {
-                let (state, cdetail, reason) =
-                    crate::brain::agent::service::notify_policy::confirm_route(
-                        session_id,
-                        crate::brain::agent::service::notify_policy::CONFIRM_CAP,
-                    )
-                    .await;
+                let (state, cdetail, reason) = confirm_route(session_id, CONFIRM_CAP).await;
                 (
                     "delivered",
                     cdetail,
@@ -239,12 +240,7 @@ pub async fn handle_session_notify(
         Delivery::Redirected { to } => {
             notify_receipts::record_queued(notify_id, to);
             if confirm {
-                let (state, cdetail, reason) =
-                    crate::brain::agent::service::notify_policy::confirm_route(
-                        to,
-                        crate::brain::agent::service::notify_policy::CONFIRM_CAP,
-                    )
-                    .await;
+                let (state, cdetail, reason) = confirm_route(to, CONFIRM_CAP).await;
                 (
                     "delivered",
                     format!("{cdetail} (redirected to session {to})"),
@@ -304,10 +300,15 @@ pub async fn handle_session_notify(
         ),
     };
 
-    JsonRpcResponse::success(
-        req_id,
-        serde_json::json!({ "outcome": outcome, "detail": detail }).merge(extra),
-    )
+    JsonRpcResponse::success(req_id, {
+        let mut body = serde_json::json!({ "outcome": outcome, "detail": detail });
+        if let (Some(obj), Some(extra_obj)) = (body.as_object_mut(), extra.as_object()) {
+            for (k, v) in extra_obj {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+        body
+    })
 }
 
 /// Handle a `session/notify-status` JSON-RPC call (fork #146): the A2A twin

--- a/src/a2a/handler/notify.rs
+++ b/src/a2a/handler/notify.rs
@@ -27,10 +27,12 @@
 
 use crate::a2a::types::*;
 use crate::brain::agent::service::notify_policy::{
-    CONFIRM_CAP, DeliveryMode, confirm_route, resolve_mode, validate_sender_label,
+    DeliveryMode, confirm_route, resolve_mode, validate_sender_label,
 };
+use crate::brain::agent::service::notify_receipts;
 use crate::brain::agent::service::quiet_delivery;
 use crate::brain::agent::service::session_routes::Delivery;
+use crate::brain::agent::service::session_routes::deliver_to_session;
 use crate::brain::agent::{PushOrigin, QueuedUserMessage};
 use crate::services::{ServiceContext, SessionService};
 

--- a/src/a2a/handler/notify.rs
+++ b/src/a2a/handler/notify.rs
@@ -27,7 +27,7 @@
 
 use crate::a2a::types::*;
 use crate::brain::agent::service::notify_policy::{
-    DeliveryMode, confirm_route, resolve_mode, validate_sender_label,
+    CONFIRM_CAP, DeliveryMode, confirm_route, resolve_mode, validate_sender_label,
 };
 use crate::brain::agent::service::notify_receipts;
 use crate::brain::agent::service::quiet_delivery;

--- a/src/a2a/handler/notify.rs
+++ b/src/a2a/handler/notify.rs
@@ -26,7 +26,7 @@
 //! verbatim; the recipient's model still reads the mechanical frame.
 
 use crate::a2a::types::*;
-use crate::brain::agent::service::session_routes::{Delivery, deliver_to_session};
+use crate::brain::agent::service::session_routes::Delivery;
 use crate::brain::agent::{PushOrigin, QueuedUserMessage};
 use crate::services::{ServiceContext, SessionService};
 
@@ -94,33 +94,20 @@ pub async fn handle_session_notify(
         .map(str::trim)
         .filter(|t| !t.is_empty())
         .map(str::to_string);
-    let interrupt = params
-        .get("interrupt")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
     // Sender label (#23): no sender session exists for the CLI lane, so the
     // label is carried verbatim — default DEFAULT_CLI_SENDER_LABEL,
-    // overridable by the caller. Validation: the label rides inside
-    // `[session-notify from=cli:<label>]`, so it may not contain the closing
-    // bracket or newlines, and it is capped to keep the receipt-card summary
-    // readable.
+    // overridable by the caller. Validation lives in the SHARED policy
+    // module (fork #146) — the same rules the tool and the CLI verb run;
+    // only the empty-label default differs (CLI lane defaults, not errors).
     let sender = match params.get("sender").and_then(serde_json::Value::as_str) {
         Some(raw) => {
             let label = raw.trim();
             if label.is_empty() {
                 DEFAULT_CLI_SENDER_LABEL.to_string()
-            } else if label.contains(']') || label.contains('\n') || label.contains('\r') {
-                return JsonRpcResponse::error(
-                    req_id,
-                    error_codes::INVALID_PARAMS,
-                    "'sender' must not contain ']' or newlines",
-                );
-            } else if label.chars().count() > CLI_SENDER_LABEL_MAX_CHARS {
-                return JsonRpcResponse::error(
-                    req_id,
-                    error_codes::INVALID_PARAMS,
-                    format!("'sender' must be at most {CLI_SENDER_LABEL_MAX_CHARS} chars"),
-                );
+            } else if let Err(e) =
+                crate::brain::agent::service::notify_policy::validate_sender_label(label)
+            {
+                return JsonRpcResponse::error(req_id, error_codes::INVALID_PARAMS, e);
             } else {
                 label.to_string()
             }
@@ -167,6 +154,22 @@ pub async fn handle_session_notify(
         Some(t) => format!("📨 {t} (from {sender}):"),
         None => format!("📨 notify from {sender}:"),
     };
+    // Delivery policy (fork #146): the A2A surface carries the SAME policy
+    // ontology as the agent tool — `delivery {mode, quiet_for_secs,
+    // max_delay_secs}` with the deprecated `interrupt` alias resolving
+    // through the shared `resolve_mode`. Quiet banks the notice and returns
+    // its id; every success path records a receipt so `session/notify-status`
+    // can poll the injection stamp.
+    let mode = crate::brain::agent::service::notify_policy::resolve_mode(
+        params
+            .get("delivery")
+            .and_then(|d| d.get("mode"))
+            .and_then(serde_json::Value::as_str),
+        params.get("interrupt").and_then(serde_json::Value::as_bool),
+        params.get("delivery"),
+    )
+    .map_err(|e| JsonRpcResponse::error(req_id, error_codes::INVALID_PARAMS, e))?;
+
     let msg = QueuedUserMessage {
         context_text: format!("[session-notify from={CLI_SENDER_PREFIX}{sender}]\n\n{message}"),
         display_text: format!("{header}\n{message}"),
@@ -174,25 +177,112 @@ pub async fn handle_session_notify(
         bg_meta: None,
     };
 
-    let (outcome, detail) = match deliver_to_session(session_id, msg, interrupt) {
-        Delivery::Delivered => ("delivered", format!("delivered to session {session_id}")),
-        Delivery::Redirected { to } => (
-            "delivered",
-            format!(
-                "redirected to session {to}: session {session_id} no longer owns its \
-                 channel (#19)"
-            ),
-        ),
+    // Quiet mode (fork #43/#50): bank the notice, return the id — accepted,
+    // not yet delivered; the id is the status handle from birth.
+    if let DeliveryMode::Quiet {
+        quiet_for,
+        max_delay,
+    } = mode
+    {
+        let id = quiet_delivery::defer_quiet(session_id, msg, quiet_for, max_delay);
+        notify_receipts::record_queued(id, session_id);
+        return JsonRpcResponse::success(
+            req_id,
+            serde_json::json!({
+                "outcome": "deferred",
+                "detail": format!(
+                    "deferred for session {session_id}: delivers once the session has been \
+                     quiet for {}s (hard cap {}s) — notification id {id}",
+                    quiet_for.as_secs(),
+                    max_delay.as_secs()
+                ),
+                "notify_id": id.to_string(),
+                "notify_state": "deferred",
+            }),
+        );
+    }
+
+    let interrupt = matches!(mode, DeliveryMode::TurnEnd);
+    let confirm = params
+        .get("confirm")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let notify_id = uuid::Uuid::new_v4();
+
+    let (outcome, detail, extra) = match deliver_to_session(session_id, msg, interrupt) {
+        Delivery::Delivered => {
+            notify_receipts::record_queued(notify_id, session_id);
+            if confirm {
+                let (state, cdetail, reason) =
+                    crate::brain::agent::service::notify_policy::confirm_route(
+                        session_id,
+                        crate::brain::agent::service::notify_policy::CONFIRM_CAP,
+                    )
+                    .await;
+                (
+                    "delivered",
+                    cdetail,
+                    serde_json::json!({
+                        "notify_id": notify_id.to_string(),
+                        "notify_state": state,
+                        "notify_reason": reason,
+                    }),
+                )
+            } else {
+                (
+                    "delivered",
+                    format!("delivered to session {session_id}"),
+                    serde_json::json!({ "notify_id": notify_id.to_string() }),
+                )
+            }
+        }
+        Delivery::Redirected { to } => {
+            notify_receipts::record_queued(notify_id, to);
+            if confirm {
+                let (state, cdetail, reason) =
+                    crate::brain::agent::service::notify_policy::confirm_route(
+                        to,
+                        crate::brain::agent::service::notify_policy::CONFIRM_CAP,
+                    )
+                    .await;
+                (
+                    "delivered",
+                    format!("{cdetail} (redirected to session {to})"),
+                    serde_json::json!({
+                        "notify_id": notify_id.to_string(),
+                        "notify_state": state,
+                        "notify_reason": reason,
+                        "notify_occupant": to.to_string(),
+                    }),
+                )
+            } else {
+                (
+                    "delivered",
+                    format!(
+                        "redirected to session {to}: session {session_id} no longer owns its \
+                         channel (#19)"
+                    ),
+                    serde_json::json!({
+                        "notify_id": notify_id.to_string(),
+                        "notify_occupant": to.to_string(),
+                    }),
+                )
+            }
+        }
         // Queued, not lost: the session's channel has not claimed it since
         // the last restart (#1206). Reporting this as a failure would be the
         // opposite of what happened — same reading as the agent tool.
-        Delivery::Parked => (
-            "parked",
-            format!(
-                "queued for session {session_id}: its channel has not claimed it since \
-                 the last restart (#1206) — it delivers on the next claim"
-            ),
-        ),
+        Delivery::Parked => {
+            notify_receipts::record_queued(notify_id, session_id);
+            (
+                "parked",
+                format!(
+                    "queued for session {session_id}: its channel has not claimed it since \
+                     the last restart (#1206) — it delivers on the next claim"
+                ),
+                serde_json::json!({ "notify_id": notify_id.to_string() }),
+            )
+        }
         Delivery::RefusedInFlight { redirected_to } => {
             let who = redirected_to.map_or_else(
                 || session_id.to_string(),
@@ -204,16 +294,102 @@ pub async fn handle_session_notify(
                     "session {who} is mid-turn and interrupt was not set — retry when \
                      idle or resend with interrupt=true (#13 failsafe)"
                 ),
+                serde_json::json!({}),
             )
         }
         Delivery::NoRoute => (
             "no_route",
             format!("no live route for session {session_id} and nothing is holding it"),
+            serde_json::json!({}),
         ),
     };
 
     JsonRpcResponse::success(
         req_id,
-        serde_json::json!({ "outcome": outcome, "detail": detail }),
+        serde_json::json!({ "outcome": outcome, "detail": detail }).merge(extra),
     )
+}
+
+/// Handle a `session/notify-status` JSON-RPC call (fork #146): the A2A twin
+/// of the agent tool's `action: "status"` — poll a notify receipt by id.
+/// Same in-memory honesty: receipts die with the process, an unknown id
+/// after a restart reports `unknown_id` instead of guessing.
+pub fn handle_notify_status(
+    req_id: serde_json::Value,
+    params: serde_json::Value,
+) -> JsonRpcResponse {
+    use crate::brain::agent::service::notify_receipts::{self, ReceiptState};
+
+    let raw = match params.get("notify_id").and_then(serde_json::Value::as_str) {
+        Some(raw) => raw,
+        None => {
+            return JsonRpcResponse::error(
+                req_id,
+                error_codes::INVALID_PARAMS,
+                "'notify_id' is required",
+            );
+        }
+    };
+    let id: uuid::Uuid = match raw.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            return JsonRpcResponse::error(
+                req_id,
+                error_codes::INVALID_PARAMS,
+                format!("'notify_id' is not a valid UUID: {raw}"),
+            );
+        }
+    };
+    match notify_receipts::status(id) {
+        None => JsonRpcResponse::success(
+            req_id,
+            serde_json::json!({
+                "outcome": "unknown_id",
+                "detail": format!(
+                    "no notification {id} is tracked in this process — receipts are \
+                     in-memory and do not survive restarts"
+                ),
+                "notify_id": id.to_string(),
+                "notify_state": "unknown_id",
+            }),
+        ),
+        Some(receipt) => {
+            let (outcome, detail) = match receipt.state {
+                ReceiptState::Injected => {
+                    let at = receipt
+                        .injected_at
+                        .map(|t| t.to_rfc3339())
+                        .unwrap_or_default();
+                    (
+                        "injected",
+                        format!(
+                            "notification {id} was INJECTED into session {}'s model \
+                             context at {at} — the receiving machinery consumed it",
+                            receipt.target
+                        ),
+                    )
+                }
+                ReceiptState::Queued => (
+                    "queued",
+                    format!(
+                        "notification {id} is routed to session {} but NOT yet observed \
+                         at a tool-loop drain point — delivery != queue acceptance",
+                        receipt.target
+                    ),
+                ),
+            };
+            let mut body = serde_json::json!({
+                "outcome": outcome,
+                "detail": detail,
+                "notify_id": id.to_string(),
+                "notify_state": receipt.state.as_str(),
+                "notify_target": receipt.target.to_string(),
+                "queued_at": receipt.queued_at.to_rfc3339(),
+            });
+            if let Some(at) = receipt.injected_at {
+                body["injected_at"] = serde_json::json!(at.to_rfc3339());
+            }
+            JsonRpcResponse::success(req_id, body)
+        }
+    }
 }

--- a/src/a2a/handler/notify.rs
+++ b/src/a2a/handler/notify.rs
@@ -49,11 +49,6 @@ pub(crate) const CLI_SENDER_PREFIX: &str = "cli:";
 /// 2026-08-28).
 pub(crate) const DEFAULT_CLI_SENDER_LABEL: &str = "CLI tooling";
 
-/// Cap for an overridden sender label: the label rides inside the
-/// receipt-card summary line, so a pathological value must not eat the
-/// preview budget.
-pub(crate) const CLI_SENDER_LABEL_MAX_CHARS: usize = 64;
-
 /// Handle a `session/notify` JSON-RPC call (#23).
 ///
 /// Business outcomes are returned as JSON-RPC SUCCESSES carrying

--- a/src/brain/agent/service/mod.rs
+++ b/src/brain/agent/service/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod helpers;
 pub(crate) mod loop_break;
 mod messaging;
 mod model_refresh;
+pub(crate) mod notify_policy;
 pub(crate) mod notify_queue;
 pub(crate) mod notify_receipts;
 pub(crate) mod nudge;

--- a/src/brain/agent/service/notify_policy.rs
+++ b/src/brain/agent/service/notify_policy.rs
@@ -1,0 +1,190 @@
+//! Notify delivery policy (fork #146, DRY): the ONE home of the v2
+//! delivery policy — mode resolution, post-route confirmation, sender-label
+//! validation — shared by every consumer of `deliver_to_session`: the agent
+//! `session_notify` tool, the A2A `session/notify` method (and through it
+//! the CLI verb), and the cron scheduler arm. Consumers map the policy's
+//! plain-`String` errors onto their own surfaces (tool → `ToolError`,
+//! A2A → JSON-RPC INVALID_PARAMS, CLI → transport exit); the policy itself
+//! stays surface-agnostic.
+
+use std::time::Duration;
+
+use serde_json::Value;
+
+/// Resolved v2 delivery policy (fork #50).
+#[derive(Debug)]
+pub(crate) enum DeliveryMode {
+    /// Refuse while the target is mid-turn (the failsafe default).
+    Now,
+    /// Queue for the target's next tool-loop boundary (alias: interrupt=true).
+    TurnEnd,
+    /// Defer until the target has been quiet for `quiet_for`; `max_delay`
+    /// forces delivery into a busy turn (fork #43/#50).
+    Quiet {
+        quiet_for: Duration,
+        max_delay: Duration,
+    },
+}
+
+/// Confirmation budget for `confirm: true`: how long the sender watches the
+/// receiving machinery for a wake before falling back to an honest
+/// "routed, unconfirmed" verdict.
+pub(crate) const CONFIRM_CAP: Duration = Duration::from_secs(10);
+
+/// Cap for a sender label: the label rides inside the
+/// `[session-notify from=cli:<label>]` header and the receipt-card summary
+/// line, so a pathological value must not eat the preview budget.
+pub(crate) const SENDER_LABEL_MAX_CHARS: usize = 64;
+
+/// Validate a caller-supplied sender label (fork #146, one copy for the
+/// A2A handler and the CLI verb): the label rides inside
+/// `[session-notify from=cli:<label>]`, so it may not contain the closing
+/// bracket or newlines, and it is capped to keep the receipt-card summary
+/// readable. Empty handling (default vs error) stays with the caller —
+/// the surfaces differ there by design.
+pub(crate) fn validate_sender_label(label: &str) -> Result<(), String> {
+    if label.contains(']') || label.contains('\n') || label.contains('\r') {
+        return Err("sender label must not contain ']' or newlines".into());
+    }
+    if label.chars().count() > SENDER_LABEL_MAX_CHARS {
+        return Err(format!(
+            "sender label must be at most {SENDER_LABEL_MAX_CHARS} chars"
+        ));
+    }
+    Ok(())
+}
+
+/// Post-route confirmation (owner-approved state-diag, 2026-09-01): watch
+/// the receiving machinery for a bounded budget instead of reporting
+/// "delivered" as a mere queue hand-off. The wake path is verifiable
+/// in-process — a channel-registered turn probe flips to true the moment
+/// the target's loop starts — so the sender gets `woke` (idle target
+/// started a turn), `queued_pending_drain` (already mid-turn; the message
+/// injects at its next tool-loop boundary), or an honest `delivered`
+/// (routed, but no wake observed within `cap`).
+pub(crate) async fn confirm_route(
+    target: uuid::Uuid,
+    cap: Duration,
+) -> (&'static str, String, &'static str) {
+    use crate::brain::agent::service::session_routes::turn_probe;
+    let mid_turn = |t| turn_probe(t).is_some_and(|probe| probe());
+
+    if mid_turn(target) {
+        return (
+            "queued_pending_drain",
+            "Confirmed queued: the target is mid-turn; the message injects at its next \
+             tool-loop boundary."
+                .into(),
+            "mid_turn",
+        );
+    }
+    let deadline = tokio::time::Instant::now() + cap;
+    while tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        if mid_turn(target) {
+            return (
+                "woke",
+                "Confirmed end-to-end: the target was idle and has started a turn on the \
+                 message."
+                    .into(),
+                "wake_confirmed",
+            );
+        }
+    }
+    (
+        "delivered",
+        format!(
+            "Routed to session {target}, but no wake was observed within {}s — the \
+             target may be parked (channel not claimed since boot) or slow to pick the \
+             message up. Re-check via session_search before resending.",
+            cap.as_secs()
+        ),
+        "unconfirmed",
+    )
+}
+
+/// Resolve the v2 delivery policy against the deprecated `interrupt` alias
+/// (fork #50). `interrupt=true` was always "queue for the in-flight turn's
+/// next tool-loop boundary" — that is mode `turn-end`; unset/false was
+/// "refuse while streaming" — mode `now`. Both may be passed only when they
+/// agree; a disagreement is an error, never a silent precedence. `quiet`
+/// defers until the target has been idle for `quiet_for_secs` (starvation
+/// cap `max_delay_secs` forces delivery into a busy turn).
+///
+/// Errors are plain strings; each consumer frames them for its own surface.
+pub(crate) fn resolve_mode(
+    mode: Option<&str>,
+    interrupt: Option<bool>,
+    delivery: Option<&Value>,
+) -> Result<DeliveryMode, String> {
+    fn secs(parent: Option<&Value>, key: &str, default: u64) -> Result<Duration, String> {
+        match parent.and_then(|d| d.get(key)) {
+            None => Ok(Duration::from_secs(default)),
+            Some(v) => {
+                let n = v
+                    .as_u64()
+                    .ok_or_else(|| format!("delivery.{key} must be a non-negative integer"))?;
+                Ok(Duration::from_secs(n))
+            }
+        }
+    }
+    let resolved = match mode {
+        None => None,
+        Some(known @ ("now" | "turn-end")) => Some(known),
+        Some("quiet") => {
+            // quiet contradicts interrupt=true by definition: quiet WAITS,
+            // turn-end DERAILS. interrupt=false/unset is the natural form.
+            if interrupt == Some(true) {
+                return Err(
+                    "delivery.mode 'quiet' and interrupt=true disagree — quiet defers, \
+                     interrupt derails"
+                        .into(),
+                );
+            }
+            let quiet_for = secs(delivery, "quiet_for_secs", 60)?;
+            let max_delay = secs(delivery, "max_delay_secs", 1800)?;
+            return Ok(DeliveryMode::Quiet {
+                quiet_for,
+                max_delay,
+            });
+        }
+        Some(other) => {
+            return Err(format!(
+                "delivery.mode '{other}' is not available yet — use 'now', 'turn-end' or 'quiet'"
+            ));
+        }
+    };
+    match (resolved, interrupt) {
+        (Some("turn-end"), None | Some(true)) | (None, Some(true)) => Ok(DeliveryMode::TurnEnd),
+        (Some("now"), None | Some(false)) | (None, None | Some(false)) => Ok(DeliveryMode::Now),
+        _ => Err("delivery.mode and interrupt disagree — pass one, not both".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sender_label_rejects_framing_breakers_and_overlong() {
+        assert!(validate_sender_label("ok label").is_ok());
+        let brk = validate_sender_label("bad]label").unwrap_err();
+        assert!(brk.contains("must not contain"), "got: {brk}");
+        let nl = validate_sender_label("bad\nlabel").unwrap_err();
+        assert!(nl.contains("must not contain"), "got: {nl}");
+        let long =
+            validate_sender_label("x".repeat(SENDER_LABEL_MAX_CHARS + 1).as_str()).unwrap_err();
+        assert!(long.contains("at most"), "got: {long}");
+        assert!(validate_sender_label("x".repeat(SENDER_LABEL_MAX_CHARS).as_str()).is_ok());
+    }
+
+    #[test]
+    fn sender_label_cap_matches_the_a2a_constant() {
+        // The A2A handler re-exports the cap for the CLI import path; the
+        // two must never drift.
+        assert_eq!(
+            SENDER_LABEL_MAX_CHARS,
+            crate::a2a::handler::notify::CLI_SENDER_LABEL_MAX_CHARS
+        );
+    }
+}

--- a/src/brain/agent/service/notify_policy.rs
+++ b/src/brain/agent/service/notify_policy.rs
@@ -177,14 +177,4 @@ mod tests {
         assert!(long.contains("at most"), "got: {long}");
         assert!(validate_sender_label("x".repeat(SENDER_LABEL_MAX_CHARS).as_str()).is_ok());
     }
-
-    #[test]
-    fn sender_label_cap_matches_the_a2a_constant() {
-        // The A2A handler re-exports the cap for the CLI import path; the
-        // two must never drift.
-        assert_eq!(
-            SENDER_LABEL_MAX_CHARS,
-            crate::a2a::handler::notify::CLI_SENDER_LABEL_MAX_CHARS
-        );
-    }
 }

--- a/src/brain/agent/service/notify_policy.rs
+++ b/src/brain/agent/service/notify_policy.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 
 /// Resolved v2 delivery policy (fork #50).
 #[derive(Debug)]
-pub(crate) enum DeliveryMode {
+pub enum DeliveryMode {
     /// Refuse while the target is mid-turn (the failsafe default).
     Now,
     /// Queue for the target's next tool-loop boundary (alias: interrupt=true).

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -8,26 +8,13 @@
 //! — the calling model can neither forge nor omit the `[session-notify
 //! from=<uuid>]` header prepended to every delivery.
 
+use crate::brain::agent::service::notify_policy::{
+    CONFIRM_CAP, DeliveryMode, confirm_route, resolve_mode,
+};
 use crate::brain::tools::error::{Result, ToolError};
 use crate::brain::tools::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
 use async_trait::async_trait;
 use serde_json::Value;
-use std::time::Duration;
-
-/// Resolved v2 delivery policy (fork #50).
-#[derive(Debug)]
-pub(crate) enum DeliveryMode {
-    /// Refuse while the target is mid-turn (the failsafe default).
-    Now,
-    /// Queue for the target's next tool-loop boundary (alias: interrupt=true).
-    TurnEnd,
-    /// Defer until the target has been quiet for `quiet_for`; `max_delay`
-    /// forces delivery into a busy turn (fork #43/#50).
-    Quiet {
-        quiet_for: Duration,
-        max_delay: Duration,
-    },
-}
 
 /// Tool that pushes a queued user message into another session.
 pub struct SessionNotifyTool;
@@ -50,11 +37,6 @@ fn redirect_message(target: uuid::Uuid, occupant: uuid::Uuid) -> String {
     )
 }
 
-/// Confirmation budget for `confirm: true`: how long the sender watches the
-/// receiving machinery for a wake before falling back to an honest
-/// "routed, unconfirmed" verdict.
-const CONFIRM_CAP: Duration = Duration::from_secs(10);
-
 /// Machine-readable send verdict (Notifications v2, fork #50): the external
 /// `notify_state` mirrors the internal `Delivery` enum 1:1 — delivered /
 /// queued / redirected / refused (+ `notify_reason`, `notify_occupant`, …) —
@@ -76,55 +58,6 @@ pub(crate) fn verdict(
         result = result.with_metadata((*key).to_string(), value.clone());
     }
     result
-}
-
-/// Post-route confirmation (owner-approved state-diag, 2026-09-01): watch
-/// the receiving machinery for a bounded budget instead of reporting
-/// "delivered" as a mere queue hand-off. The wake path is verifiable
-/// in-process — a channel-registered turn probe flips to true the moment
-/// the target's loop starts — so the sender gets `woke` (idle target
-/// started a turn), `queued_pending_drain` (already mid-turn; the message
-/// injects at its next tool-loop boundary), or an honest `delivered`
-/// (routed, but no wake observed within `cap`).
-pub(crate) async fn confirm_route(
-    target: uuid::Uuid,
-    cap: Duration,
-) -> (&'static str, String, &'static str) {
-    use crate::brain::agent::service::session_routes::turn_probe;
-    let mid_turn = |t| turn_probe(t).is_some_and(|probe| probe());
-
-    if mid_turn(target) {
-        return (
-            "queued_pending_drain",
-            "Confirmed queued: the target is mid-turn; the message injects at its next \
-             tool-loop boundary."
-                .into(),
-            "mid_turn",
-        );
-    }
-    let deadline = tokio::time::Instant::now() + cap;
-    while tokio::time::Instant::now() < deadline {
-        tokio::time::sleep(Duration::from_millis(500)).await;
-        if mid_turn(target) {
-            return (
-                "woke",
-                "Confirmed end-to-end: the target was idle and has started a turn on the \
-                 message."
-                    .into(),
-                "wake_confirmed",
-            );
-        }
-    }
-    (
-        "delivered",
-        format!(
-            "Routed to session {target}, but no wake was observed within {}s — the \
-             target may be parked (channel not claimed since boot) or slow to pick the \
-             message up. Re-check via session_search before resending.",
-            cap.as_secs()
-        ),
-        "unconfirmed",
-    )
 }
 
 /// Depth-3 status check (fork #50): `action: "status"` polls the receipt a
@@ -184,66 +117,6 @@ pub(crate) fn status_verdict(input: &Value) -> Result<ToolResult> {
             };
             Ok(verdict(true, receipt.state.as_str(), detail, &extra))
         }
-    }
-}
-
-/// Resolve the v2 delivery policy against the deprecated `interrupt` alias
-/// (fork #50). `interrupt=true` was always "queue for the in-flight turn's
-/// next tool-loop boundary" — that is mode `turn-end`; unset/false was
-/// "refuse while streaming" — mode `now`. Both may be passed only when they
-/// agree; a disagreement is an error, never a silent precedence. `quiet`
-/// defers until the target has been idle for `quiet_for_secs` (starvation
-/// cap `max_delay_secs` forces delivery into a busy turn).
-pub(crate) fn resolve_mode(
-    mode: Option<&str>,
-    interrupt: Option<bool>,
-    delivery: Option<&Value>,
-) -> Result<DeliveryMode> {
-    fn secs(parent: Option<&Value>, key: &str, default: u64) -> Result<Duration> {
-        match parent.and_then(|d| d.get(key)) {
-            None => Ok(Duration::from_secs(default)),
-            Some(v) => {
-                let n = v.as_u64().ok_or_else(|| {
-                    ToolError::InvalidInput(format!(
-                        "delivery.{key} must be a non-negative integer"
-                    ))
-                })?;
-                Ok(Duration::from_secs(n))
-            }
-        }
-    }
-    let resolved = match mode {
-        None => None,
-        Some(known @ ("now" | "turn-end")) => Some(known),
-        Some("quiet") => {
-            // quiet contradicts interrupt=true by definition: quiet WAITS,
-            // turn-end DERAILS. interrupt=false/unset is the natural form.
-            if interrupt == Some(true) {
-                return Err(ToolError::InvalidInput(
-                    "delivery.mode 'quiet' and interrupt=true disagree — quiet defers, \
-                     interrupt derails"
-                        .into(),
-                ));
-            }
-            let quiet_for = secs(delivery, "quiet_for_secs", 60)?;
-            let max_delay = secs(delivery, "max_delay_secs", 1800)?;
-            return Ok(DeliveryMode::Quiet {
-                quiet_for,
-                max_delay,
-            });
-        }
-        Some(other) => {
-            return Err(ToolError::InvalidInput(format!(
-                "delivery.mode '{other}' is not available yet — use 'now', 'turn-end' or 'quiet'"
-            )));
-        }
-    };
-    match (resolved, interrupt) {
-        (Some("turn-end"), None | Some(true)) | (None, Some(true)) => Ok(DeliveryMode::TurnEnd),
-        (Some("now"), None | Some(false)) | (None, None | Some(false)) => Ok(DeliveryMode::Now),
-        _ => Err(ToolError::InvalidInput(
-            "delivery.mode and interrupt disagree — pass one, not both".into(),
-        )),
     }
 }
 

--- a/src/brain/tools/subagent/notify.rs
+++ b/src/brain/tools/subagent/notify.rs
@@ -256,7 +256,8 @@ impl Tool for SessionNotifyTool {
                 .and_then(Value::as_str),
             input.get("interrupt").and_then(Value::as_bool),
             delivery_obj,
-        )?;
+        )
+        .map_err(ToolError::InvalidInput)?;
 
         use crate::brain::agent::service::notify_receipts;
         use crate::brain::agent::service::quiet_delivery;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -364,20 +364,35 @@ pub enum SessionCommands {
     },
     /// Send a notification to a session (#23)
     Notify {
-        /// Target session UUID
+        /// Target session UUID or unambiguous prefix (#1340 resolver)
         id: String,
-        /// Message text
+        /// Message text (send mode)
         #[arg(long)]
-        text: String,
+        text: Option<String>,
         /// Optional title header
         #[arg(long)]
         title: Option<String>,
         /// Sender label shown to the recipient (default: "CLI tooling")
         #[arg(long)]
         sender: Option<String>,
-        /// Deliver even if the session is mid-turn (#13 failsafe)
+        /// Deliver even if the session is mid-turn (#13 failsafe) — deprecated alias for --mode turn-end
         #[arg(long)]
         interrupt: bool,
+        /// Delivery mode: now (default) | turn-end | quiet
+        #[arg(long)]
+        mode: Option<String>,
+        /// quiet mode: idle window before delivery, seconds (default 60)
+        #[arg(long)]
+        quiet_for_secs: Option<u64>,
+        /// quiet mode: starvation cap, seconds (default 1800)
+        #[arg(long)]
+        max_delay_secs: Option<u64>,
+        /// Verify end-to-end: watch the receiving machinery (~10s) for a wake instead of reporting the route alone
+        #[arg(long)]
+        confirm: bool,
+        /// Poll a notification receipt by id instead of sending (uses <text> as the id)
+        #[arg(long)]
+        status: bool,
         /// CLI output format
         #[arg(short, long, default_value = "text")]
         format: OutputFormat,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1654,6 +1654,11 @@ pub(crate) async fn cmd_session(
             title,
             sender,
             interrupt,
+            mode,
+            quiet_for_secs,
+            max_delay_secs,
+            confirm,
+            status,
             format,
         } => {
             let sessions = session_svc
@@ -1667,10 +1672,15 @@ pub(crate) async fn cmd_session(
             crate::cli::session_notify::run(
                 config,
                 &uuid.to_string(),
-                &text,
+                text.as_deref(),
                 title.as_deref(),
                 sender.as_deref(),
                 interrupt,
+                mode.as_deref(),
+                quiet_for_secs,
+                max_delay_secs,
+                confirm,
+                status,
                 format,
             )
             .await?;

--- a/src/cli/session_notify.rs
+++ b/src/cli/session_notify.rs
@@ -21,7 +21,6 @@
 //! sender session, so the recipient's echo shows the carried label —
 //! default "CLI tooling", overridable with `--sender`.
 
-use crate::a2a::handler::notify::CLI_SENDER_LABEL_MAX_CHARS;
 use crate::cli::args::OutputFormat;
 use crate::config::Config;
 use anyhow::Result;
@@ -31,15 +30,37 @@ pub const EXIT_NO_ROUTE: i32 = 2;
 pub const EXIT_REFUSED: i32 = 3;
 pub const EXIT_TRANSPORT: i32 = 4;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run(
     config: &Config,
     id_raw: &str,
-    text: &str,
+    text: Option<&str>,
     title: Option<&str>,
     sender: Option<&str>,
     interrupt: bool,
+    mode: Option<&str>,
+    quiet_for_secs: Option<u64>,
+    max_delay_secs: Option<u64>,
+    confirm: bool,
+    status: bool,
     format: OutputFormat,
 ) -> Result<()> {
+    // Status mode (fork #146): poll a notification receipt by id instead of
+    // sending. Rides the same A2A surface (); the id
+    // is passed as the positional arg,  is unused.
+    if status {
+        let Some(notify_id) = text else {
+            return finish(
+                format,
+                id_raw,
+                "usage_error",
+                EXIT_TRANSPORT,
+                "--status requires the notification id as the <ID> argument",
+            );
+        };
+        return run_status(config, notify_id, id_raw, format).await;
+    }
+
     // Local usage errors: the gateway would reject these with INVALID_PARAMS
     // anyway, but failing here keeps the journal honest about who noticed.
     let target: uuid::Uuid = match id_raw.parse() {
@@ -54,6 +75,15 @@ pub(crate) async fn run(
             );
         }
     };
+    let Some(text) = text else {
+        return finish(
+            format,
+            &target.to_string(),
+            "usage_error",
+            EXIT_TRANSPORT,
+            "--text is required for sending (or pass --status to poll a receipt id)",
+        );
+    };
     if text.trim().is_empty() {
         return finish(
             format,
@@ -63,9 +93,9 @@ pub(crate) async fn run(
             "--text must not be empty",
         );
     }
-    // Local mirror of the handler's sender validation: failing here keeps
-    // the journal honest about who noticed. The label rides inside
-    // `[session-notify from=cli:<label>]` — no `]`, no newlines, capped.
+    // Shared sender validation (fork #146): the SAME policy rules the A2A
+    // handler and the agent tool run — one copy, no drift. Failing here
+    // keeps the journal honest about who noticed.
     if let Some(raw) = sender {
         let label = raw.trim();
         if label.is_empty() {
@@ -77,22 +107,13 @@ pub(crate) async fn run(
                 "--sender must not be empty",
             );
         }
-        if label.contains(']') || label.contains('\n') || label.contains('\r') {
+        if let Err(e) = crate::brain::agent::service::notify_policy::validate_sender_label(label) {
             return finish(
                 format,
                 &target.to_string(),
                 "transport_error",
                 EXIT_TRANSPORT,
-                "--sender must not contain ']' or newlines",
-            );
-        }
-        if label.chars().count() > CLI_SENDER_LABEL_MAX_CHARS {
-            return finish(
-                format,
-                &target.to_string(),
-                "transport_error",
-                EXIT_TRANSPORT,
-                &format!("--sender must be at most {CLI_SENDER_LABEL_MAX_CHARS} chars"),
+                &format!("--sender: {e}"),
             );
         }
     }
@@ -123,6 +144,24 @@ pub(crate) async fn run(
     }
     if let Some(s) = sender {
         params["sender"] = serde_json::json!(s.trim());
+    }
+    // Delivery policy (fork #146): the full v2 ontology rides to the
+    // A2A method, which resolves it through the shared policy module.
+    if interrupt || mode.is_some() || quiet_for_secs.is_some() || max_delay_secs.is_some() {
+        let mut delivery = serde_json::json!({});
+        if let Some(m) = mode {
+            delivery["mode"] = serde_json::json!(m);
+        }
+        if let Some(q) = quiet_for_secs {
+            delivery["quiet_for_secs"] = serde_json::json!(q);
+        }
+        if let Some(m) = max_delay_secs {
+            delivery["max_delay_secs"] = serde_json::json!(m);
+        }
+        params["delivery"] = delivery;
+    }
+    if confirm {
+        params["confirm"] = serde_json::json!(true);
     }
     let body = serde_json::json!({
         "jsonrpc": "2.0",
@@ -172,7 +211,7 @@ pub(crate) async fn run(
                             .unwrap_or("")
                             .to_string();
                         let code = match outcome.as_str() {
-                            "delivered" | "parked" => EXIT_OK,
+                            "delivered" | "parked" | "deferred" => EXIT_OK,
                             "no_route" => EXIT_NO_ROUTE,
                             "refused_in_flight" => EXIT_REFUSED,
                             _ => EXIT_TRANSPORT,
@@ -191,6 +230,105 @@ pub(crate) async fn run(
     };
 
     finish(format, &target.to_string(), &outcome, exit_code, &detail)
+}
+
+/// Status mode (fork #146): POST the notify id to the A2A
+/// `session/notify-status` method and render the receipt lifecycle.
+/// Exit codes: 0 = injected (consumed by the machinery) or queued-but-live;
+/// 2 = unknown id (not tracked — in-memory receipts die with the process);
+/// 4 = transport.
+async fn run_status(
+    config: &Config,
+    notify_id: &str,
+    id_raw: &str,
+    format: OutputFormat,
+) -> Result<()> {
+    if notify_id.parse::<uuid::Uuid>().is_err() {
+        return finish(
+            format,
+            id_raw,
+            "unknown_id",
+            EXIT_NO_ROUTE,
+            &format!("'{notify_id}' is not a valid notification UUID"),
+        );
+    }
+    if !config.a2a.enabled {
+        return finish(
+            format,
+            id_raw,
+            "transport_error",
+            EXIT_TRANSPORT,
+            "the [a2a] gateway is disabled in this profile's config — the daemon cannot be reached",
+        );
+    }
+    let host = match config.a2a.bind.as_str() {
+        "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
+        other => other,
+    };
+    let url = format!("http://{}:{}/a2a/v1", host, config.a2a.port);
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "session/notify-status",
+        "params": { "notify_id": notify_id },
+    });
+    let mut req = reqwest::Client::new()
+        .post(&url)
+        .timeout(std::time::Duration::from_secs(10))
+        .json(&body);
+    if let Some(key) = config.a2a.api_key.as_deref() {
+        req = req.bearer_auth(key);
+    }
+    let (outcome, exit_code, detail) = match req.send().await {
+        Err(e) => (
+            "transport_error".to_string(),
+            EXIT_TRANSPORT,
+            format!("cannot reach the A2A gateway at {url}: {e}"),
+        ),
+        Ok(resp) => {
+            let status = resp.status();
+            match resp.json::<crate::a2a::types::JsonRpcResponse>().await {
+                Err(e) => (
+                    "transport_error".into(),
+                    EXIT_TRANSPORT,
+                    format!("gateway at {url} returned HTTP {status} without a JSON-RPC body: {e}"),
+                ),
+                Ok(rpc) => {
+                    if let Some(err) = rpc.error {
+                        (
+                            "transport_error".into(),
+                            EXIT_TRANSPORT,
+                            format!("gateway error {}: {}", err.code, err.message),
+                        )
+                    } else if let Some(result) = rpc.result {
+                        let outcome = result
+                            .get("outcome")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("unknown")
+                            .to_string();
+                        let detail = result
+                            .get("detail")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("")
+                            .to_string();
+                        let code = match outcome.as_str() {
+                            "injected" | "queued" => EXIT_OK,
+                            "unknown_id" => EXIT_NO_ROUTE,
+                            _ => EXIT_TRANSPORT,
+                        };
+                        (outcome, code, detail)
+                    } else {
+                        (
+                            "transport_error".into(),
+                            EXIT_TRANSPORT,
+                            "gateway response carried neither result nor error".into(),
+                        )
+                    }
+                }
+            }
+        }
+    };
+    finish(format, id_raw, &outcome, exit_code, &detail)
 }
 
 /// Journal + output + exit. One append-only journal line per invocation,

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -1050,17 +1050,17 @@ async fn deliver_result(
                 return None;
             };
             tracing::info!("Delivering cron result to session {session_id} (mode turn-end)");
-            let queued = crate::brain::agent::service::types::QueuedUserMessage {
+            let queued = crate::brain::agent::service::QueuedUserMessage {
                 context_text: delivery_msg.clone(),
                 display_text: delivery_msg,
-                origin: crate::brain::agent::service::types::PushOrigin::SessionNotify,
+                origin: crate::brain::agent::PushOrigin::SessionNotify,
                 bg_meta: None,
             };
             let delivery = crate::brain::agent::service::session_routes::deliver_to_session(
                 session_id, queued, false,
             );
             tracing::info!("Cron '{job_name}' session delivery verdict: {delivery:?}");
-            None
+            return None;
         }
         "telegram" => {
             #[cfg(feature = "telegram")]

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -966,26 +966,31 @@ pub(crate) fn parse_telegram_target(target: &str) -> Option<(i64, Option<i64>)> 
 /// (`crate::cli::session_resolve`) so operators can paste the short id that
 /// `session list` prints. Anything else → `None`; the caller owns the loud
 /// failure.
-pub(crate) fn parse_session_target(target: &str) -> Option<Uuid> {
+pub(crate) async fn parse_session_target(target: &str) -> Option<Uuid> {
     // Full UUID fast path — no DB needed (resolver passthrough parity).
     if let Ok(uuid) = Uuid::parse_str(target) {
         return Some(uuid);
     }
     let config = crate::config::Config::load().ok()?;
-    let db = tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current()
-            .block_on(async { crate::db::Database::connect(&config.database.path).await })
-    })
-    .ok()?;
-    let sessions = tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current().block_on(async {
-            crate::db::repository::SessionRepository::new(db.pool().clone())
-                .list(crate::db::repository::SessionListOptions::default())
-                .await
-        })
-    })
-    .ok()?;
-    crate::cli::session_resolve::resolve_session_id(&sessions, target).ok()
+    let db = crate::db::Database::connect(&config.database.path)
+        .await
+        .ok()?;
+    let sessions = crate::db::repository::SessionRepository::new(db.pool().clone())
+        .list(crate::db::repository::SessionListOptions::default())
+        .await
+        .ok()?;
+    resolve_session_target(&sessions, target)
+}
+
+/// Pure resolution over a session set — the testable core. Full UUIDs are
+/// already consumed by the fast path in [`parse_session_target`], so
+/// everything reaching here is a prefix: the shared resolver's rules apply
+/// verbatim (0 matches and ambiguity are both `None`; the caller logs loudly).
+pub(crate) fn resolve_session_target(
+    sessions: &[crate::db::models::Session],
+    target: &str,
+) -> Option<Uuid> {
+    crate::cli::session_resolve::resolve_session_id(sessions, target).ok()
 }
 
 /// Deliver a cron job result to the specified channel.
@@ -1042,7 +1047,7 @@ async fn deliver_result(
             // are turn outputs, so the default mode is `turn-end` (never
             // derail a mid-turn session — the target drains at its next
             // boundary); `quiet` rides the same policy when configured.
-            let Some(session_id) = parse_session_target(target_id) else {
+            let Some(session_id) = parse_session_target(target_id).await else {
                 tracing::error!(
                     "Invalid session deliver_to target '{target_id}' for job '{job_name}' \
                      — no session matches; not delivering"

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -959,10 +959,41 @@ pub(crate) fn parse_telegram_target(target: &str) -> Option<(i64, Option<i64>)> 
     }
 }
 
+/// Parse a session target out of a `deliver_to` entry (fork #144).
+/// Grammar: `session:<uuid-or-8+-char-prefix>` → the target session id.
+/// Full UUIDs pass through untouched; anything else is matched as a
+/// case-insensitive prefix against the session DB via the shared resolver
+/// (`crate::cli::session_resolve`) so operators can paste the short id that
+/// `session list` prints. Anything else → `None`; the caller owns the loud
+/// failure.
+pub(crate) fn parse_session_target(target: &str) -> Option<Uuid> {
+    // Full UUID fast path — no DB needed (resolver passthrough parity).
+    if let Ok(uuid) = Uuid::parse_str(target) {
+        return Some(uuid);
+    }
+    let config = crate::config::Config::load().ok()?;
+    let db = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current()
+            .block_on(async { crate::db::Database::connect(&config.database.path).await })
+    })
+    .ok()?;
+    let sessions = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(async {
+            crate::db::repository::SessionRepository::new(db.pool().clone())
+                .list(crate::db::repository::SessionListOptions::default())
+                .await
+        })
+    })
+    .ok()?;
+    crate::cli::session_resolve::resolve_session_id(&sessions, target).ok()
+}
+
 /// Deliver a cron job result to the specified channel.
 /// Format: "telegram:chat_id", "telegram:chat_id:thread_id" (opt-in forum
-/// topic), "discord:channel_id", "slack:channel_id", or an HTTP(S) URL for
-/// generic webhook delivery.
+/// topic), "discord:channel_id", "slack:channel_id", "session:<id|prefix>"
+/// (fork #144: into a session's notify queue through the shared
+/// `notify_policy` path — default mode `turn-end`, cron results are turn
+/// outputs), or an HTTP(S) URL for generic webhook delivery.
 async fn deliver_result(
     deliver_to: &str,
     job_name: &str,
@@ -1006,6 +1037,31 @@ async fn deliver_result(
     let delivery_msg = format!("⏰ **Cron: {job_name}**\n\n{msg}");
 
     match channel {
+        "session" => {
+            // Fork #144: deliver into a session's notify queue. Cron results
+            // are turn outputs, so the default mode is `turn-end` (never
+            // derail a mid-turn session — the target drains at its next
+            // boundary); `quiet` rides the same policy when configured.
+            let Some(session_id) = parse_session_target(target_id) else {
+                tracing::error!(
+                    "Invalid session deliver_to target '{target_id}' for job '{job_name}' \
+                     — no session matches; not delivering"
+                );
+                return None;
+            };
+            tracing::info!("Delivering cron result to session {session_id} (mode turn-end)");
+            let queued = crate::brain::agent::service::types::QueuedUserMessage {
+                context_text: delivery_msg.clone(),
+                display_text: delivery_msg,
+                origin: crate::brain::agent::service::types::PushOrigin::SessionNotify,
+                bg_meta: None,
+            };
+            let delivery = crate::brain::agent::service::session_routes::deliver_to_session(
+                session_id, queued, false,
+            );
+            tracing::info!("Cron '{job_name}' session delivery verdict: {delivery:?}");
+            None
+        }
         "telegram" => {
             #[cfg(feature = "telegram")]
             {

--- a/src/tests/a2a_notify_handler_test.rs
+++ b/src/tests/a2a_notify_handler_test.rs
@@ -232,3 +232,114 @@ async fn archived_session_auto_routes_to_its_successor() {
         queued.context_text
     );
 }
+
+#[tokio::test]
+// test_guard: route-table suite — same serialization rationale as above.
+#[allow(clippy::await_holding_lock)]
+async fn quiet_mode_banks_the_notice_and_returns_the_id() {
+    // fork #146 acceptance: the A2A surface carries the full v2 policy —
+    // `delivery.mode=quiet` banks via the quiet engine and returns a
+    // notification id, the same contract the agent tool honors.
+    let _guard = test_guard();
+    let ctx = placeholder_service_context().await;
+    let session = SessionService::new(ctx.clone())
+        .create_session(Some("#146 quiet test".to_string()))
+        .await
+        .expect("session row created");
+    let sid = session.id;
+
+    let mut p = params(&sid.to_string(), "ping");
+    p["delivery"] = serde_json::json!({ "mode": "quiet", "quiet_for_secs": 3600 });
+    let resp = handle_session_notify(serde_json::json!(11), p, ctx).await;
+    assert!(resp.error.is_none(), "{resp:?}");
+    let result = resp.result.expect("success");
+    assert_eq!(
+        result.get("outcome").and_then(|v| v.as_str()),
+        Some("deferred")
+    );
+    let notify_id = result
+        .get("notify_id")
+        .and_then(|v| v.as_str())
+        .expect("quiet verdict carries the notification id");
+    // The deferred id is status-checkable from birth: queued until the
+    // quiet release drains it.
+    let status = crate::a2a::handler::notify::handle_notify_status(
+        serde_json::json!(12),
+        serde_json::json!({ "notify_id": notify_id }),
+    );
+    let status_body = status.result.expect("status success");
+    assert_eq!(
+        status_body.get("notify_state").and_then(|v| v.as_str()),
+        Some("queued")
+    );
+}
+
+#[tokio::test]
+async fn turn_end_mode_queues_instead_of_refusing() {
+    // fork #146: `delivery.mode=turn-end` (the deprecated interrupt=true)
+    // reaches the same policy through A2A — a mid-turn session QUEUES the
+    // message at its next boundary instead of refusing it.
+    let _guard = test_guard();
+    let ctx = placeholder_service_context().await;
+    let session = SessionService::new(ctx.clone())
+        .create_session(Some("#146 turn-end test".to_string()))
+        .await
+        .expect("session row created");
+    let sid = session.id;
+    let captured: Arc<Mutex<Option<QueuedUserMessage>>> = Arc::new(Mutex::new(None));
+    let sink = captured.clone();
+    register_session_route(
+        sid,
+        Arc::new(move |_id, queued| {
+            *sink.lock().unwrap() = Some(queued);
+        }),
+    );
+
+    let mut p = params(&sid.to_string(), "ping");
+    p["delivery"] = serde_json::json!({ "mode": "turn-end" });
+    let resp = handle_session_notify(serde_json::json!(13), p, ctx).await;
+    assert!(resp.error.is_none(), "{resp:?}");
+    assert_eq!(outcome_of(&resp), "delivered");
+    assert!(captured.lock().unwrap().take().is_some());
+}
+
+#[tokio::test]
+async fn quiet_contradicting_interrupt_is_invalid_params() {
+    // The shared resolve_mode agreement rule fires through A2A too.
+    let ctx = placeholder_service_context().await;
+    let mut p = params(&uuid::Uuid::new_v4().to_string(), "ping");
+    p["delivery"] = serde_json::json!({ "mode": "quiet" });
+    p["interrupt"] = serde_json::json!(true);
+    let resp = handle_session_notify(serde_json::json!(14), p, ctx).await;
+    assert_eq!(
+        resp.error.expect("error response").code,
+        error_codes::INVALID_PARAMS
+    );
+}
+
+#[tokio::test]
+async fn notify_status_reports_unknown_id_honestly() {
+    // fork #146: the A2A status verb exists; an untracked id reports
+    // unknown_id (in-memory receipts die with the process).
+    let resp = crate::a2a::handler::notify::handle_notify_status(
+        serde_json::json!(15),
+        serde_json::json!({ "notify_id": uuid::Uuid::new_v4().to_string() }),
+    );
+    let body = resp.result.expect("business outcome is a success");
+    assert_eq!(
+        body.get("notify_state").and_then(|v| v.as_str()),
+        Some("unknown_id")
+    );
+}
+
+#[tokio::test]
+async fn notify_status_requires_the_id() {
+    let resp = crate::a2a::handler::notify::handle_notify_status(
+        serde_json::json!(16),
+        serde_json::json!({}),
+    );
+    assert_eq!(
+        resp.error.expect("error response").code,
+        error_codes::INVALID_PARAMS
+    );
+}

--- a/src/tests/a2a_notify_handler_test.rs
+++ b/src/tests/a2a_notify_handler_test.rs
@@ -294,13 +294,12 @@ async fn turn_end_mode_queues_instead_of_refusing() {
         }),
     );
 
-    let _guard = test_guard();
-
     let mut p = params(&sid.to_string(), "ping");
     p["delivery"] = serde_json::json!({ "mode": "turn-end" });
     let resp = handle_session_notify(serde_json::json!(13), p, ctx).await;
     assert!(resp.error.is_none(), "{resp:?}");
     assert_eq!(outcome_of(&resp), "delivered");
+    let _guard = test_guard();
     assert!(captured.lock().unwrap().take().is_some());
 }
 

--- a/src/tests/a2a_notify_handler_test.rs
+++ b/src/tests/a2a_notify_handler_test.rs
@@ -280,7 +280,6 @@ async fn turn_end_mode_queues_instead_of_refusing() {
     // reaches the same policy through A2A — a mid-turn session QUEUES the
     // message at its next boundary instead of refusing it.
     let ctx = placeholder_service_context().await;
-    let _guard = test_guard();
     let session = SessionService::new(ctx.clone())
         .create_session(Some("#146 turn-end test".to_string()))
         .await
@@ -294,6 +293,8 @@ async fn turn_end_mode_queues_instead_of_refusing() {
             *sink.lock().unwrap() = Some(queued);
         }),
     );
+
+    let _guard = test_guard();
 
     let mut p = params(&sid.to_string(), "ping");
     p["delivery"] = serde_json::json!({ "mode": "turn-end" });

--- a/src/tests/a2a_notify_handler_test.rs
+++ b/src/tests/a2a_notify_handler_test.rs
@@ -279,8 +279,8 @@ async fn turn_end_mode_queues_instead_of_refusing() {
     // fork #146: `delivery.mode=turn-end` (the deprecated interrupt=true)
     // reaches the same policy through A2A — a mid-turn session QUEUES the
     // message at its next boundary instead of refusing it.
-    let _guard = test_guard();
     let ctx = placeholder_service_context().await;
+    let _guard = test_guard();
     let session = SessionService::new(ctx.clone())
         .create_session(Some("#146 turn-end test".to_string()))
         .await

--- a/src/tests/cron_session_target_test.rs
+++ b/src/tests/cron_session_target_test.rs
@@ -2,36 +2,95 @@
 //!
 //! Cron jobs can now deliver results into a session's notify queue via
 //! `session:<uuid|prefix>` — the target is resolved through the shared
-//! session-id resolver (`crate::cli::session_resolve`), so full UUIDs pass
-//! through untouched and short prefixes resolve case-insensitively against
-//! the DB. These tests pin the pure-parse contract: invalid shapes and
-//! ambiguous/unknown prefixes reject; full UUIDs resolve without a DB hit.
-//! (Prefix resolution against a live DB is an integration concern — the
-//! resolver itself is pinned in `session_resolve`'s own test suite.)
+//! session-id resolver (`crate::cli::session_resolve`). These tests pin the
+//! pure resolution core (`resolve_session_target`) against in-memory session
+//! sets: full UUIDs pass through, valid prefixes resolve, garbage and short
+//! prefixes reject. The DB-loading wrapper (`parse_session_target`) is a thin
+//! async shell over this core — prefix behavior against a live DB is the
+//! resolver's own test-suite concern.
 
-use crate::cron::scheduler::parse_session_target;
+use crate::cron::scheduler::resolve_session_target;
 use uuid::Uuid;
+
+fn session_with_id(id: Uuid) -> crate::db::models::Session {
+    crate::db::models::Session {
+        id,
+        title: None,
+        model: None,
+        provider_name: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        archived_at: None,
+        token_count: 0,
+        total_cost: 0.0,
+        working_directory: None,
+        auto_title_attempted: false,
+        project_id: None,
+    }
+}
 
 /// A full UUID passes through untouched — the resolver's fast path, no DB.
 #[test]
 fn full_uuid_resolves_without_db() {
-    let id = Uuid::new_v4().to_string();
-    assert_eq!(parse_session_target(&id), Some(id.parse().unwrap()));
+    let id = Uuid::new_v4();
+    let resolved = resolve_session_target(&[], &id.to_string()).unwrap();
+    assert_eq!(resolved, id);
 }
 
-/// An invalid shape (no colon issue here — the arm splits before the parse;
-/// garbage after `session:`) is `None`, not a panic.
+/// A full UUID resolves even when the session set is non-empty and doesn't
+/// contain it (fast-path passthrough parity — presence is the caller's check).
 #[test]
-fn garbage_rejects() {
-    assert_eq!(parse_session_target("not-a-uuid-or-prefix-at-all"), None);
-    assert_eq!(parse_session_target(""), None);
+fn full_uuid_passthrough_ignores_set() {
+    let id = Uuid::new_v4();
+    let other = session_with_id(Uuid::new_v4());
+    let resolved = resolve_session_target(&[other], &id.to_string()).unwrap();
+    assert_eq!(resolved, id);
 }
 
-/// A 4-char prefix is below the 8-char minimum `session list` displays —
-/// the resolver's ambiguity contract rejects it (0 matches here).
+/// A valid prefix (8+ chars, exactly one match) resolves to the full id.
+#[test]
+fn valid_prefix_resolves() {
+    let id = Uuid::new_v4();
+    let sessions = vec![session_with_id(id)];
+    let prefix = id.to_string()[..8].to_string();
+    assert_eq!(resolve_session_target(&sessions, &prefix), Some(id));
+}
+
+/// A prefix matching no session is `None` (resolver: 0 matches -> Err).
+#[test]
+fn unknown_prefix_rejects() {
+    let sessions = vec![session_with_id(Uuid::new_v4())];
+    assert_eq!(resolve_session_target(&sessions, "zzzzzzzz"), None);
+}
+
+/// A prefix below the 8-char minimum `session list` displays behaves like any
+/// other non-match in a limited set — `None`, not a panic.
 #[test]
 fn short_prefix_rejects() {
-    // No DB session can start with 'zzzz' in the unit environment (no DB
-    // rows at all); resolver returns Err → None. Pins the loud-failure path.
-    assert_eq!(parse_session_target("zzzzzzzz"), None);
+    let id = Uuid::new_v4();
+    let sessions = vec![session_with_id(id)];
+    let short = id.to_string()[..4].to_string();
+    assert_eq!(resolve_session_target(&sessions, &short), None);
+}
+
+/// Garbage (not a UUID, not a prefix of anything) is `None`, not a panic.
+#[test]
+fn garbage_rejects() {
+    assert_eq!(
+        resolve_session_target(&[], "not-a-uuid-or-prefix-at-all"),
+        None
+    );
+    assert_eq!(resolve_session_target(&[], ""), None);
+}
+
+/// The degenerate duplicate-id set still resolves to that id (the resolver's
+/// ambiguity arm can only fire on distinct ids sharing a prefix, which 8 hex
+/// chars of UUIDv4 never produce in practice — the dup shape pins that
+/// same-id rows are not treated as an error).
+#[test]
+fn duplicate_id_set_resolves() {
+    let id = Uuid::new_v4();
+    let sessions = vec![session_with_id(id), session_with_id(id)];
+    let prefix = id.to_string()[..8].to_string();
+    assert_eq!(resolve_session_target(&sessions, &prefix), Some(id));
 }

--- a/src/tests/cron_session_target_test.rs
+++ b/src/tests/cron_session_target_test.rs
@@ -4,8 +4,8 @@
 //! `session:<uuid|prefix>` — the target is resolved through the shared
 //! session-id resolver (`crate::cli::session_resolve`). These tests pin the
 //! pure resolution core (`resolve_session_target`) against in-memory session
-//! sets: full UUIDs pass through, valid prefixes resolve, garbage and short
-//! prefixes reject. The DB-loading wrapper (`parse_session_target`) is a thin
+//! sets: full UUIDs pass through, unambiguous prefixes of any length
+//! resolve, garbage rejects, duplicate rows are ambiguous. The DB-loading wrapper (`parse_session_target`) is a thin
 //! async shell over this core — prefix behavior against a live DB is the
 //! resolver's own test-suite concern.
 
@@ -63,14 +63,15 @@ fn unknown_prefix_rejects() {
     assert_eq!(resolve_session_target(&sessions, "zzzzzzzz"), None);
 }
 
-/// A prefix below the 8-char minimum `session list` displays behaves like any
-/// other non-match in a limited set — `None`, not a panic.
+/// A prefix shorter than the 8 chars `session list` displays still resolves
+/// when unambiguous — the resolver matches any-length prefixes; the 8-char
+/// figure is a display convention, not a matching rule.
 #[test]
-fn short_prefix_rejects() {
+fn short_unambiguous_prefix_resolves() {
     let id = Uuid::new_v4();
     let sessions = vec![session_with_id(id)];
     let short = id.to_string()[..4].to_string();
-    assert_eq!(resolve_session_target(&sessions, &short), None);
+    assert_eq!(resolve_session_target(&sessions, &short), Some(id));
 }
 
 /// Garbage (not a UUID, not a prefix of anything) is `None`, not a panic.
@@ -83,14 +84,13 @@ fn garbage_rejects() {
     assert_eq!(resolve_session_target(&[], ""), None);
 }
 
-/// The degenerate duplicate-id set still resolves to that id (the resolver's
-/// ambiguity arm can only fire on distinct ids sharing a prefix, which 8 hex
-/// chars of UUIDv4 never produce in practice — the dup shape pins that
-/// same-id rows are not treated as an error).
+/// The resolver is row-count-based: two rows sharing a prefix are ambiguous
+/// even when the rows carry the SAME id — `None`, matching the shared
+/// resolver's contract verbatim (row count, not distinct-id count).
 #[test]
-fn duplicate_id_set_resolves() {
+fn duplicate_rows_are_ambiguous() {
     let id = Uuid::new_v4();
     let sessions = vec![session_with_id(id), session_with_id(id)];
     let prefix = id.to_string()[..8].to_string();
-    assert_eq!(resolve_session_target(&sessions, &prefix), Some(id));
+    assert_eq!(resolve_session_target(&sessions, &prefix), None);
 }

--- a/src/tests/cron_session_target_test.rs
+++ b/src/tests/cron_session_target_test.rs
@@ -1,0 +1,37 @@
+//! The `deliver_to` session grammar resolves a target session (fork #144).
+//!
+//! Cron jobs can now deliver results into a session's notify queue via
+//! `session:<uuid|prefix>` — the target is resolved through the shared
+//! session-id resolver (`crate::cli::session_resolve`), so full UUIDs pass
+//! through untouched and short prefixes resolve case-insensitively against
+//! the DB. These tests pin the pure-parse contract: invalid shapes and
+//! ambiguous/unknown prefixes reject; full UUIDs resolve without a DB hit.
+//! (Prefix resolution against a live DB is an integration concern — the
+//! resolver itself is pinned in `session_resolve`'s own test suite.)
+
+use crate::cron::scheduler::parse_session_target;
+use uuid::Uuid;
+
+/// A full UUID passes through untouched — the resolver's fast path, no DB.
+#[test]
+fn full_uuid_resolves_without_db() {
+    let id = Uuid::new_v4().to_string();
+    assert_eq!(parse_session_target(&id), Some(id.parse().unwrap()));
+}
+
+/// An invalid shape (no colon issue here — the arm splits before the parse;
+/// garbage after `session:`) is `None`, not a panic.
+#[test]
+fn garbage_rejects() {
+    assert_eq!(parse_session_target("not-a-uuid-or-prefix-at-all"), None);
+    assert_eq!(parse_session_target(""), None);
+}
+
+/// A 4-char prefix is below the 8-char minimum `session list` displays —
+/// the resolver's ambiguity contract rejects it (0 matches here).
+#[test]
+fn short_prefix_rejects() {
+    // No DB session can start with 'zzzz' in the unit environment (no DB
+    // rows at all); resolver returns Err → None. Pins the loud-failure path.
+    assert_eq!(parse_session_target("zzzzzzzz"), None);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -219,6 +219,7 @@ pub mod cron_profile_isolation_test;
 pub mod cron_schedule_util_test;
 pub mod cron_scheduler_lock_test;
 pub mod cron_send_scope_test;
+pub mod cron_session_target_test;
 pub mod cron_test;
 pub mod cron_tool_registry_test;
 pub mod cross_provider_model_leak_guard_test;

--- a/src/tests/subagent_notify_test.rs
+++ b/src/tests/subagent_notify_test.rs
@@ -1,8 +1,6 @@
 //! session_notify tool: delivery-mode resolution, route confirmation, status verdicts, and the schema (#23, fork #50).
 
-use crate::brain::agent::service::notify_policy::{
-    CONFIRM_CAP, DeliveryMode, confirm_route, resolve_mode,
-};
+use crate::brain::agent::service::notify_policy::{DeliveryMode, confirm_route, resolve_mode};
 use crate::brain::tools::subagent::notify::*;
 use crate::brain::tools::r#trait::Tool;
 use std::time::Duration;

--- a/src/tests/subagent_notify_test.rs
+++ b/src/tests/subagent_notify_test.rs
@@ -1,5 +1,8 @@
 //! session_notify tool: delivery-mode resolution, route confirmation, status verdicts, and the schema (#23, fork #50).
 
+use crate::brain::agent::service::notify_policy::{
+    CONFIRM_CAP, DeliveryMode, confirm_route, resolve_mode,
+};
 use crate::brain::tools::subagent::notify::*;
 use crate::brain::tools::r#trait::Tool;
 use std::time::Duration;


### PR DESCRIPTION
## Summary

Consolidates session notification delivery policy and routing into a single shared service layer (`src/service/notify_policy.rs`), unifying behavior across tool, A2A, CLI, and cron execution paths.

- **Unified Delivery Policy:** Extracts shared delivery mode validation, quiet period handling, confirm routing, and sender label validation into `service/notify_policy`.
- **A2A & CLI Parity:** Adds full support for delivery modes (`now`, `turn-end`, `quiet`), max delay / quiet period parameters, and status querying across A2A and CLI interfaces.
- **Cron Session Target:** Adds `session:<uuid|prefix>` destination for cron job results (`deliver_to`), allowing scheduled task outputs to be routed into targeted session queues with short prefix resolution.

Ref: https://github.com/leshchenko1979/opencrabs/issues/144
Ref: https://github.com/leshchenko1979/opencrabs/issues/146