### PR TITLE
feat(brain/tools): add optional background parameter to bash tool

### DIFF
--- a/src/brain/tools/bash.rs
+++ b/src/brain/tools/bash.rs
@@ -266,6 +266,10 @@ struct BashInput {
     /// Optional timeout in seconds (overrides context default)
     #[serde(skip_serializing_if = "Option::is_none")]
     timeout_secs: Option<u64>,
+
+    /// Optional flag to run detached in background (true) or force inline (false)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    background: Option<bool>,
 }
 
 #[async_trait]
@@ -308,6 +312,10 @@ impl Tool for BashTool {
                 "timeout_secs": {
                     "type": "integer",
                     "description": "Optional: Timeout in seconds (default 120, max 600). Use higher values for builds."
+                },
+                "background": {
+                    "type": "boolean",
+                    "description": "Optional: Set to true to run the command in the background (detached), or false to force inline execution. If omitted, uses automatic heuristic detection."
                 }
             },
             "required": ["command"]
@@ -433,50 +441,101 @@ impl Tool for BashTool {
         // Anything else falls through and runs inline exactly as before.
         // #1195: pure workers (allow_nested=false) lose detachment too -
         // their long commands run inline so nothing outlives their verdict.
+        let is_sudo = input.command.trim_start().starts_with("sudo ");
         let nesting_ok = context
             .subagent_manager
             .as_ref()
             .map(|m| m.nesting_allowed_for_session(context.session_id))
             .unwrap_or(true);
-        if let Some(ref mgr) = context.background_manager
-            && !input.command.trim_start().starts_with("sudo ")
-            && nesting_ok
-        {
-            match crate::utils::long_command::classify(&input.command) {
-                Detach::Yes { marker } => {
-                    let label =
-                        crate::brain::agent::service::background_tasks::short_label(&input.command);
-                    tracing::info!(
-                        target: "background_task",
-                        "Detaching '{label}' for session {}: '{marker}' starts a command",
-                        context.session_id
-                    );
-                    mgr.clone().spawn_command(
-                        context.session_id,
-                        context.working_directory.clone(),
-                        label.clone(),
-                        input.command.clone(),
-                    );
-                    return Ok(ToolResult::success(format!(
-                        "Started in the background: {label}\n\nThis is a long-running task, so it \
-                         is running detached. I'll continue this session automatically when it \
-                         finishes — no need to poll or wait. Do other independent work meanwhile \
-                         if there is any."
-                    )));
-                }
-                // Worth a line: the command looks long to a reader, and the
-                // reason it ran inline is not visible anywhere else.
-                Detach::Mentioned { marker } => tracing::debug!(
+
+        // Check explicit background override or heuristic auto-detection
+        match input.background {
+            Some(false) => {
+                tracing::debug!(
                     target: "background_task",
-                    "Running inline: '{marker}' appears only as data (heredoc body or quoted \
-                     argument), not as a command"
-                ),
-                Detach::No => {}
+                    "Forced inline execution (background: false) for session {}",
+                    context.session_id
+                );
+            }
+            Some(true) => {
+                if is_sudo {
+                    return Ok(ToolResult::error(
+                        "Cannot run sudo commands in the background (password prompt requires inline execution)",
+                    ));
+                }
+                if !nesting_ok {
+                    return Ok(ToolResult::error(
+                        "Background execution is disabled in pure worker sessions (allow_nested=false)",
+                    ));
+                }
+                let Some(ref mgr) = context.background_manager else {
+                    return Ok(ToolResult::error(
+                        "Background execution is unavailable on this surface (no background task manager)",
+                    ));
+                };
+
+                let label =
+                    crate::brain::agent::service::background_tasks::short_label(&input.command);
+                tracing::info!(
+                    target: "background_task",
+                    "Explicitly detaching '{label}' for session {} (background: true)",
+                    context.session_id
+                );
+                mgr.clone().spawn_command(
+                    context.session_id,
+                    context.working_directory.clone(),
+                    label.clone(),
+                    input.command.clone(),
+                );
+                return Ok(ToolResult::success(format!(
+                    "Started in the background: {label}\n\nThis is a long-running task, so it \
+                     is running detached. I'll continue this session automatically when it \
+                     finishes — no need to poll or wait. Do other independent work meanwhile \
+                     if there is any."
+                )));
+            }
+            None => {
+                if let Some(ref mgr) = context.background_manager
+                    && !is_sudo
+                    && nesting_ok
+                {
+                    match crate::utils::long_command::classify(&input.command) {
+                        Detach::Yes { marker } => {
+                            let label = crate::brain::agent::service::background_tasks::short_label(
+                                &input.command,
+                            );
+                            tracing::info!(
+                                target: "background_task",
+                                "Detaching '{label}' for session {}: '{marker}' starts a command",
+                                context.session_id
+                            );
+                            mgr.clone().spawn_command(
+                                context.session_id,
+                                context.working_directory.clone(),
+                                label.clone(),
+                                input.command.clone(),
+                            );
+                            return Ok(ToolResult::success(format!(
+                                "Started in the background: {label}\n\nThis is a long-running task, so it \
+                                 is running detached. I'll continue this session automatically when it \
+                                 finishes — no need to poll or wait. Do other independent work meanwhile \
+                                 if there is any."
+                            )));
+                        }
+                        // Worth a line: the command looks long to a reader, and the
+                        // reason it ran inline is not visible anywhere else.
+                        Detach::Mentioned { marker } => tracing::debug!(
+                            target: "background_task",
+                            "Running inline: '{marker}' appears only as data (heredoc body or quoted \
+                             argument), not as a command"
+                        ),
+                        Detach::No => {}
+                    }
+                }
             }
         }
 
         // Detect sudo commands and request password via callback
-        let is_sudo = input.command.trim_start().starts_with("sudo ");
         let sudo_password = if is_sudo {
             if let Some(ref callback) = context.sudo_callback {
                 match callback(input.command.clone()).await {

--- a/src/brain/tools/bash.rs
+++ b/src/brain/tools/bash.rs
@@ -460,17 +460,20 @@ impl Tool for BashTool {
             Some(true) => {
                 if is_sudo {
                     return Ok(ToolResult::error(
-                        "Cannot run sudo commands in the background (password prompt requires inline execution)",
+                        "Cannot run sudo commands in the background (password prompt requires inline execution)"
+                            .to_string(),
                     ));
                 }
                 if !nesting_ok {
                     return Ok(ToolResult::error(
-                        "Background execution is disabled in pure worker sessions (allow_nested=false)",
+                        "Background execution is disabled in pure worker sessions (allow_nested=false)"
+                            .to_string(),
                     ));
                 }
                 let Some(ref mgr) = context.background_manager else {
                     return Ok(ToolResult::error(
-                        "Background execution is unavailable on this surface (no background task manager)",
+                        "Background execution is unavailable on this surface (no background task manager)"
+                            .to_string(),
                     ));
                 };
 

--- a/src/tests/brain_tools_bash_test.rs
+++ b/src/tests/brain_tools_bash_test.rs
@@ -123,10 +123,11 @@ async fn test_bash_background_explicit_true_fails_when_unavailable() {
 
     let result = tool.execute(input, &context).await.unwrap();
     assert!(!result.success);
+    let err = result.error.as_deref().unwrap_or(&result.output);
     assert!(
+        err.contains("Background execution is unavailable"),
+        "expected error message, got: {:?}",
         result
-            .output
-            .contains("Background execution is unavailable")
     );
 }
 
@@ -143,10 +144,11 @@ async fn test_bash_background_explicit_true_refuses_sudo() {
 
     let result = tool.execute(input, &context).await.unwrap();
     assert!(!result.success);
+    let err = result.error.as_deref().unwrap_or(&result.output);
     assert!(
+        err.contains("Cannot run sudo commands in the background"),
+        "expected error message, got: {:?}",
         result
-            .output
-            .contains("Cannot run sudo commands in the background")
     );
 }
 

--- a/src/tests/brain_tools_bash_test.rs
+++ b/src/tests/brain_tools_bash_test.rs
@@ -85,6 +85,69 @@ fn test_bash_tool_schema() {
     let capabilities = tool.capabilities();
     assert!(capabilities.contains(&ToolCapability::ExecuteShell));
     assert!(capabilities.contains(&ToolCapability::SystemModification));
+
+    let schema = tool.input_schema();
+    assert_eq!(
+        schema["properties"]["background"]["type"],
+        serde_json::json!("boolean")
+    );
+}
+
+#[tokio::test]
+async fn test_bash_background_explicit_false_runs_inline() {
+    let tool = BashTool;
+    let session_id = Uuid::new_v4();
+    let context = ToolExecutionContext::new(session_id).with_auto_approve(true);
+
+    let input = serde_json::json!({
+        "command": "echo 'forced inline'",
+        "background": false
+    });
+
+    let result = tool.execute(input, &context).await.unwrap();
+    assert!(result.success);
+    assert!(result.output.contains("forced inline"));
+}
+
+#[tokio::test]
+async fn test_bash_background_explicit_true_fails_when_unavailable() {
+    let tool = BashTool;
+    let session_id = Uuid::new_v4();
+    // context without background_manager
+    let context = ToolExecutionContext::new(session_id).with_auto_approve(true);
+
+    let input = serde_json::json!({
+        "command": "echo 'background test'",
+        "background": true
+    });
+
+    let result = tool.execute(input, &context).await.unwrap();
+    assert!(!result.success);
+    assert!(
+        result
+            .output
+            .contains("Background execution is unavailable")
+    );
+}
+
+#[tokio::test]
+async fn test_bash_background_explicit_true_refuses_sudo() {
+    let tool = BashTool;
+    let session_id = Uuid::new_v4();
+    let context = ToolExecutionContext::new(session_id).with_auto_approve(true);
+
+    let input = serde_json::json!({
+        "command": "sudo echo 'background sudo'",
+        "background": true
+    });
+
+    let result = tool.execute(input, &context).await.unwrap();
+    assert!(!result.success);
+    assert!(
+        result
+            .output
+            .contains("Cannot run sudo commands in the background")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Adds an optional `background: Option<bool>` parameter to the `bash` tool:
- `Some(true)` explicitly detaches the command to run asynchronously in the background via `background_manager` (bypassing command prefix heuristic checks). Safety guardrails enforce refusal on `sudo`, pure worker sessions (`allow_nested=false`), or environments lacking a background manager.
- `Some(false)` forces synchronous inline execution, bypassing background auto-classification even if the command matches a known long-running prefix (e.g. `cargo test`).
- `None` (default) preserves existing heuristic auto-classification via `long_command::classify()`.

Also updates `BashTool::input_schema` so LLM tool calls can discover and use `"background"`.

## Tests & Evidence
- Added unit tests in `src/tests/brain_tools_bash_test.rs`:
  - `test_bash_tool_schema_includes_background`
  - `test_bash_background_explicit_false_runs_inline`
  - `test_bash_background_explicit_true_fails_when_unavailable`
  - `test_bash_background_explicit_true_refuses_sudo`
- CI Gate: https://github.com/leshchenko1979/opencrabs/actions/runs/34517524004 (completed success)
- Live smoke tested on fork main `05b5dec3` (IDENTITY-MATCH, verified both inline and detached background runs with event resume).