### PR TITLE
feat(memory): deterministic ordering, pagination, and provenance for memory search

### DIFF
--- a/src/brain/tools/memory_search.rs
+++ b/src/brain/tools/memory_search.rs
@@ -166,8 +166,23 @@ impl Tool for MemorySearchTool {
             ))),
             Ok(results) => {
                 let mut output = String::new();
+                // scope=all merges brain/memory/external blocks in order, so
+                // the model can tell provenance: tag EVERY hit symmetrically
+                // (#89) — the formatter stays corpus-generic.
+                let tag_results = scope == "all";
                 for (i, r) in results.iter().enumerate() {
-                    output.push_str(&format!("{}. **{}**\n   {}\n\n", i + 1, r.path, r.snippet));
+                    let tag = if tag_results && !r.corpus.is_empty() {
+                        format!("[{}] ", r.corpus)
+                    } else {
+                        String::new()
+                    };
+                    output.push_str(&format!(
+                        "{}. {}**{}**\n   {}\n\n",
+                        i + 1,
+                        tag,
+                        r.path,
+                        r.snippet
+                    ));
                 }
                 Ok(ToolResult::success(output))
             }

--- a/src/brain/tools/memory_search.rs
+++ b/src/brain/tools/memory_search.rs
@@ -171,15 +171,10 @@ impl Tool for MemorySearchTool {
                 // (#89) — the formatter stays corpus-generic.
                 let tag_results = scope == "all";
                 for (i, r) in results.iter().enumerate() {
-                    let tag = if tag_results && !r.corpus.is_empty() {
-                        format!("[{}] ", r.corpus)
-                    } else {
-                        String::new()
-                    };
                     output.push_str(&format!(
                         "{}. {}**{}**\n   {}\n\n",
                         i + 1,
-                        tag,
+                        corpus_tag(r.corpus, tag_results),
                         r.path,
                         r.snippet
                     ));
@@ -188,5 +183,17 @@ impl Tool for MemorySearchTool {
             }
             Err(e) => Ok(ToolResult::error(format!("Memory search failed: {e}"))),
         }
+    }
+}
+
+/// The one-token corpus marker for a hit block (#89): `[brain] `, `[memory] `,
+/// `[external] ` — symmetric across ALL corpora when scope=all merges them.
+/// Empty when the scope names one corpus (no provenance ambiguity) or the
+/// result carries no corpus (collection-wide search()).
+pub(crate) fn corpus_tag(corpus: &str, scope_all: bool) -> String {
+    if scope_all && !corpus.is_empty() {
+        format!("[{corpus}] ")
+    } else {
+        String::new()
     }
 }

--- a/src/brain/tools/memory_search.rs
+++ b/src/brain/tools/memory_search.rs
@@ -40,7 +40,12 @@ impl Tool for MemorySearchTool {
          \
          Once a hit tells you WHICH file holds a rule, use `load_brain_file` with a \
          `query` to read the whole section — this returns snippets, which are enough \
-         to locate a rule but not always to judge it."
+         to locate a rule but not always to judge it. \
+         \
+         Structural code queries (\"who calls X\", \"impact of X\") return complete, \
+         sorted listings that support n/offset pagination and report their own \
+         truncation; ranked FTS/vector results do NOT paginate (they stay \
+         n-truncated by rank)."
     }
 
     fn input_schema(&self) -> Value {
@@ -55,6 +60,11 @@ impl Tool for MemorySearchTool {
                     "type": "integer",
                     "description": "Number of results to return (default: 5)",
                     "default": 5
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Skip this many sorted results first. Structural listings only (who calls X / callees / definitions / impact — pagination window after ORDER BY). Ranked FTS/vector results ignore it.",
+                    "default": 0
                 },
                 "scope": {
                     "type": "string",
@@ -87,6 +97,10 @@ impl Tool for MemorySearchTool {
         }
 
         let n = input.get("n").and_then(|v| v.as_u64()).unwrap_or(5) as usize;
+        // Structural-only pagination (#89): applied after ORDER BY on the
+        // graph-listing paths; ranked paths ignore it (enforced inside
+        // search_external).
+        let offset = input.get("offset").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
         // Default stays "memory" so existing callers are unaffected (#1020).
         let scope = input
             .get("scope")
@@ -124,7 +138,7 @@ impl Tool for MemorySearchTool {
                             .to_string(),
                     ));
                 }
-                crate::memory::search_external(store, &query, n).await
+                crate::memory::search_external(store, &query, n, offset).await
             }
             "all" => match crate::memory::search_brain(store, &query, n).await {
                 Ok(mut brain) => match crate::memory::search_memory(store, &query, n).await {
@@ -134,7 +148,7 @@ impl Tool for MemorySearchTool {
                         if external_blocked {
                             Ok(brain)
                         } else {
-                            match crate::memory::search_external(store, &query, n).await {
+                            match crate::memory::search_external(store, &query, n, offset).await {
                                 // External hits land last: brain > memory > external (Q10).
                                 Ok(ext) => {
                                     brain.extend(ext);
@@ -171,13 +185,20 @@ impl Tool for MemorySearchTool {
                 // (#89) — the formatter stays corpus-generic.
                 let tag_results = scope == "all";
                 for (i, r) in results.iter().enumerate() {
-                    output.push_str(&format!(
-                        "{}. {}**{}**\n   {}\n\n",
-                        i + 1,
-                        corpus_tag(r.corpus, tag_results),
-                        r.path,
-                        r.snippet
-                    ));
+                    let tag = corpus_tag(r.corpus, tag_results);
+                    // Truncation markers ride empty-path results (#89): print
+                    // them bare, without bolding a nonexistent path.
+                    if r.path.is_empty() {
+                        output.push_str(&format!("{}. {}{}\n\n", i + 1, tag, r.snippet));
+                    } else {
+                        output.push_str(&format!(
+                            "{}. {}**{}**\n   {}\n\n",
+                            i + 1,
+                            tag,
+                            r.path,
+                            r.snippet
+                        ));
+                    }
                 }
                 Ok(ToolResult::success(output))
             }

--- a/src/memory/db.rs
+++ b/src/memory/db.rs
@@ -726,6 +726,60 @@ impl Store {
             .map_err(|e| format!("query_callees_of collect: {e}"))
     }
 
+    /// Transitive callers of a symbol up to `max_depth` hops, via a recursive
+    /// walk of `call_edges` (#89). Returns (caller, file, call_line, depth)
+    /// with depth 1 = direct caller; each caller appears once at its SHALLOWEST
+    /// depth, deterministically ordered by (depth, caller, file, line).
+    ///
+    /// Cycle guard: the recursive member increments `depth` and is bounded by
+    /// `imp.depth < ?2`, so an A→B→A cycle in corrupt data terminates at the
+    /// depth cap instead of walking forever; UNION (not UNION ALL) keeps the
+    /// intermediate row set from fanning out on repeated identical edges.
+    #[cfg(feature = "code-graph")]
+    pub fn query_transitive_callers(
+        &self,
+        callee: &str,
+        max_depth: usize,
+    ) -> Result<Vec<(String, String, usize, usize)>, String> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                r"
+                SELECT caller_symbol, file_path, call_line, MIN(depth) AS depth
+                FROM (
+                    WITH RECURSIVE impact(caller_symbol, file_path, call_line, depth) AS (
+                        SELECT caller_symbol, file_path, call_line, 1
+                        FROM call_edges
+                        WHERE callee_symbol = ?1
+                        UNION
+                        SELECT ce.caller_symbol, ce.file_path, ce.call_line, imp.depth + 1
+                        FROM call_edges ce
+                        JOIN impact imp ON ce.callee_symbol = imp.caller_symbol
+                        WHERE imp.depth < ?2
+                    )
+                    SELECT caller_symbol, file_path, call_line, depth FROM impact
+                )
+                GROUP BY caller_symbol
+                ORDER BY depth, caller_symbol, file_path, call_line
+                ",
+            )
+            .map_err(|e| format!("query_transitive_callers prepare: {e}"))?;
+
+        let rows = stmt
+            .query_map(params![callee, max_depth as i64], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)? as usize,
+                    row.get::<_, i64>(3)? as usize,
+                ))
+            })
+            .map_err(|e| format!("query_transitive_callers: {e}"))?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("query_transitive_callers collect: {e}"))
+    }
+
     /// Insert (or replace) an embedding for one chunk of a content hash.
     /// `hash_seq` is `{hash}_{seq}` — the key format `vector_search.rs`
     /// reads, so it must not change.

--- a/src/memory/db.rs
+++ b/src/memory/db.rs
@@ -648,7 +648,7 @@ impl Store {
                 SELECT kind, file_path, start_line, end_line
                 FROM symbols
                 WHERE symbol_name = ?1
-                ORDER BY (file_path LIKE '%/tests/%'), kind
+                ORDER BY (file_path LIKE '%/tests/%'), kind, file_path, start_line
                 ",
             )
             .map_err(|e| format!("query_symbols_by_name prepare: {e}"))?;
@@ -678,6 +678,7 @@ impl Store {
                 SELECT caller_symbol, file_path, call_line
                 FROM call_edges
                 WHERE callee_symbol = ?1
+                ORDER BY caller_symbol, file_path, call_line
                 ",
             )
             .map_err(|e| format!("query_callers_of prepare: {e}"))?;
@@ -706,6 +707,7 @@ impl Store {
                 SELECT callee_symbol, file_path, call_line
                 FROM call_edges
                 WHERE caller_symbol = ?1
+                ORDER BY callee_symbol, file_path, call_line
                 ",
             )
             .map_err(|e| format!("query_callees_of prepare: {e}"))?;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -52,7 +52,7 @@ pub(crate) use embedding_config::{
 };
 pub use index::{BRAIN_FILES, index_file, index_file_fts_only, reindex};
 pub use search::{RrfResult, hybrid_search_rrf, search, search_brain};
-pub(crate) use search::{search_external, search_memory};
+pub(crate) use search::{resolve_path, search_external, search_memory};
 pub(crate) use settings::{
     external_allowed_in_shared, external_excludes, extra_paths_config, read_memory_config,
     sweep_interval_secs, vector_enabled,

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -51,8 +51,6 @@ pub(crate) use embedding_config::{
     embedding_api_config, embedding_api_configured, embedding_dimensions,
 };
 pub use index::{BRAIN_FILES, index_file, index_file_fts_only, reindex};
-#[cfg(feature = "code-graph")]
-pub(crate) use search::search_symbol_graph;
 pub use search::{RrfResult, hybrid_search_rrf, search, search_brain};
 pub(crate) use search::{search_external, search_memory};
 pub(crate) use settings::{

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -51,6 +51,8 @@ pub(crate) use embedding_config::{
     embedding_api_config, embedding_api_configured, embedding_dimensions,
 };
 pub use index::{BRAIN_FILES, index_file, index_file_fts_only, reindex};
+#[cfg(feature = "code-graph")]
+pub(crate) use search::search_symbol_graph;
 pub use search::{RrfResult, hybrid_search_rrf, search, search_brain};
 pub(crate) use search::{resolve_path, search_external, search_memory};
 pub(crate) use settings::{

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -54,7 +54,7 @@ pub use index::{BRAIN_FILES, index_file, index_file_fts_only, reindex};
 #[cfg(feature = "code-graph")]
 pub(crate) use search::search_symbol_graph;
 pub use search::{RrfResult, hybrid_search_rrf, search, search_brain};
-pub(crate) use search::{resolve_path, search_external, search_memory};
+pub(crate) use search::{search_external, search_memory};
 pub(crate) use settings::{
     external_allowed_in_shared, external_excludes, extra_paths_config, read_memory_config,
     sweep_interval_secs, vector_enabled,

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -116,14 +116,23 @@ pub(crate) fn search_symbol_graph(
     query_type: &str,
     symbol: &str,
     n: usize,
+    offset: usize,
 ) -> Result<Vec<MemoryResult>, String> {
     let n = n.max(MIN_STRUCTURAL_RESULTS);
     match query_type {
         "calls" => {
-            // Find who calls this symbol
+            // Who calls this symbol. Real caller sets are unbounded —
+            // measured in a live index: to_string=5404 callers — so the
+            // listing reports its own truncation, paginates via offset, and
+            // switches to a per-file rollup on mega-sets (#89).
             let callers = store.query_callers_of(symbol)?;
-            Ok(callers
+            let total = callers.len();
+            if total > MAX_CALLER_LINE_ROWS {
+                return Ok(caller_rollup(callers, symbol));
+            }
+            let mut results: Vec<MemoryResult> = callers
                 .into_iter()
+                .skip(offset)
                 .take(n)
                 .map(|(caller, file_path, line)| MemoryResult {
                     path: file_path,
@@ -131,13 +140,20 @@ pub(crate) fn search_symbol_graph(
                     rank: 1.0,
                     corpus: COLLECTION_EXTERNAL,
                 })
-                .collect())
+                .collect();
+            if offset + results.len() < total {
+                let remaining = total - offset - results.len();
+                results.push(truncation_marker("callers", symbol, remaining));
+            }
+            Ok(results)
         }
         "called_by" => {
             // Find what this symbol calls
             let callees = store.query_callees_of(symbol)?;
-            Ok(callees
+            let total = callees.len();
+            let mut results: Vec<MemoryResult> = callees
                 .into_iter()
+                .skip(offset)
                 .take(n)
                 .map(|(callee, file_path, line)| MemoryResult {
                     path: file_path,
@@ -145,14 +161,21 @@ pub(crate) fn search_symbol_graph(
                     rank: 1.0,
                     corpus: COLLECTION_EXTERNAL,
                 })
-                .collect())
+                .collect();
+            if offset + results.len() < total {
+                let remaining = total - offset - results.len();
+                results.push(truncation_marker("callees", symbol, remaining));
+            }
+            Ok(results)
         }
         "impact" => {
             // Transitive callers, indented by depth, breadth-capped (#89).
             let rows = store.query_transitive_callers(symbol, IMPACT_MAX_DEPTH)?;
-            Ok(rows
+            let total = rows.len();
+            let mut results: Vec<MemoryResult> = rows
                 .into_iter()
-                .take(MAX_IMPACT_ROWS)
+                .skip(offset)
+                .take(MAX_IMPACT_ROWS.min(n))
                 .map(|(caller, file_path, line, depth)| MemoryResult {
                     path: file_path,
                     snippet: format!(
@@ -162,13 +185,20 @@ pub(crate) fn search_symbol_graph(
                     rank: 1.0,
                     corpus: COLLECTION_EXTERNAL,
                 })
-                .collect())
+                .collect();
+            if offset + results.len() < total {
+                let remaining = total - offset - results.len();
+                results.push(truncation_marker("transitive callers", symbol, remaining));
+            }
+            Ok(results)
         }
         "implements" | "defined_in" => {
             // Find symbol definitions
             let symbols = store.query_symbols_by_name(symbol)?;
-            Ok(symbols
+            let total = symbols.len();
+            let mut results: Vec<MemoryResult> = symbols
                 .into_iter()
+                .skip(offset)
                 .take(n)
                 .map(|(kind, file_path, start_line, end_line)| MemoryResult {
                     path: file_path,
@@ -179,10 +209,72 @@ pub(crate) fn search_symbol_graph(
                     rank: 1.0,
                     corpus: COLLECTION_EXTERNAL,
                 })
-                .collect())
+                .collect();
+            if offset + results.len() < total {
+                let remaining = total - offset - results.len();
+                results.push(truncation_marker("definitions", symbol, remaining));
+            }
+            Ok(results)
         }
         _ => Ok(vec![]),
     }
+}
+
+/// Mega-set threshold for caller listings (#89): above this many callers the
+/// one-line-per-caller listing would blow the response budget (measured live:
+/// `to_string` has 5404 callers), so the listing collapses to a per-file
+/// rollup the model can target.
+#[cfg(feature = "code-graph")]
+pub(crate) const MAX_CALLER_LINE_ROWS: usize = 500;
+
+/// The trailing truncation line for a structural listing (#89): silent
+/// truncation on mega-symbols hid most of the answer; when anything is cut,
+/// the listing says how much remains and how to page to it. Rendered as a
+/// result with an empty path — the formatter prints it bare.
+#[cfg(feature = "code-graph")]
+pub(crate) fn truncation_marker(kind: &str, symbol: &str, remaining: usize) -> MemoryResult {
+    MemoryResult {
+        path: String::new(),
+        snippet: format!(
+            "… and {remaining} more {kind} of {symbol} (re-query with higher n or offset)"
+        ),
+        rank: 1.0,
+        corpus: COLLECTION_EXTERNAL,
+    }
+}
+
+/// Per-file rollup of a mega caller set (#89): one line per file with its
+/// call-site count, sorted by file, plus the total line. Keeps a 5k-caller
+/// answer at ~tens of lines and gives the model a file to target.
+#[cfg(feature = "code-graph")]
+fn caller_rollup(callers: Vec<(String, String, usize)>, symbol: &str) -> Vec<MemoryResult> {
+    use std::collections::BTreeMap;
+
+    let total = callers.len();
+    let mut by_file: BTreeMap<String, usize> = BTreeMap::new();
+    for (_, file, _) in callers {
+        *by_file.entry(file).or_default() += 1;
+    }
+    let mut results: Vec<MemoryResult> = by_file
+        .into_iter()
+        .map(|(file, count)| MemoryResult {
+            path: file,
+            snippet: format!("{count} call sites of {symbol}"),
+            rank: 1.0,
+            corpus: COLLECTION_EXTERNAL,
+        })
+        .collect();
+    // Rollup totals read differently from a paged remainder: nothing was
+    // shown per-line, so the line states the full count (HQ amendment #89).
+    results.push(MemoryResult {
+        path: String::new(),
+        snippet: format!(
+            "… {total} total callers of {symbol} (per-file rollup; target a file for detail)"
+        ),
+        rank: 1.0,
+        corpus: COLLECTION_EXTERNAL,
+    });
+    results
 }
 
 /// Hybrid search across ALL collections in the store: FTS5 (BM25) + vector
@@ -229,16 +321,18 @@ pub(crate) async fn search_external(
     store: &'static Mutex<Store>,
     query: &str,
     n: usize,
+    offset: usize,
 ) -> Result<Vec<MemoryResult>, String> {
-    // Check for structural query (code-graph feature)
+    // Check for structural query (code-graph feature). Offset applies ONLY
+    // here — ranked FTS/vector pagination is by rank, not by window (#89).
     #[cfg(feature = "code-graph")]
     if let Some((query_type, symbol)) = detect_structural_query(query) {
         let store_lock = store
             .lock()
             .map_err(|e| format!("Store lock poisoned: {e}"))?;
-        return search_symbol_graph(&store_lock, &query_type, &symbol, n);
+        return search_symbol_graph(&store_lock, &query_type, &symbol, n, offset);
     }
-
+    let _ = offset; // ranked path: offset deliberately unused
     let results = search_core(store, query, n, Some(COLLECTION_EXTERNAL)).await?;
     let paths: Vec<String> = results.iter().map(|r| r.path.clone()).collect();
     if super::freshness::refresh_stale_external(&paths).await > 0 {

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -17,6 +17,18 @@ use super::{
 #[cfg(feature = "code-graph")]
 pub(crate) const MIN_STRUCTURAL_RESULTS: usize = 25;
 
+/// Impact chains walk at most this many hops (#89): depth 1 = direct
+/// callers, depth 2 adds callers-of-callers. Deeper than that the noise
+/// outweighs the signal for a one-screen answer.
+#[cfg(feature = "code-graph")]
+pub(crate) const IMPACT_MAX_DEPTH: usize = 2;
+
+/// Impact chains cap total rows across all depths (#89): a hub symbol in a
+/// 96k-edge graph can have hundreds of transitive callers; beyond this many
+/// indented lines the model stops reading them anyway.
+#[cfg(feature = "code-graph")]
+pub(crate) const MAX_IMPACT_ROWS: usize = 50;
+
 /// Detect if a query is asking for structural code relationships.
 ///
 /// Returns `Some((query_type, symbol))` where query_type is one of:
@@ -29,6 +41,28 @@ pub(crate) const MIN_STRUCTURAL_RESULTS: usize = 25;
 #[cfg(feature = "code-graph")]
 pub(crate) fn detect_structural_query(query: &str) -> Option<(String, String)> {
     let query_lower = query.to_lowercase();
+
+    // "who calls X transitively" / "transitive callers of X" → impact chain (#89).
+    // MUST precede the plain "who calls X" pattern, which would otherwise
+    // swallow the same query and answer depth-0 only.
+    if let Some(caps) = regex::Regex::new(
+        r"(?i)(?:who\s+calls|transitive\s+callers\s+of)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+transitively",
+    )
+    .ok()
+    .and_then(|re| re.captures(&query_lower))
+    {
+        return Some(("impact".to_string(), caps[1].to_string()));
+    }
+
+    // "impact of X" / "what breaks if I change X" → impact chain (#89)
+    if let Some(caps) = regex::Regex::new(
+        r"(?i)(?:impact\s+(?:of|for)|what\s+breaks\s+if\s+(?:i|we)\s+(?:change|touch|modify))\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+    )
+    .ok()
+    .and_then(|re| re.captures(&query_lower))
+    {
+        return Some(("impact".to_string(), caps[1].to_string()));
+    }
 
     // "who calls X" / "what calls X" → find callers of X
     if let Some(caps) = regex::Regex::new(r"(?i)(who|what)\s+calls\s+([a-zA-Z_][a-zA-Z0-9_]*)")
@@ -77,7 +111,7 @@ pub(crate) fn detect_structural_query(query: &str) -> Option<(String, String)> {
 /// [`MIN_STRUCTURAL_RESULTS`] here — and ONLY here. Ranked FTS/vector paths
 /// keep the caller's requested `n` by design (Issue-Ref: leshchenko1979/opencrabs#89).
 #[cfg(feature = "code-graph")]
-fn search_symbol_graph(
+pub(crate) fn search_symbol_graph(
     store: &Store,
     query_type: &str,
     symbol: &str,
@@ -108,6 +142,23 @@ fn search_symbol_graph(
                 .map(|(callee, file_path, line)| MemoryResult {
                     path: file_path,
                     snippet: format!("{} calls {} at line {}", symbol, callee, line),
+                    rank: 1.0,
+                    corpus: COLLECTION_EXTERNAL,
+                })
+                .collect())
+        }
+        "impact" => {
+            // Transitive callers, indented by depth, breadth-capped (#89).
+            let rows = store.query_transitive_callers(symbol, IMPACT_MAX_DEPTH)?;
+            Ok(rows
+                .into_iter()
+                .take(MAX_IMPACT_ROWS)
+                .map(|(caller, file_path, line, depth)| MemoryResult {
+                    path: file_path,
+                    snippet: format!(
+                        "{indent}{caller} calls {symbol} at line {line} (depth {depth})",
+                        indent = "  ".repeat(depth.saturating_sub(1))
+                    ),
                     rank: 1.0,
                     corpus: COLLECTION_EXTERNAL,
                 })

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -10,6 +10,13 @@ use super::{
     embedding_api_configured,
 };
 
+/// Minimum effective cap for structural graph listings (#89): callers/callees/
+/// definitions are rank-1 one-liners where the full set is the answer, so a
+/// search-default n=5 would truncate arbitrarily. Applies to structural
+/// listings only — never to ranked FTS/vector search paths.
+#[cfg(feature = "code-graph")]
+pub(crate) const MIN_STRUCTURAL_RESULTS: usize = 25;
+
 /// Detect if a query is asking for structural code relationships.
 ///
 /// Returns `Some((query_type, symbol))` where query_type is one of:
@@ -63,6 +70,12 @@ pub(crate) fn detect_structural_query(query: &str) -> Option<(String, String)> {
 }
 
 /// Execute a structural query against the symbol graph.
+///
+/// Structural listings ("who calls X") are RANK-1 result sets, not a ranked
+/// search: every hit matters, so the search-default n=5 cap would truncate
+/// the answer arbitrarily. The effective cap is floored at
+/// [`MIN_STRUCTURAL_RESULTS`] here — and ONLY here. Ranked FTS/vector paths
+/// keep the caller's requested `n` by design (Issue-Ref: leshchenko1979/opencrabs#89).
 #[cfg(feature = "code-graph")]
 fn search_symbol_graph(
     store: &Store,
@@ -70,6 +83,7 @@ fn search_symbol_graph(
     symbol: &str,
     n: usize,
 ) -> Result<Vec<MemoryResult>, String> {
+    let n = n.max(MIN_STRUCTURAL_RESULTS);
     match query_type {
         "calls" => {
             // Find who calls this symbol

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 use super::embedding::{embed_query_api, engine_if_ready};
 use super::{
     COLLECTION_BRAIN, COLLECTION_EXTERNAL, COLLECTION_MEMORY, MemoryResult,
-    embedding_api_configured,
+    embedding_api_configured, extra_paths_config,
 };
 
 /// Minimum effective cap for structural graph listings (#89): callers/callees/
@@ -418,12 +418,26 @@ fn results_to_tuples_for(
 }
 
 /// Resolve filesystem path for a search result based on its collection.
-fn resolve_path(home: &Path, collection: &str, doc_path: &str) -> String {
+pub(crate) fn resolve_path(home: &Path, collection: &str, doc_path: &str) -> String {
     if collection == COLLECTION_EXTERNAL {
         // External documents are keyed by ABSOLUTE path (#1051): the stored
         // path IS the filesystem path. Rebuilding it as home/memory/<key>
         // would point every external hit at a nonexistent file, so pass it
         // through unchanged (mine map #3).
+        //
+        // (#89) When the absolute path sits under a configured [memory]
+        // extra_paths root, emit it relative to that root instead — the
+        // shared prefix is the same on every hit and drowns the informative
+        // part. Paths outside every configured root pass through unchanged.
+        for ep in extra_paths_config() {
+            let root = ep.path().trim_end_matches('/');
+            if let Some(rest) = doc_path
+                .strip_prefix(root)
+                .filter(|rest| rest.starts_with('/'))
+            {
+                return rest[1..].to_string();
+            }
+        }
         return doc_path.to_string();
     }
     let p = if collection == COLLECTION_BRAIN {

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -95,6 +95,7 @@ fn search_symbol_graph(
                     path: file_path,
                     snippet: format!("{} calls {} at line {}", caller, symbol, line),
                     rank: 1.0,
+                    corpus: COLLECTION_EXTERNAL,
                 })
                 .collect())
         }
@@ -108,6 +109,7 @@ fn search_symbol_graph(
                     path: file_path,
                     snippet: format!("{} calls {} at line {}", symbol, callee, line),
                     rank: 1.0,
+                    corpus: COLLECTION_EXTERNAL,
                 })
                 .collect())
         }
@@ -124,6 +126,7 @@ fn search_symbol_graph(
                         kind, symbol, start_line, end_line
                     ),
                     rank: 1.0,
+                    corpus: COLLECTION_EXTERNAL,
                 })
                 .collect())
         }
@@ -265,6 +268,7 @@ async fn search_core(
                         path: r.file,
                         snippet: extract_snippet(&r.body, &fts_query, 200),
                         rank: r.score,
+                        corpus: collection.unwrap_or(""),
                     })
                     .collect());
             }
@@ -285,6 +289,7 @@ async fn search_core(
                     path: resolve_path(&home, &r.doc.collection_name, &r.doc.path),
                     snippet,
                     rank: r.score,
+                    corpus: collection.unwrap_or(""),
                 }
             })
             .collect())
@@ -339,6 +344,7 @@ pub async fn search_brain(
                     path: resolve_path(&home, &r.doc.collection_name, &r.doc.path),
                     snippet,
                     rank: r.score,
+                    corpus: COLLECTION_BRAIN,
                 }
             })
             .collect())

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -6,6 +6,10 @@ pub struct MemoryResult {
     pub path: String,
     pub snippet: String,
     pub rank: f64,
+    /// Source corpus (COLLECTION_*), shown as a `[tag]` when scope=all merges
+    /// corpora (#89). Empty when the source collection is unknown (the
+    /// collection-wide `search()` used by a2a debate context).
+    pub corpus: &'static str,
 }
 
 /// Collection name for daily compaction logs.

--- a/src/tests/brain_hints_test.rs
+++ b/src/tests/brain_hints_test.rs
@@ -11,6 +11,7 @@ fn result(path: &str, snippet: &str, rank: f64) -> MemoryResult {
         path: path.to_string(),
         snippet: snippet.to_string(),
         rank,
+        corpus: "",
     }
 }
 

--- a/src/tests/memory_search_parity_test.rs
+++ b/src/tests/memory_search_parity_test.rs
@@ -1,0 +1,162 @@
+//! memory_search external-tier parity pins (#89).
+//!
+//! Structural graph listings used to truncate at the schema-default n=5 in
+//! arbitrary (unsorted) order, scope=all merged corpora unlabeled, and
+//! external hits echoed absolute paths. These tests pin the fixes:
+//! deterministic ordering in the query layer, the structural-only n floor,
+//! and the symmetric corpus-tag contract.
+//!
+//! Graph-tier throughout — the whole file is gated on `code-graph` like the
+//! query layer it exercises.
+
+#![cfg(feature = "code-graph")]
+
+use crate::memory::COLLECTION_EXTERNAL;
+use crate::memory::db::Store;
+use crate::memory::search::{MIN_STRUCTURAL_RESULTS, search_symbol_graph};
+use tempfile::TempDir;
+
+/// 8 distinct callers of one symbol, inserted in scrambled order.
+fn store_with_n_callers(n: usize) -> (TempDir, Store) {
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("parity.db");
+    let store = Store::open(&db_path).unwrap();
+    store.ensure_symbol_tables().unwrap();
+    // Scrambled: names reverse-ordered, lines shuffled, two files.
+    for i in 0..n {
+        let caller = format!("caller_{:02}", n - i);
+        let file = if i % 2 == 0 { "b.rs" } else { "a.rs" };
+        store
+            .insert_call_edge(&caller, "target", file, (n - i) as i64)
+            .unwrap();
+    }
+    (temp, store)
+}
+
+/// Structural listings must NOT truncate at the schema-default n=5 (#89):
+/// every hit is a rank-1.0 one-liner, so the full set IS the answer. The
+/// effective cap floors at MIN_STRUCTURAL_RESULTS (25).
+#[test]
+fn structural_listing_returns_full_set_above_search_default() {
+    let (_temp, store) = store_with_n_callers(8);
+    let results = search_symbol_graph(&store, "calls", "target", 5).unwrap();
+    assert_eq!(
+        results.len(),
+        8,
+        "n=5 must not truncate a structural listing; floor is {MIN} (got {})",
+        results.len(),
+        MIN = MIN_STRUCTURAL_RESULTS
+    );
+}
+
+/// The floor is a floor, not a hard cap: results beyond 25 still return when
+/// the caller asks for more.
+#[test]
+fn structural_floor_does_not_cap_higher_requests() {
+    let (_temp, store) = store_with_n_callers(8);
+    let results = search_symbol_graph(&store, "calls", "target", 50).unwrap();
+    assert_eq!(results.len(), 8, "a request above the floor must not clamp");
+}
+
+/// Caller listings come back deterministically ordered by
+/// (caller_symbol, file_path, call_line) — db-layer ORDER BY (#89).
+#[test]
+fn caller_listings_are_deterministically_ordered() {
+    let (_temp, store) = store_with_n_callers(6);
+    let callers = store.query_callers_of("target").unwrap();
+
+    let mut expected: Vec<(String, String, usize)> = callers.clone();
+    expected.sort();
+    assert_eq!(
+        callers, expected,
+        "query_callers_of must return rows sorted by (caller, file, line)"
+    );
+
+    // And the order is stable across repeated queries.
+    let again = store.query_callers_of("target").unwrap();
+    assert_eq!(callers, again, "repeated queries must not reshuffle");
+}
+
+/// Callee listings get the same deterministic treatment.
+#[test]
+fn callee_listings_are_deterministically_ordered() {
+    let temp = TempDir::new().unwrap();
+    let store = Store::open(temp.path().join("callees.db")).unwrap();
+    store.ensure_symbol_tables().unwrap();
+    for (callee, file, line) in [
+        ("zeta", "a.rs", 3),
+        ("alpha", "b.rs", 1),
+        ("alpha", "a.rs", 9),
+        ("alpha", "a.rs", 2),
+    ] {
+        store
+            .insert_call_edge("caller_fn", callee, file, line)
+            .unwrap();
+    }
+    let callees = store.query_callees_of("caller_fn").unwrap();
+    let got: Vec<(String, String, usize)> = callees;
+    assert_eq!(
+        got,
+        vec![
+            ("alpha".into(), "a.rs".into(), 2),
+            ("alpha".into(), "a.rs".into(), 9),
+            ("alpha".into(), "b.rs".into(), 1),
+            ("zeta".into(), "a.rs".into(), 3),
+        ]
+    );
+}
+
+/// Symbol definitions keep tests-last ordering and are now fully
+/// deterministic (file_path, start_line tiebreakers) (#89).
+#[test]
+fn symbol_definitions_are_deterministically_ordered() {
+    let temp = TempDir::new().unwrap();
+    let store = Store::open(temp.path().join("symbols.db")).unwrap();
+    store.ensure_symbol_tables().unwrap();
+    for (file, line) in [
+        ("src/lib.rs", 20),
+        ("src/lib.rs", 5),
+        ("tests/it.rs", 1),
+        ("src/main.rs", 2),
+    ] {
+        store
+            .insert_symbol("Widget", "struct", file, line, line + 1)
+            .unwrap();
+    }
+    let defs = store.query_symbols_by_name("Widget").unwrap();
+    let files: Vec<&str> = defs.iter().map(|(_, f, _, _)| f.as_str()).collect();
+    assert_eq!(
+        files,
+        vec!["src/lib.rs", "src/main.rs", "src/lib.rs", "tests/it.rs"],
+        "expected non-test files first sorted by path/line, tests last — got {files:?}"
+    );
+}
+
+/// Structural results carry the external corpus so scope=all can tag them (#89).
+#[test]
+fn structural_results_stamp_external_corpus() {
+    let (_temp, store) = store_with_n_callers(2);
+    let results = search_symbol_graph(&store, "calls", "target", 5).unwrap();
+    assert!(!results.is_empty());
+    assert!(
+        results.iter().all(|r| r.corpus == COLLECTION_EXTERNAL),
+        "structural hits belong to the external corpus"
+    );
+}
+
+/// The tag law is corpus-symmetric (#89): in scope=all, brain and memory hits
+/// get tagged exactly like external ones. A named scope stays untagged, and
+/// a result with no corpus (collection-wide search()) stays untagged too.
+#[test]
+fn corpus_tags_are_symmetric_across_corpora() {
+    let tag = crate::brain::tools::memory_search::corpus_tag;
+    assert_eq!(tag("brain", true), "[brain] ");
+    assert_eq!(tag("memory", true), "[memory] ");
+    assert_eq!(tag("external", true), "[external] ");
+    // Named scope: no provenance ambiguity, no tag.
+    assert_eq!(tag("brain", false), "");
+    assert_eq!(tag("external", false), "");
+    // Collection-wide search() stamps an empty corpus.
+    assert_eq!(tag("", true), "");
+    assert_eq!(tag("", false), "");
+}

--- a/src/tests/memory_search_parity_test.rs
+++ b/src/tests/memory_search_parity_test.rs
@@ -11,7 +11,6 @@
 
 #![cfg(feature = "code-graph")]
 
-use crate::brain::tools::memory_search::MemorySearchTool;
 use crate::brain::tools::r#trait::Tool;
 use crate::memory::COLLECTION_EXTERNAL;
 use crate::memory::db::Store;
@@ -342,7 +341,7 @@ fn mega_caller_sets_roll_up_per_file() {
 /// their signature (search_core) has no offset parameter to pass.
 #[test]
 fn offset_is_documented_as_structural_only() {
-    let schema = crate::brain::tools::memory_search::MemorySearchTool.input_schema();
+    let schema = MemorySearchTool.input_schema();
     let offset = &schema["properties"]["offset"];
     assert_eq!(offset["default"], 0, "offset defaults to 0");
     let desc = offset["description"].as_str().unwrap().to_lowercase();

--- a/src/tests/memory_search_parity_test.rs
+++ b/src/tests/memory_search_parity_test.rs
@@ -11,6 +11,8 @@
 
 #![cfg(feature = "code-graph")]
 
+use crate::brain::tools::memory_search::MemorySearchTool;
+use crate::brain::tools::r#trait::Tool;
 use crate::memory::COLLECTION_EXTERNAL;
 use crate::memory::db::Store;
 use crate::memory::search::{MIN_STRUCTURAL_RESULTS, detect_structural_query, search_symbol_graph};

--- a/src/tests/memory_search_parity_test.rs
+++ b/src/tests/memory_search_parity_test.rs
@@ -129,7 +129,7 @@ fn symbol_definitions_are_deterministically_ordered() {
     let files: Vec<&str> = defs.iter().map(|(_, f, _, _)| f.as_str()).collect();
     assert_eq!(
         files,
-        vec!["src/lib.rs", "src/main.rs", "src/lib.rs", "tests/it.rs"],
+        vec!["src/lib.rs", "src/lib.rs", "src/main.rs", "tests/it.rs"],
         "expected non-test files first sorted by path/line, tests last — got {files:?}"
     );
 }

--- a/src/tests/memory_search_parity_test.rs
+++ b/src/tests/memory_search_parity_test.rs
@@ -11,6 +11,7 @@
 
 #![cfg(feature = "code-graph")]
 
+use crate::brain::tools::memory_search::MemorySearchTool;
 use crate::brain::tools::r#trait::Tool;
 use crate::memory::COLLECTION_EXTERNAL;
 use crate::memory::db::Store;

--- a/src/tests/memory_search_parity_test.rs
+++ b/src/tests/memory_search_parity_test.rs
@@ -13,7 +13,7 @@
 
 use crate::memory::COLLECTION_EXTERNAL;
 use crate::memory::db::Store;
-use crate::memory::search::{MIN_STRUCTURAL_RESULTS, search_symbol_graph};
+use crate::memory::search::{MIN_STRUCTURAL_RESULTS, detect_structural_query, search_symbol_graph};
 use tempfile::TempDir;
 
 /// 8 distinct callers of one symbol, inserted in scrambled order.
@@ -159,4 +159,98 @@ fn corpus_tags_are_symmetric_across_corpora() {
     // Collection-wide search() stamps an empty corpus.
     assert_eq!(tag("", true), "");
     assert_eq!(tag("", false), "");
+}
+
+/// "impact of X" routes to the impact chain; plain "who calls X" must NOT.
+#[test]
+fn impact_queries_route_to_the_impact_chain() {
+    assert_eq!(
+        detect_structural_query("impact of validate_input"),
+        Some(("impact".into(), "validate_input".into()))
+    );
+    assert_eq!(
+        detect_structural_query("what breaks if I change process_message"),
+        Some(("impact".into(), "process_message".into()))
+    );
+    assert_eq!(
+        detect_structural_query("who calls validate_input transitively"),
+        Some(("impact".into(), "validate_input".into()))
+    );
+    // Plain depth-0 queries stay where they were.
+    assert_eq!(
+        detect_structural_query("who calls validate_input"),
+        Some(("calls".into(), "validate_input".into()))
+    );
+}
+
+/// Chain A→B→C: impact of C reaches A at depth 2, each caller reported once
+/// at its shallowest depth, output ordered by (depth, caller).
+#[test]
+fn impact_chain_walks_two_hops() {
+    let temp = TempDir::new().unwrap();
+    let store = Store::open(temp.path().join("impact.db")).unwrap();
+    store.ensure_symbol_tables().unwrap();
+    // a.rs line numbers scrambled to prove ordering, not insertion order.
+    store.insert_call_edge("mid", "leaf", "a.rs", 42).unwrap();
+    store.insert_call_edge("top", "mid", "a.rs", 7).unwrap();
+    store.insert_call_edge("mid2", "leaf", "b.rs", 2).unwrap();
+
+    let rows = store.query_transitive_callers("leaf", 2).unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            ("mid".into(), "a.rs".into(), 42, 1),
+            ("mid2".into(), "b.rs".into(), 2, 1),
+            ("top".into(), "a.rs".into(), 7, 2),
+        ],
+        "depth-1 callers first, then depth-2, each ordered by (file, line)"
+    );
+
+    // Depth 1 answers direct callers only.
+    let direct = store.query_transitive_callers("leaf", 1).unwrap();
+    assert_eq!(direct.len(), 2, "depth cap must exclude depth-2 callers");
+}
+
+/// CYCLE GUARD: corrupt data with A→B→A must terminate at the depth cap,
+/// not walk forever or fan out — the query returns bounded, deduplicated
+/// rows (the guard exists precisely for this case) (#89).
+#[test]
+fn impact_chain_survives_a_call_cycle() {
+    let temp = TempDir::new().unwrap();
+    let store = Store::open(temp.path().join("cycle.db")).unwrap();
+    store.ensure_symbol_tables().unwrap();
+    store.insert_call_edge("b_fn", "a_fn", "a.rs", 1).unwrap();
+    store.insert_call_edge("a_fn", "b_fn", "a.rs", 2).unwrap();
+
+    let rows = store.query_transitive_callers("a_fn", 2).unwrap();
+    // b_fn (depth 1) then a_fn itself (depth 2, via the cycle). Bounded rows,
+    // no duplication blowup, no hang.
+    assert!(
+        rows.len() <= 2,
+        "cycle must not fan out beyond one row per symbol per depth: {rows:?}"
+    );
+    assert!(
+        rows.iter().any(|(c, _, _, d)| c == "b_fn" && *d == 1),
+        "direct caller b_fn must be present"
+    );
+}
+
+/// The rendered impact chain indents by depth.
+#[test]
+fn impact_snippets_indent_by_depth() {
+    let temp = TempDir::new().unwrap();
+    let store = Store::open(temp.path().join("indent.db")).unwrap();
+    store.ensure_symbol_tables().unwrap();
+    store.insert_call_edge("mid", "leaf", "a.rs", 42).unwrap();
+    store.insert_call_edge("top", "mid", "a.rs", 7).unwrap();
+
+    let results = search_symbol_graph(&store, "impact", "leaf", 5).unwrap();
+    let snippets: Vec<&str> = results.iter().map(|r| r.snippet.as_str()).collect();
+    assert_eq!(
+        snippets,
+        vec![
+            "mid calls leaf at line 42 (depth 1)",
+            "  top calls leaf at line 7 (depth 2)",
+        ]
+    );
 }

--- a/src/tests/memory_search_parity_test.rs
+++ b/src/tests/memory_search_parity_test.rs
@@ -27,7 +27,7 @@ fn store_with_n_callers(n: usize) -> (TempDir, Store) {
         let caller = format!("caller_{:02}", n - i);
         let file = if i % 2 == 0 { "b.rs" } else { "a.rs" };
         store
-            .insert_call_edge(&caller, "target", file, (n - i) as i64)
+            .insert_call_edge(&caller, "target", file, n - i)
             .unwrap();
     }
     (temp, store)
@@ -39,7 +39,7 @@ fn store_with_n_callers(n: usize) -> (TempDir, Store) {
 #[test]
 fn structural_listing_returns_full_set_above_search_default() {
     let (_temp, store) = store_with_n_callers(8);
-    let results = search_symbol_graph(&store, "calls", "target", 5).unwrap();
+    let results = search_symbol_graph(&store, "calls", "target", 5, 0).unwrap();
     assert_eq!(
         results.len(),
         8,
@@ -54,7 +54,7 @@ fn structural_listing_returns_full_set_above_search_default() {
 #[test]
 fn structural_floor_does_not_cap_higher_requests() {
     let (_temp, store) = store_with_n_callers(8);
-    let results = search_symbol_graph(&store, "calls", "target", 50).unwrap();
+    let results = search_symbol_graph(&store, "calls", "target", 50, 0).unwrap();
     assert_eq!(results.len(), 8, "a request above the floor must not clamp");
 }
 
@@ -81,7 +81,7 @@ fn caller_listings_are_deterministically_ordered() {
 #[test]
 fn callee_listings_are_deterministically_ordered() {
     let temp = TempDir::new().unwrap();
-    let store = Store::open(temp.path().join("callees.db")).unwrap();
+    let store = Store::open(&temp.path().join("callees.db")).unwrap();
     store.ensure_symbol_tables().unwrap();
     for (callee, file, line) in [
         ("zeta", "a.rs", 3),
@@ -111,7 +111,7 @@ fn callee_listings_are_deterministically_ordered() {
 #[test]
 fn symbol_definitions_are_deterministically_ordered() {
     let temp = TempDir::new().unwrap();
-    let store = Store::open(temp.path().join("symbols.db")).unwrap();
+    let store = Store::open(&temp.path().join("symbols.db")).unwrap();
     store.ensure_symbol_tables().unwrap();
     for (file, line) in [
         ("src/lib.rs", 20),
@@ -136,7 +136,7 @@ fn symbol_definitions_are_deterministically_ordered() {
 #[test]
 fn structural_results_stamp_external_corpus() {
     let (_temp, store) = store_with_n_callers(2);
-    let results = search_symbol_graph(&store, "calls", "target", 5).unwrap();
+    let results = search_symbol_graph(&store, "calls", "target", 5, 0).unwrap();
     assert!(!results.is_empty());
     assert!(
         results.iter().all(|r| r.corpus == COLLECTION_EXTERNAL),
@@ -188,7 +188,7 @@ fn impact_queries_route_to_the_impact_chain() {
 #[test]
 fn impact_chain_walks_two_hops() {
     let temp = TempDir::new().unwrap();
-    let store = Store::open(temp.path().join("impact.db")).unwrap();
+    let store = Store::open(&temp.path().join("impact.db")).unwrap();
     store.ensure_symbol_tables().unwrap();
     // a.rs line numbers scrambled to prove ordering, not insertion order.
     store.insert_call_edge("mid", "leaf", "a.rs", 42).unwrap();
@@ -217,7 +217,7 @@ fn impact_chain_walks_two_hops() {
 #[test]
 fn impact_chain_survives_a_call_cycle() {
     let temp = TempDir::new().unwrap();
-    let store = Store::open(temp.path().join("cycle.db")).unwrap();
+    let store = Store::open(&temp.path().join("cycle.db")).unwrap();
     store.ensure_symbol_tables().unwrap();
     store.insert_call_edge("b_fn", "a_fn", "a.rs", 1).unwrap();
     store.insert_call_edge("a_fn", "b_fn", "a.rs", 2).unwrap();
@@ -239,12 +239,12 @@ fn impact_chain_survives_a_call_cycle() {
 #[test]
 fn impact_snippets_indent_by_depth() {
     let temp = TempDir::new().unwrap();
-    let store = Store::open(temp.path().join("indent.db")).unwrap();
+    let store = Store::open(&temp.path().join("indent.db")).unwrap();
     store.ensure_symbol_tables().unwrap();
     store.insert_call_edge("mid", "leaf", "a.rs", 42).unwrap();
     store.insert_call_edge("top", "mid", "a.rs", 7).unwrap();
 
-    let results = search_symbol_graph(&store, "impact", "leaf", 5).unwrap();
+    let results = search_symbol_graph(&store, "impact", "leaf", 5, 0).unwrap();
     let snippets: Vec<&str> = results.iter().map(|r| r.snippet.as_str()).collect();
     assert_eq!(
         snippets,
@@ -252,5 +252,104 @@ fn impact_snippets_indent_by_depth() {
             "mid calls leaf at line 42 (depth 1)",
             "  top calls leaf at line 7 (depth 2)",
         ]
+    );
+}
+
+/// TRUNCATION VISIBILITY (#89): a 30-caller symbol listed with the floor n=25
+/// must end with a marker counting the 5 hidden callers — never a silent cut.
+#[test]
+fn truncated_listing_reports_the_hidden_remainder() {
+    let (_temp, store) = store_with_n_callers(30);
+    let results = search_symbol_graph(&store, "calls", "target", 5, 0).unwrap();
+    // 25 shown (floor) + 1 marker line.
+    assert_eq!(results.len(), 26);
+    let last = results.last().unwrap();
+    assert!(
+        last.path.is_empty(),
+        "the marker rides an empty-path result"
+    );
+    assert_eq!(
+        last.snippet,
+        "… and 5 more callers of target (re-query with higher n or offset)"
+    );
+    // No marker when nothing was cut.
+    let (_temp2, store2) = store_with_n_callers(8);
+    let full = search_symbol_graph(&store2, "calls", "target", 5, 0).unwrap();
+    assert_eq!(full.len(), 8, "a fully-shown listing gets no marker");
+}
+
+/// OFFSET PAGINATION (#89): offset=25 with n=25 returns the NEXT sorted page
+/// — no overlap with page 1, in the same deterministic order.
+#[test]
+fn offset_returns_the_next_sorted_page_without_overlap() {
+    let (_temp, store) = store_with_n_callers(30);
+    let page1 = search_symbol_graph(&store, "calls", "target", 5, 0).unwrap();
+    let page2 = search_symbol_graph(&store, "calls", "target", 5, 25).unwrap();
+
+    // Page 1 = 25 hits + marker; page 2 = the remaining 5, no marker.
+    assert_eq!(page1.len(), 26);
+    assert_eq!(page2.len(), 5);
+    assert!(
+        page2.iter().all(|r| !r.path.is_empty()),
+        "exhausted listing must not carry a marker"
+    );
+
+    let names1: Vec<String> = page1
+        .iter()
+        .filter(|r| !r.path.is_empty())
+        .map(|r| r.snippet.split_whitespace().next().unwrap().to_string())
+        .collect();
+    let names2: Vec<String> = page2
+        .iter()
+        .map(|r| r.snippet.split_whitespace().next().unwrap().to_string())
+        .collect();
+    assert!(
+        names1.iter().all(|n| !names2.contains(n)),
+        "pages must not overlap: {names2:?} vs page 1"
+    );
+
+    // Page 2 continues the sorted order: its 5 callers are the tail of the
+    // full sorted set.
+    let all = store.query_callers_of("target").unwrap();
+    let tail: Vec<String> = all[25..].iter().map(|(c, _, _)| c.clone()).collect();
+    assert_eq!(names2, tail);
+}
+
+/// MEGA-SET ROLLUP (#89): above 500 callers the listing collapses to one line
+/// per file with its call-site count, plus the total line.
+#[test]
+fn mega_caller_sets_roll_up_per_file() {
+    let (_temp, store) = store_with_n_callers(501);
+    let results = search_symbol_graph(&store, "calls", "target", 5, 0).unwrap();
+
+    // Two fixture files (a.rs / b.rs) + the total line — tens of lines, not 501.
+    assert_eq!(results.len(), 3);
+    // Rollups sorted by file: a.rs first, then b.rs, then the marker.
+    assert_eq!(results[0].path, "a.rs");
+    assert_eq!(results[0].snippet, "250 call sites of target");
+    assert_eq!(results[1].path, "b.rs");
+    assert_eq!(results[1].snippet, "251 call sites of target");
+    assert_eq!(
+        results[2].snippet,
+        "… 501 total callers of target (per-file rollup; target a file for detail)"
+    );
+}
+
+/// The offset contract is declared structural-only: the schema documents
+/// offset for structural listings, and ranked paths take no offset at all —
+/// their signature (search_core) has no offset parameter to pass.
+#[test]
+fn offset_is_documented_as_structural_only() {
+    let schema = crate::brain::tools::memory_search::MemorySearchTool.input_schema();
+    let offset = &schema["properties"]["offset"];
+    assert_eq!(offset["default"], 0, "offset defaults to 0");
+    let desc = offset["description"].as_str().unwrap().to_lowercase();
+    assert!(
+        desc.contains("structural"),
+        "offset description must scope it to structural listings: {desc}"
+    );
+    assert!(
+        desc.contains("ignore") || desc.contains("not"),
+        "offset description must say ranked paths ignore it: {desc}"
     );
 }

--- a/src/tests/memory_search_resolve_path_test.rs
+++ b/src/tests/memory_search_resolve_path_test.rs
@@ -1,0 +1,100 @@
+//! External-scope hits render repo-relative paths (#89).
+//!
+//! External documents are keyed by absolute path (#1051), so every hit used
+//! to echo its full configured root back — the same 16+ char prefix on every
+//! line, drowning the informative part. When the path sits under a
+//! `[memory]` `extra_paths` root, `resolve_path` now emits it relative to
+//! that root; paths outside every configured root pass through unchanged.
+
+use crate::config::profile::with_home_override;
+use crate::memory::{COLLECTION_EXTERNAL, resolve_path};
+use std::path::Path;
+
+const CONFIG_WITH_EXTRA_PATHS: &str = r#"
+[memory]
+extra_paths = ["/home/u/notes"]
+"#;
+
+/// Path under a configured extra_path root → relative to that root.
+#[test]
+fn external_path_under_root_strips_prefix() {
+    let (_temp, home) = temp_home_with(CONFIG_WITH_EXTRA_PATHS);
+    with_home_override(home, || {
+        let got = resolve_path(
+            Path::new("/unused"),
+            COLLECTION_EXTERNAL,
+            "/home/u/notes/rust/opencrabs/src/memory/search.rs",
+        );
+        assert_eq!(got, "rust/opencrabs/src/memory/search.rs");
+    });
+}
+
+/// Root with a trailing slash still strips (prefix boundary is normalized).
+#[test]
+fn external_path_strips_trailing_slash_root() {
+    let (_temp, home) = temp_home_with(
+        r#"[memory]
+extra_paths = ["/home/u/notes/"]
+"#,
+    );
+    with_home_override(home, || {
+        let got = resolve_path(
+            Path::new("/unused"),
+            COLLECTION_EXTERNAL,
+            "/home/u/notes/a.md",
+        );
+        assert_eq!(got, "a.md");
+    });
+}
+
+/// A sibling directory sharing the root's prefix must NOT be stripped —
+/// `/home/u/notes` must not turn `/home/u/notes2/x.md` into `2/x.md`.
+#[test]
+fn external_path_prefix_boundary_is_respected() {
+    let (_temp, home) = temp_home_with(CONFIG_WITH_EXTRA_PATHS);
+    with_home_override(home, || {
+        let got = resolve_path(
+            Path::new("/unused"),
+            COLLECTION_EXTERNAL,
+            "/home/u/notes2/x.md",
+        );
+        assert_eq!(got, "/home/u/notes2/x.md");
+    });
+}
+
+/// Path outside every configured root passes through unchanged (#1051).
+#[test]
+fn external_path_outside_roots_passes_through() {
+    let (_temp, home) = temp_home_with(CONFIG_WITH_EXTRA_PATHS);
+    with_home_override(home, || {
+        let got = resolve_path(
+            Path::new("/unused"),
+            COLLECTION_EXTERNAL,
+            "/var/data/other.md",
+        );
+        assert_eq!(got, "/var/data/other.md");
+    });
+}
+
+/// Brain/memory paths are home-anchored as before — the strip is
+/// external-only (#1051 behavior preserved).
+#[test]
+fn brain_path_still_home_anchored() {
+    let (_temp, home) = temp_home_with(CONFIG_WITH_EXTRA_PATHS);
+    with_home_override(home, || {
+        let home_path = home.clone();
+        let got = resolve_path(&home_path, "brain", "SOUL.md");
+        assert_eq!(got, home_path.join("SOUL.md").to_string_lossy());
+    });
+}
+
+/// A tempdir laid out as an `.opencrabs` home, plus the config it starts with
+/// (same fixture shape as config_last_good_recovery_test).
+fn temp_home_with(config_toml: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let opencrabs = dir.path().join(".opencrabs");
+    std::fs::create_dir_all(&opencrabs).expect("create .opencrabs");
+    std::fs::write(opencrabs.join("config.toml"), config_toml).expect("write config");
+    std::fs::write(opencrabs.join("keys.toml"), b"").expect("write keys");
+    (dir, opencrabs)
+}

--- a/src/tests/memory_search_resolve_path_test.rs
+++ b/src/tests/memory_search_resolve_path_test.rs
@@ -7,7 +7,8 @@
 //! that root; paths outside every configured root pass through unchanged.
 
 use crate::config::profile::with_home_override;
-use crate::memory::{COLLECTION_EXTERNAL, resolve_path};
+use crate::memory::COLLECTION_EXTERNAL;
+use crate::memory::search::resolve_path;
 use std::path::Path;
 
 const CONFIG_WITH_EXTRA_PATHS: &str = r#"
@@ -81,10 +82,10 @@ fn external_path_outside_roots_passes_through() {
 #[test]
 fn brain_path_still_home_anchored() {
     let (_temp, home) = temp_home_with(CONFIG_WITH_EXTRA_PATHS);
+    let anchor = home.clone();
     with_home_override(home, || {
-        let home_path = home.clone();
-        let got = resolve_path(&home_path, "brain", "SOUL.md");
-        assert_eq!(got, home_path.join("SOUL.md").to_string_lossy());
+        let got = resolve_path(&anchor, "brain", "SOUL.md");
+        assert_eq!(got, anchor.join("SOUL.md").to_string_lossy());
     });
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -289,6 +289,7 @@ pub mod memory_local_engine_test;
 pub mod memory_recall_eval_test;
 pub mod memory_recall_multilingual_test;
 pub mod memory_recall_test;
+pub mod memory_search_resolve_path_test;
 pub mod memory_search_rrf_test;
 pub mod memory_search_scope_test;
 pub mod memory_search_test;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -289,6 +289,7 @@ pub mod memory_local_engine_test;
 pub mod memory_recall_eval_test;
 pub mod memory_recall_multilingual_test;
 pub mod memory_recall_test;
+pub mod memory_search_parity_test;
 pub mod memory_search_resolve_path_test;
 pub mod memory_search_rrf_test;
 pub mod memory_search_scope_test;


### PR DESCRIPTION
## Summary
Ports the memory search parity suite (fork issue leshchenko1979/opencrabs#89) to adolfousier/main:

1. **Deterministic ordering**: Explicit `ORDER BY caller_symbol, file_path, call_line` in code graph queries to avoid non-deterministic result ordering across SQLite query plans.
2. **Floor cap & pagination**: Configurable `MIN_STRUCTURAL_RESULTS` floor (25) and `offset` pagination parameter on structural code symbol queries.
3. **Corpus provenance tags**: Symmetric `[brain]`, `[memory]`, and `[external]` headers under `scope=all` so callers can distinguish daily notes from brain rules and external codebase hits.
4. **Repo-relative paths**: Normalizes `[memory] extra_paths` so results strip machine-specific absolute prefixes where appropriate.
5. **Depth-2 impact chains**: Recursive `query_transitive_callers` with cycle bounds for `impact of X` queries.
6. **Mega-set rollup**: Per-file aggregation for symbols with >500 callers to avoid buffer overflow.

## Gate Evidence
- Gated commit: `61d6ec099896a6486ee49dce30c854ed5ed39447`
- GitHub Actions gate run: [34517720638](https://github.com/leshchenko1979/opencrabs/actions/runs/34517720638) (`PR-lane gates`: **completed / success**)
- Format, clippy, unit and integration tests passed clean.

Clean rebase on `adolfousier/main` tip (`80857867`).