### PR TITLE
feat(subagents): add include_brain parameter and context gap disclosure

### DIFF
--- a/src/brain/tools/subagent/brain.rs
+++ b/src/brain/tools/subagent/brain.rs
@@ -1,0 +1,48 @@
+use crate::brain::prompt_builder::{BrainLoader, RuntimeInfo};
+use crate::brain::tools::error::collapse_home;
+use std::path::Path;
+
+pub const READ_ONLY_CAPABILITY_NOTE: &str = "[Capability note: This sub-agent runs with a read-restricted tool registry (#1173) — file reads, search, and web research only. Tools for shell execution, file writes, and further sub-agents are absent.]\n\n";
+
+pub const LEAN_BRAIN_CONTEXT_NOTE: &str = "[Context note: This sub-agent runs without pre-injected workspace brain files (SOUL.md, USER.md, AGENTS.md). Call load_brain_file(name, query) to consult workspace conventions when relevant, or note missing guidelines if needed.]\n\n";
+
+/// Builds the system brain string for a child agent if include_brain is true.
+pub fn child_system_brain(
+    include_brain: bool,
+    child_dir: &Path,
+    model: Option<&str>,
+    provider: Option<&str>,
+) -> Option<String> {
+    if !include_brain {
+        return None;
+    }
+    let runtime_info = RuntimeInfo {
+        model: model.map(|s| s.to_string()),
+        provider: provider.map(|s| s.to_string()),
+        working_directory: Some(collapse_home(child_dir)),
+    };
+    let brain_path = BrainLoader::resolve_path();
+    let loader = BrainLoader::new(brain_path);
+    Some(loader.build_core_brain(Some(&runtime_info)))
+}
+
+/// Constructs the full prompt delivered to a child agent, stacking capability and context notes.
+pub fn child_prompt(read_only: bool, include_brain: bool, prompt: &str) -> String {
+    let mut prefix = String::new();
+    if read_only {
+        prefix.push_str(READ_ONLY_CAPABILITY_NOTE);
+    }
+    if !include_brain {
+        prefix.push_str(LEAN_BRAIN_CONTEXT_NOTE);
+    }
+    format!("{}{}", prefix, prompt)
+}
+
+/// Human-readable label for spawn response reporting.
+pub fn brain_status_label(include_brain: bool) -> &'static str {
+    if include_brain {
+        "core attached (SOUL/USER/AGENTS)"
+    } else {
+        "lean (none pre-injected; use load_brain_file)"
+    }
+}

--- a/src/brain/tools/subagent/manager.rs
+++ b/src/brain/tools/subagent/manager.rs
@@ -53,6 +53,11 @@ pub struct SubAgent {
     /// manager's `get_read_only` instead of reaching through the lock.
     pub read_only: bool,
 
+    /// Whether this child was spawned with workspace brain files pre-injected (#145).
+    ///
+    /// Frozen for the agent's lifetime: resume re-attaches system brain when true.
+    pub include_brain: bool,
+
     /// Whether this child may spawn further sub-agents or background tasks
     /// (#1195). Frozen for the agent's lifetime like [`SubAgent::read_only`]:
     /// enforcement live-queries the manager by the caller's session id, so
@@ -109,6 +114,7 @@ impl SubAgent {
             session_id,
             parent_session_id,
             read_only: false,
+            include_brain: false,
             allow_nested: true,
             state: SubAgentState::Running,
             cancel_token: CancellationToken::new(),
@@ -167,6 +173,15 @@ impl SubAgentManager {
             .expect("subagent manager lock poisoned")
             .get(id)
             .map(|a| a.read_only)
+    }
+
+    /// Whether the agent was spawned with workspace brain files pre-injected (#145).
+    pub fn get_include_brain(&self, id: &str) -> Option<bool> {
+        self.agents
+            .read()
+            .expect("subagent manager lock poisoned")
+            .get(id)
+            .map(|a| a.include_brain)
     }
 
     /// May the agent operating on `session_id` spawn further sub-agents or

--- a/src/brain/tools/subagent/mod.rs
+++ b/src/brain/tools/subagent/mod.rs
@@ -8,6 +8,7 @@
 //! close, or resume any child by agent_id.
 
 pub mod agent_type;
+pub mod brain;
 mod close;
 pub mod manager;
 pub(crate) mod notify;

--- a/src/brain/tools/subagent/resume.rs
+++ b/src/brain/tools/subagent/resume.rs
@@ -214,13 +214,27 @@ impl Tool for ResumeAgentTool {
                 );
             }
 
-            Arc::new(
+            let child_dir = context.working_dir();
+            let include_brain = self.manager.get_include_brain(agent_id).unwrap_or(false);
+            let system_brain = super::brain::child_system_brain(
+                include_brain,
+                &child_dir,
+                subagent_model.as_deref(),
+                effective_provider_name.as_deref(),
+            );
+
+            let mut builder =
                 crate::brain::agent::AgentService::new(provider, service_context, &config)
                     .await
                     .with_tool_registry(child_registry)
                     .with_auto_approve_tools(true)
-                    .with_working_directory(context.working_dir()),
-            )
+                    .with_working_directory(child_dir);
+
+            if let Some(brain) = system_brain {
+                builder = builder.with_system_brain(brain);
+            }
+
+            Arc::new(builder)
         };
 
         // Spawn resumed task with input loop

--- a/src/brain/tools/subagent/spawn.rs
+++ b/src/brain/tools/subagent/spawn.rs
@@ -198,6 +198,10 @@ impl Tool for SpawnAgentTool {
                     "type": "boolean",
                     "description": "Spawn this child with a read-restricted tool registry (#1173): file reads, glob/grep/ls and web research only — no writes, no bash, no spawning. Use for exploration, code review, and research children. Omit or false for a full-capability worker (still minus recursive/dangerous tools)."
                 },
+                "include_brain": {
+                    "type": "boolean",
+                    "description": "Whether to pre-inject workspace brain files (SOUL.md, USER.md, AGENTS.md) into the child agent (#145). Default false (lean execution — sub-agents query workspace files on demand via load_brain_file). Set true when delegating full co-worker tasks that need immediate ambient access to all workspace rules and personality."
+                },
                 "provider": {
                     "type": "string",
                     "description": "Optional provider override for THIS spawn (e.g., 'zhipu', 'openrouter', 'custom:my-provider'). Highest precedence — overrides config.agent.subagent_provider and parent inheritance. Use to route this single sub-agent differently from the global subagent config."
@@ -276,6 +280,21 @@ impl Tool for SpawnAgentTool {
                 )
             })?),
             None => None,
+        };
+
+        // Brain pre-injection flag (#145): absent = false (lean default).
+        // Non-boolean is a hard error.
+        let include_brain = match input.get("include_brain") {
+            None | Some(serde_json::Value::Bool(_)) => input
+                .get("include_brain")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            Some(_) => {
+                return Ok(ToolResult::error(
+                    "'include_brain' must be a boolean (true = pre-inject workspace brain, false = lean)"
+                        .to_string(),
+                ));
+            }
         };
         let deprecated_raw = input
             .get("agent_type")
@@ -459,13 +478,24 @@ impl Tool for SpawnAgentTool {
                 .map(|w| w.path.clone())
                 .unwrap_or_else(|| context.working_dir());
 
-            let agent =
+            let system_brain = super::brain::child_system_brain(
+                include_brain,
+                &child_dir,
+                model_override.as_deref(),
+                effective_provider_name.as_deref(),
+            );
+
+            let mut agent =
                 crate::brain::agent::AgentService::new(provider, service_context.clone(), &config)
                     .await
                     .with_tool_registry(child_registry)
                     .with_auto_approve_tools(true) // children auto-approve (parent already approved spawn)
                     .with_working_directory(child_dir)
                     .with_plan_session_override(plan_session_override);
+
+            if let Some(brain) = system_brain {
+                agent = agent.with_system_brain(brain);
+            }
 
             Arc::new(agent)
         };
@@ -474,15 +504,8 @@ impl Tool for SpawnAgentTool {
         // gets one factual capability line derived from its actual grant —
         // no role-play text that could drift from what the registry truly
         // allows. Full-access children receive just the task.
-        let full_prompt = if read_only {
-            format!(
-                "[Capability note: you are a READ-ONLY sub-agent. Your tool set \
-                 contains file reading/search and web research only — no writes, \
-                 no bash, no spawning. Report findings; do not attempt changes.]\n\n{prompt}"
-            )
-        } else {
-            prompt.clone()
-        };
+        // #145: stacked capability + lean context note.
+        let full_prompt = super::brain::child_prompt(read_only, include_brain, &prompt);
 
         // Create the status file in Pending state before spawning. new()
         // writes the file; we don't need the returned handle, but we do
@@ -691,6 +714,7 @@ impl Tool for SpawnAgentTool {
         // Register in manager
         self.manager.insert(SubAgent {
             read_only,
+            include_brain,
             allow_nested,
             cancel_token,
             join_handle: Some(handle),
@@ -704,7 +728,7 @@ impl Tool for SpawnAgentTool {
         });
 
         Ok(ToolResult::success(format!(
-            "Spawned sub-agent '{}' with id: {}\nSession: {}\nAccess: {}\nPrompt: {}{}",
+            "Spawned sub-agent '{}' with id: {}\nSession: {}\nAccess: {}\nBrain: {}\nPrompt: {}{}",
             label,
             agent_id,
             child_session_id,
@@ -713,6 +737,7 @@ impl Tool for SpawnAgentTool {
             } else {
                 "full (minus recursive/dangerous tools)"
             },
+            super::brain::brain_status_label(include_brain),
             prompt,
             deprecation_note
                 .as_deref()

--- a/src/brain/tools/subagent/team/create.rs
+++ b/src/brain/tools/subagent/team/create.rs
@@ -79,6 +79,10 @@ impl Tool for TeamCreateTool {
                                 "type": "boolean",
                                 "description": "Spawn this member with a read-restricted tool registry (#1173): reads/search/research only. Omit or false for full capability."
                             },
+                            "include_brain": {
+                                "type": "boolean",
+                                "description": "Whether to pre-inject workspace brain files (SOUL.md, USER.md, AGENTS.md) into this team member (#145). Default false (lean execution). Set true when delegating full co-worker tasks."
+                            },
                             "provider": {
                                 "type": "string",
                                 "description": "Optional per-member provider override (e.g., 'zhipu', 'openrouter', 'custom:my-provider'). Highest precedence — overrides config.agent.subagent_provider for THIS member only."
@@ -190,6 +194,17 @@ impl Tool for TeamCreateTool {
                 }
             };
 
+            // Brain pre-injection flag (#145): absent = false; non-boolean = hard error.
+            let member_include_brain = match agent_def.get("include_brain") {
+                None => false,
+                Some(serde_json::Value::Bool(b)) => *b,
+                Some(_) => {
+                    return Ok(ToolResult::error(format!(
+                        "Team member '{label}': 'include_brain' must be a boolean"
+                    )));
+                }
+            };
+
             let (read_only, member_grant_note) = match (member_read_only, deprecated_raw) {
                 (Some(ro), _) => (ro, None),
                 (None, Some(raw)) => {
@@ -284,26 +299,33 @@ impl Tool for TeamCreateTool {
                 );
             }
 
-            let child_service = Arc::new(
+            let child_dir = context.working_dir();
+            let system_brain = super::super::brain::child_system_brain(
+                member_include_brain,
+                &child_dir,
+                model_override.as_deref(),
+                effective_provider_name.as_deref(),
+            );
+
+            let mut child_service_builder =
                 crate::brain::agent::AgentService::new(provider, service_context.clone(), &config)
                     .await
                     .with_tool_registry(child_registry)
                     .with_auto_approve_tools(true)
-                    .with_working_directory(context.working_dir()),
-            );
+                    .with_working_directory(child_dir);
+
+            if let Some(brain) = system_brain {
+                child_service_builder = child_service_builder.with_system_brain(brain);
+            }
+
+            let child_service = Arc::new(child_service_builder);
 
             // Typed preambles are gone (#1173, Proposal B): restricted
             // members get one factual capability line, full members just the
             // task.
-            let full_prompt = if read_only {
-                format!(
-                    "[Capability note: you are a READ-ONLY team member. Your tool \
-                     set contains file reading/search and web research only — no \
-                     writes, no bash, no spawning.]\n\n{prompt}"
-                )
-            } else {
-                prompt
-            };
+            // #145: stacked capability + lean context note.
+            let full_prompt =
+                super::super::brain::child_prompt(read_only, member_include_brain, &prompt);
 
             let cancel_clone = cancel_token.clone();
             let manager = self.subagent_manager.clone();
@@ -391,6 +413,7 @@ impl Tool for TeamCreateTool {
             // Register in subagent manager
             self.subagent_manager.insert(SubAgent {
                 read_only,
+                include_brain: member_include_brain,
                 allow_nested: member_allow_nested,
                 cancel_token,
                 join_handle: Some(handle),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -713,6 +713,7 @@ pub mod slash_autocomplete_dimensions_test;
 pub mod slash_command_resolution_test;
 pub mod slash_models_target_test;
 pub mod split_pane_test;
+pub mod subagent_brain_test;
 pub mod subagent_compaction_preamble_test;
 pub mod subagent_natural_completion_test;
 pub mod subagent_provider_pair_test;

--- a/src/tests/subagent_brain_test.rs
+++ b/src/tests/subagent_brain_test.rs
@@ -1,0 +1,164 @@
+//! Tests for sub-agent brain context boundary (#145).
+//!
+//! Sub-agents run lean by default (no pre-injected brain files), but can
+//! opt in to full workspace brain via `include_brain: true`.
+
+use crate::brain::tools::Tool;
+use crate::brain::tools::subagent::brain::{
+    LEAN_BRAIN_CONTEXT_NOTE, READ_ONLY_CAPABILITY_NOTE, brain_status_label, child_prompt,
+    child_system_brain,
+};
+use crate::brain::tools::subagent::{SpawnAgentTool, SubAgentManager, TeamCreateTool, TeamManager};
+use crate::config::profile::with_home_override;
+use std::fs;
+use std::sync::Arc;
+
+#[test]
+fn prompt_stacking_lean_full_access() {
+    let prompt = child_prompt(false, false, "Fix the bug");
+    assert!(
+        prompt.contains(LEAN_BRAIN_CONTEXT_NOTE.trim()),
+        "lean full-access child must carry the lean context note"
+    );
+    assert!(
+        !prompt.contains(READ_ONLY_CAPABILITY_NOTE.trim()),
+        "full-access child must not carry read-only capability note"
+    );
+    assert!(
+        prompt.ends_with("Fix the bug"),
+        "task prompt must be at the end"
+    );
+}
+
+#[test]
+fn prompt_stacking_lean_read_only() {
+    let prompt = child_prompt(true, false, "Review the PR");
+    assert!(
+        prompt.contains(READ_ONLY_CAPABILITY_NOTE.trim()),
+        "read-only child must carry capability note"
+    );
+    assert!(
+        prompt.contains(LEAN_BRAIN_CONTEXT_NOTE.trim()),
+        "lean read-only child must carry lean context note"
+    );
+    assert!(
+        prompt.find(READ_ONLY_CAPABILITY_NOTE.trim()).unwrap()
+            < prompt.find(LEAN_BRAIN_CONTEXT_NOTE.trim()).unwrap(),
+        "capability note must precede context note"
+    );
+    assert!(
+        prompt.ends_with("Review the PR"),
+        "task prompt must be at the end"
+    );
+}
+
+#[test]
+fn prompt_stacking_included_brain() {
+    let prompt = child_prompt(false, true, "Implement feature");
+    assert!(
+        !prompt.contains(LEAN_BRAIN_CONTEXT_NOTE.trim()),
+        "child with include_brain=true must NOT carry lean context note"
+    );
+    assert!(
+        !prompt.contains(READ_ONLY_CAPABILITY_NOTE.trim()),
+        "full-access child must not carry capability note"
+    );
+    assert!(prompt.ends_with("Implement feature"));
+}
+
+#[test]
+fn brain_status_label_reporting() {
+    assert_eq!(
+        brain_status_label(false),
+        "lean (none pre-injected; use load_brain_file)"
+    );
+    assert_eq!(brain_status_label(true), "core attached (SOUL/USER/AGENTS)");
+}
+
+#[test]
+fn child_system_brain_none_when_false() {
+    let tmp = tempfile::tempdir().unwrap();
+    let brain = child_system_brain(false, tmp.path(), None, None);
+    assert!(
+        brain.is_none(),
+        "child_system_brain must return None when include_brain is false"
+    );
+}
+
+#[test]
+fn child_system_brain_loads_core_files_when_true() {
+    let home_tmp = tempfile::tempdir().unwrap();
+    let work_tmp = tempfile::tempdir().unwrap();
+
+    with_home_override(home_tmp.path().to_path_buf(), || {
+        // Seed home brain files
+        fs::write(home_tmp.path().join("SOUL.md"), "# SOUL\nBeep boop").unwrap();
+        fs::write(home_tmp.path().join("USER.md"), "# USER\nAlexey").unwrap();
+        fs::write(home_tmp.path().join("AGENTS.md"), "# AGENTS\nRunbook rules").unwrap();
+
+        // Seed project directive in child workdir
+        fs::write(work_tmp.path().join("CLAUDE.md"), "# CLAUDE\nProject rules").unwrap();
+
+        let brain = child_system_brain(
+            true,
+            work_tmp.path(),
+            Some("test-model"),
+            Some("test-provider"),
+        );
+        assert!(
+            brain.is_some(),
+            "child_system_brain must produce a brain when include_brain is true"
+        );
+        let brain_str = brain.unwrap();
+        assert!(brain_str.contains("Beep boop"), "must contain SOUL.md");
+        assert!(brain_str.contains("Alexey"), "must contain USER.md");
+        assert!(
+            brain_str.contains("Runbook rules"),
+            "must contain AGENTS.md"
+        );
+        assert!(
+            brain_str.contains("CLAUDE.md"),
+            "must discover project directive (CLAUDE.md) in child working directory"
+        );
+    });
+}
+
+#[test]
+fn spawn_agent_schema_exposes_include_brain() {
+    let tool = SpawnAgentTool::new(
+        Arc::new(SubAgentManager::new()),
+        Arc::new(crate::brain::tools::ToolRegistry::new()),
+    );
+    let schema = tool.input_schema();
+    let props = schema
+        .get("properties")
+        .and_then(|v| v.as_object())
+        .expect("schema must have properties");
+    assert!(
+        props.contains_key("include_brain"),
+        "spawn_agent must expose optional `include_brain` parameter (#145)"
+    );
+    let include_brain_prop = props.get("include_brain").unwrap();
+    assert_eq!(
+        include_brain_prop.get("type").and_then(|v| v.as_str()),
+        Some("boolean")
+    );
+}
+
+#[test]
+fn team_create_schema_exposes_include_brain_on_agent_items() {
+    let tool = TeamCreateTool::new(
+        Arc::new(SubAgentManager::new()),
+        Arc::new(TeamManager::new()),
+        Arc::new(crate::brain::tools::ToolRegistry::new()),
+    );
+    let schema = tool.input_schema();
+    let agent_props = schema
+        .pointer("/properties/agents/items/properties")
+        .and_then(|v| v.as_object())
+        .expect("agents items must have properties");
+    assert!(
+        agent_props.contains_key("include_brain"),
+        "team_create per-agent item schema must expose `include_brain` (#145)"
+    );
+}

--- a/src/tests/subagent_tool_description_test.rs
+++ b/src/tests/subagent_tool_description_test.rs
@@ -170,6 +170,23 @@ fn team_create_each_member_can_pick_its_own_provider_and_model() {
 }
 
 #[test]
+fn spawn_agent_schema_exposes_include_brain_param() {
+    let tool = SpawnAgentTool::new(
+        std::sync::Arc::new(crate::brain::tools::subagent::SubAgentManager::new()),
+        std::sync::Arc::new(crate::brain::tools::ToolRegistry::new()),
+    );
+    let schema = tool.input_schema();
+    let props = schema
+        .get("properties")
+        .and_then(|v| v.as_object())
+        .expect("schema must have properties");
+    assert!(
+        props.contains_key("include_brain"),
+        "spawn_agent must expose optional `include_brain` parameter (#145)"
+    );
+}
+
+#[test]
 fn readme_documents_subagent_provider_and_model_keys() {
     // Bundled at compile time so the test is hermetic and a doc tidy-up
     // that drops the section can't slip past CI.


### PR DESCRIPTION
## Summary

Closes the context expectation gap between parent orchestrators and spawned sub-agents by making the brain context boundary explicit and configurable:

1. **Explicit Schema & Lean Default Disclosure:**
   - Adds `include_brain: Option<bool>` (default `false`) to `spawn_agent` and `team_create` member configs.
   - Updates tool descriptions to explicitly disclose that sub-agents run lean without pre-injected workspace brain files (`SOUL.md`, `USER.md`, `AGENTS.md`), advising orchestrators to inline rules or pass `include_brain: true`.

2. **Child Prompt Grounding:**
   - When `include_brain` is `false` (the default), child prompts receive a capability note:
     `[Context note: This sub-agent runs without pre-injected workspace brain files (SOUL.md, USER.md, AGENTS.md). Use the load_brain_file tool to query workspace rules on demand, or note any missing conventions in your output.]`
   - Prevents sub-agents from hallucinating generic policies or failing in silence when workspace-specific rules are required.

3. **Opt-in Core Brain Pre-injection (`include_brain: true`):**
   - When `include_brain: true` is passed, `AgentService` attaches the core workspace brain (`BrainLoader::build_core_brain`) initialized with the child's worktree `RuntimeInfo`, pre-loading `SOUL.md`, `USER.md`, `AGENTS.md`, and any local project directives (`CLAUDE.md`, etc.).

4. **Lifecycle Parity:**
   - Preserves `include_brain` configuration across sub-agent resumption in `resume_agent`.
   - Adds strict validation rejecting non-boolean `include_brain` inputs.

## Live-Fire Verification Receipts

Tested and verified on deployed daemon:

| Probe | Configuration | Spawn Status | Observed Runtime Result |
|---|---|---|---|
| **Probe 1** | `include_brain: false` (default) | `Brain: lean (none pre-injected; use load_brain_file)` | Child `c7543d9c` acknowledged context note and lack of pre-injected brain files. |
| **Probe 2** | `include_brain: true` | `Brain: core attached (SOUL/USER/AGENTS)` | Child `b31840f2` verified pre-injected `SOUL.md`, `USER.md`, and `AGENTS.md` in system prompt and identified operator name. |

## CI Verification Receipt

- **Upstream Port Commit:** `7a31d350d4fdf3e99e7e90a68a51e955f34c2cfb`
- **CI Gate Run:** [Run 34479808755](https://github.com/leshchenko1979/opencrabs/actions/runs/34479808755) — **GREEN** (`completed success`)
- **Fork Issue Ref:** [leshchenko1979/opencrabs#145](https://github.com/leshchenko1979/opencrabs/issues/145)

