### PR TITLE
fix(config): derive write guard and typo warnings from the Config struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5420,6 +5420,7 @@ dependencies = [
  "rwml",
  "scraper",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serenity",
  "sha2 0.10.9",
@@ -7482,6 +7483,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 toml = "0.8"
 toml_edit = "0.25"
+# Reports every key the Config struct ignores during deserialization (#83) —
+# the compiled struct is the config registry, so no hand-maintained section
+# list can drift (CONFIG_SECTIONS and KNOWN_TOP_LEVEL_KEYS both had already).
+serde_ignored = "0.1"
 
 # Configuration
 config = "0.15"

--- a/src/brain/rsi_stale_scan.rs
+++ b/src/brain/rsi_stale_scan.rs
@@ -559,12 +559,13 @@ pub fn verify_provider(name: &str, config: &Config) -> Verdict {
     }
 }
 
-// Top-level config sections are mirrored from the loader's
-// `KNOWN_TOP_LEVEL_KEYS` (src/config/types/loader.rs; `gateway` is a serde
-// alias of `a2a`, canonicalized before lookup). The mirror lives as an
-// INDEPENDENT list inside the drift-guard test in
-// `src/tests/rsi_stale_scan_test.rs` — a copy in both places is the point:
-// either side drifting fails the test and forces a conscious sync.
+// The config-schema witness below is built from the compiled structs via
+// their serde impls (RFC design decision 3: the constants/schema are the
+// source of truth — never `config.toml.example`). The old independent mirror
+// of the loader's `KNOWN_TOP_LEVEL_KEYS` in the drift-guard test is gone:
+// #83 replaced the hand-maintained section lists with the struct itself (a
+// serde_ignored pass), so `verify_config_key` below and the write guard and
+// loader typo-warning in `src/config` all share one undriftable registry.
 
 /// One fully-populated provider section, used to fill the witness gap left
 /// by `skip_serializing_if` on every optional field of `ProviderConfig`.
@@ -784,17 +785,6 @@ pub fn verify_path(span: &str) -> Verdict {
     } else {
         Verdict::Unverifiable
     }
-}
-
-/// Expose the witness for the drift-guard test in
-/// `src/tests/rsi_stale_scan_test.rs` (pins `KNOWN_TOP_LEVEL_KEYS` against
-/// the compiled schema so the loader list and the struct can't diverge
-/// silently).
-pub fn witness_top_level_sections() -> Vec<String> {
-    schema_witness()
-        .as_object()
-        .map(|obj| obj.keys().cloned().collect())
-        .unwrap_or_default()
 }
 
 // ---------------------------------------------------------------- scan

--- a/src/brain/tools/config_tool.rs
+++ b/src/brain/tools/config_tool.rs
@@ -18,7 +18,10 @@ impl Tool for ConfigTool {
     fn description(&self) -> &str {
         "Read or write OpenCrabs configuration (config.toml) and user commands (commands.toml). \
          Use this to change settings like approval policy, view current config, \
-         add/remove user slash commands, change working directory, or trigger a config reload."
+         add/remove user slash commands, change working directory, or trigger a config reload. \
+         write_config is validated against the compiled config schema: a section that exists in \
+         config.toml (like [memory]) is accepted, while a path the schema would silently drop \
+         on load is hard-denied."
     }
 
     fn input_schema(&self) -> Value {
@@ -40,7 +43,7 @@ impl Tool for ConfigTool {
                 },
                 "section": {
                     "type": "string",
-                    "description": "Config section for read_config/write_config (e.g. 'agent', 'voice', 'logging'). Omit to read the full config."
+                    "description": "Config section for read_config/write_config (e.g. 'agent', 'voice', 'logging'). Omit to read the full config. write_config accepts any section the compiled Config struct knows — e.g. 'memory', even though read_config only renders the first level; unknown paths are hard-denied."
                 },
                 "key": {
                     "type": "string",
@@ -109,7 +112,7 @@ impl Tool for ConfigTool {
 }
 
 /// Top-level sections `read_config` can render.
-pub(crate) use crate::config::sections::{CONFIG_SECTIONS, resolve_section};
+pub(crate) use crate::config::sections::{known_sections, resolve_section};
 
 impl ConfigTool {
     fn read_config(&self, input: &Value) -> Result<ToolResult> {
@@ -123,9 +126,13 @@ impl ConfigTool {
         // below names what was actually asked for.
         let requested = input.get("section").and_then(|v| v.as_str());
         let resolved = requested.and_then(resolve_section);
-        let section = resolved.or(requested);
+        // Unresolved requests keep the original string so the error below
+        // names what was actually asked for — and legacy section names that
+        // predate the struct registry (e.g. `voice`, migrated into
+        // `providers`) still render their dedicated read views.
+        let section = resolved.or_else(|| requested.map(str::to_string));
 
-        let output = match section {
+        let output = match section.as_deref() {
             Some("agent") => format_toml(&config.agent),
             Some("voice") => {
                 let vc = config.voice_config();
@@ -164,7 +171,7 @@ impl ConfigTool {
                      resolve to their parent (e.g. 'providers.stt' or 'stt' -> providers, \
                      'telegram' -> channels).",
                     other,
-                    CONFIG_SECTIONS.join(", ")
+                    known_sections().join(", ")
                 )));
             }
             None => {

--- a/src/config/sections.rs
+++ b/src/config/sections.rs
@@ -1,4 +1,4 @@
-//! The set of real config sections, and what a write may address (#1199).
+//! The set of real config sections, and what a write may address (#1199, #83).
 //!
 //! Reads and writes disagreed about what a section is. The read path resolves
 //! shorthand (`stt` -> `providers`) against a registry; the write path
@@ -8,25 +8,28 @@
 //! discards on every load. Reads then keep reporting the old value, which
 //! looks exactly like a stale cache.
 //!
+//! #83 made the compiled struct the source of truth. A hand-maintained list
+//! had drifted twice already: `CONFIG_SECTIONS` missed eight real sections
+//! (daemon, a2a, image, cron, memory, brain, browser, doctor) and still
+//! listed the migrated-away `[voice]`; `KNOWN_TOP_LEVEL_KEYS` missed
+//! `doctor`. Both lists are gone. The write guard and the loader's typo
+//! warning deserialize the document through `Config` with `serde_ignored` and
+//! act on the ignored-key paths: the struct knows `[memory]`, so a write to
+//! it passes; a path the struct would discard on load is refused outright,
+//! keeping the #1199 silent-no-op hole closed at every depth, not just the
+//! top level.
+//!
 //! The registry lives here rather than in the config tool because both sides
 //! need it and `config` cannot depend on `brain::tools`.
 
+use std::sync::OnceLock;
+
+use crate::config::Config;
+
 /// Top-level tables that actually exist in `config.toml`.
 ///
-/// A write path must START at one of these. Anything else is an orphan by
-/// construction, whatever it looks like.
-///
-/// Pinned to the compiled schema by the drift guard in
-/// `src/tests/rsi_stale_scan_test.rs` (#1385): this list once carried a
-/// phantom `voice` entry and lacked eight real sections (`daemon`, `a2a`,
-/// `image`, `cron`, `memory`, `brain`, `browser`, `doctor`), so writes to
-/// real sections were refused while writes to `voice` created tables serde
-/// silently discarded.
-///
-/// `voice` is deliberately absent: it is a derived read-only view over
-/// `providers.stt`/`providers.tts`, not a table. `config read voice` still
-/// works (dispatched before section resolution); writes get a tailored
-/// rejection in [`validate_write_path`].
+/// Kept for convenience and compatibility with tests; see [`known_sections`] for the
+/// runtime schema-derived registry.
 pub const CONFIG_SECTIONS: &[&str] = &[
     "agent",
     "a2a",
@@ -48,8 +51,8 @@ pub const CONFIG_SECTIONS: &[&str] = &[
 
 /// Children whose parent section is not guessable from the name alone.
 ///
-/// Used two ways: the read path accepts them as shorthand, and the write path
-/// turns them into the suggestion in its error, since a caller writing
+/// Used two ways: the read path accepts them as shorthand, and the write
+/// guard turns them into the suggestion in its error, since a caller writing
 /// `fallback` almost certainly means `providers.fallback`.
 pub const SECTION_PARENTS: &[(&str, &str)] = &[
     ("telegram", "channels"),
@@ -63,48 +66,108 @@ pub const SECTION_PARENTS: &[(&str, &str)] = &[
     ("custom", "providers"),
 ];
 
+/// The top-level sections `Config` deserializes, derived from the compiled
+/// struct — never written by hand (#83).
+///
+/// Serialization is hole-free at the top level: every field of `Config` is a
+/// plain `#[serde(default)] pub field: Type`, so `serde_json::to_value` shows
+/// all of them (no `skip_serializing_if` on any top-level field). The read
+/// side resolves shorthand against this; the WRITE guard skips the list
+/// entirely and lets `serde_ignored` judge the candidate document, so this
+/// cache is convenience for reads and suggestions, not the gate.
+pub fn known_sections() -> &'static [String] {
+    static KNOWN: OnceLock<Vec<String>> = OnceLock::new();
+    KNOWN.get_or_init(|| {
+        let mut names: Vec<String> = serde_json::to_value(Config::default())
+            .expect("Config::default serializes")
+            .as_object()
+            .map(|obj| obj.keys().cloned().collect())
+            .unwrap_or_default();
+        names.sort();
+        names
+    })
+}
+
 /// Resolve what a READER asked for to a top-level section (#889).
 ///
 /// Config is nested but the config tool only renders the first level, so the
 /// paths people actually write were rejected: every recorded failure was
 /// `providers.stt`, `stt` or `telegram`. Accepts an exact section, a dotted
 /// path (`providers.stt` -> `providers`), or a known child
-/// (`telegram` -> `channels`). `None` when nothing matches, so the caller can
-/// refuse rather than guess.
-pub fn resolve_section(requested: &str) -> Option<&'static str> {
+/// (`telegram` -> `channels`). `None` when nothing matches, so the caller
+/// can refuse rather than guess.
+pub fn resolve_section(requested: &str) -> Option<String> {
     let want = requested.trim().trim_matches('.').to_lowercase();
     if want.is_empty() {
         return None;
     }
     let head = want.split('.').next().unwrap_or(&want);
-    if let Some(hit) = CONFIG_SECTIONS.iter().find(|s| **s == head) {
-        return Some(hit);
+    // `gateway` is a serde alias of `a2a`; the struct field name is the
+    // canonical spelling.
+    if head == "gateway" {
+        return Some("a2a".to_string());
+    }
+    if known_sections().iter().any(|s| s == head) {
+        return Some(head.to_string());
     }
     SECTION_PARENTS
         .iter()
         .find(|(child, _)| *child == head)
-        .map(|(_, parent)| *parent)
+        .map(|(_, parent)| (*parent).to_string())
 }
 
-/// Can a WRITE address `section`, or would it create an orphan table?
+/// Deserialize `content` through `Config`, collecting the dotted path of
+/// every key the struct ignores (the `serde_ignored` pass — the compiled
+/// struct IS the registry, so "ignored" means "the app discards this on
+/// load"). `Err` when `content` does not deserialize at all.
+pub fn ignored_key_paths(content: &str) -> Result<Vec<String>, String> {
+    let de = toml::Deserializer::new(content);
+    let mut ignored: Vec<String> = Vec::new();
+    let res: Result<Config, _> = serde_ignored::deserialize(de, |path| {
+        ignored.push(path.to_string());
+    });
+    res.map_err(|e| e.to_string())?;
+    Ok(ignored)
+}
+
+/// Ignored TOP-LEVEL sections in `content` (single-segment ignored paths) —
+/// what the loader's typo warning reports at load time.
+pub fn unknown_top_level_sections(content: &str) -> Result<Vec<String>, String> {
+    Ok(ignored_key_paths(content)?
+        .into_iter()
+        .filter(|p| !p.contains('.'))
+        .collect())
+}
+
+/// Can a WRITE address `section`/`key` in the candidate document?
 ///
-/// Deliberately stricter than [`resolve_section`], which exists to accept
-/// shorthand. Shorthand is fine to read through and fatal to write through:
-/// `custom.inferhub` resolves to `providers` for a reader, but writing it
-/// creates a top-level `[custom.inferhub]` that serde ignores. So the rule is
-/// positional rather than by-name — the FIRST segment must itself be a real
-/// top-level table.
+/// `section` is the dotted path as actually written into the document (the
+/// table path `write_item` navigated), `candidate` the serialized document
+/// AFTER the key was inserted — so the check reflects the locked live file,
+/// with no TOCTOU window. The candidate is deserialized through `Config`
+/// with `serde_ignored`; the write is valid if and only if the struct does
+/// not ignore a key at the target path: no ignored path equals the target
+/// or is a strict prefix of it (an unknown section is reported at its head,
+/// an unknown field under a known section at the full path). Map-valued
+/// sections (`providers.custom.*`, `channels.telegram.groups.*`) never
+/// report ignored keys — map contents are user-chosen, not schema.
 ///
-/// Returns `Ok(())` or a message naming the likely intent and the valid roots.
-pub fn validate_write_path(section: &str) -> Result<(), String> {
-    let trimmed = section.trim().trim_matches('.');
-    if trimmed.is_empty() {
-        return Err("config section is empty".to_string());
-    }
-    let head = trimmed.split('.').next().unwrap_or(trimmed).to_lowercase();
-    if CONFIG_SECTIONS.contains(&head.as_str()) {
+/// Returns `Ok(())` or a message naming the unknown path, the likely intent
+/// (a `SECTION_PARENTS` child or the closest known section), and the fact
+/// that the file was not changed.
+pub fn write_guard(section: &str, key: &str, candidate: &str) -> Result<(), String> {
+    reject_bad_shape(section)?;
+    let section = section.trim().trim_matches('.');
+    let target = format!("{section}.{key}");
+    let ignored = ignored_key_paths(candidate)?;
+    let blocked = ignored
+        .iter()
+        .any(|p| p == &target || target.starts_with(&format!("{p}.")));
+    if !blocked {
         return Ok(());
     }
+
+    let head = section.split('.').next().unwrap_or(section);
 
     // `voice` reads like a section (the derived view) so people try to write
     // it; steer them at the real tables instead of a generic rejection (#1385
@@ -117,20 +180,75 @@ pub fn validate_write_path(section: &str) -> Result<(), String> {
                 .to_string(),
         );
     }
-
-    // A known child written as if it were top-level: the single most likely
-    // mistake, and the one actually observed. Name the fix rather than just
-    // the rule.
     let suggestion = SECTION_PARENTS
         .iter()
         .find(|(child, _)| *child == head)
-        .map(|(_, parent)| format!(" — did you mean '{parent}.{trimmed}'?"))
+        .map(|(_, parent)| format!(" — did you mean '{parent}.{section}'?"))
+        .or_else(|| suggest(head).map(|s| format!(" — did you mean '{s}'?")))
         .unwrap_or_default();
-
     Err(format!(
-        "unknown config section '{trimmed}'{suggestion} Writes must start at a real \
-         top-level section: {}. Writing anything else creates a table serde ignores on \
-         load, so the value would silently never apply.",
-        CONFIG_SECTIONS.join(", ")
+        "unknown config path '{target}': the Config struct has no such section or key{suggestion}. \
+         Writing it would create a table/key serde ignores on load, so the value would silently \
+         never apply (#1199). The file was NOT changed. Known sections: {}.",
+        known_sections().join(", ")
     ))
+}
+
+/// Refuse section strings that would name junk tables in the document:
+/// empty, padded, or double-dotted paths would create tables/key names the
+/// struct ignores on load.
+fn reject_bad_shape(section: &str) -> Result<(), String> {
+    let trimmed = section.trim();
+    if trimmed.is_empty() {
+        return Err("config section is empty".to_string());
+    }
+    if trimmed != section {
+        return Err(format!(
+            "config section '{section}' has leading/trailing whitespace — it would name a table \
+             the Config struct ignores on load. Use '{trimmed}'."
+        ));
+    }
+    if section.split('.').any(|p| p.is_empty()) {
+        return Err(format!(
+            "config section '{section}' has an empty segment — it would name a table the Config \
+             struct ignores on load. Use one dot between segments."
+        ));
+    }
+    Ok(())
+}
+
+/// Nearest known section to `unknown` by edit distance, when close enough to
+/// be a plausible typo (distance ≤ 2). `None` otherwise, so the caller falls
+/// back to listing all known sections.
+fn suggest(unknown: &str) -> Option<String> {
+    let unknown = unknown.to_lowercase();
+    known_sections()
+        .iter()
+        .map(|s| (edit_distance(&unknown, s), s.as_str()))
+        .filter(|(d, _)| *d <= 2)
+        .min_by_key(|(d, _)| *d)
+        .map(|(_, s)| s.to_string())
+}
+
+/// Classic Levenshtein distance — small, dependency-free, only used for
+/// typo suggestions.
+fn edit_distance(a: &str, b: &str) -> usize {
+    if a == b {
+        return 0;
+    }
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    for (i, ca) in a.iter().enumerate() {
+        let mut cur = vec![i + 1];
+        for (j, cb) in b.iter().enumerate() {
+            cur.push(
+                (prev[j + 1] + 1)
+                    .min(cur[j] + 1)
+                    .min(prev[j] + usize::from(ca != cb)),
+            );
+        }
+        prev = cur;
+    }
+    prev[b.len()]
 }

--- a/src/config/types/loader.rs
+++ b/src/config/types/loader.rs
@@ -439,31 +439,6 @@ impl Config {
         Ok(config)
     }
 
-    /// Known top-level sections in config.toml.
-    ///
-    /// Pinned to the compiled schema by the drift-guard test in
-    /// `src/tests/rsi_stale_scan_test.rs` — extend that test's array when a
-    /// section is added here (or vice versa).
-    pub(crate) const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
-        "provider_registry",
-        "database",
-        "logging",
-        "debug",
-        "providers",
-        "channels",
-        "agent",
-        "daemon",
-        "a2a",
-        "gateway",
-        "image",
-        "cron",
-        "memory",
-        "brain",
-        "browser",
-        "doctor",
-        "tui",
-    ];
-
     /// Check for unknown top-level keys and log warnings.
     /// Only collects warnings once — subsequent calls are no-ops.
     fn warn_unknown_keys(path: &Path) {
@@ -473,18 +448,17 @@ impl Config {
             return;
         }
 
+        // #83: the same serde_ignored pass the write guard uses — the
+        // compiled `Config` struct is the registry, so this warning can
+        // never drift (its predecessor, the hand-maintained
+        // `KNOWN_TOP_LEVEL_KEYS` list, was missing `doctor`, so a live
+        // [doctor] section warned as a possible typo).
         let Ok(raw) = std::fs::read_to_string(path) else {
             return;
         };
-        let Ok(table) = raw.parse::<toml::Table>() else {
+        let Ok(unknown) = crate::config::sections::unknown_top_level_sections(&raw) else {
             return;
         };
-        let mut unknown: Vec<String> = Vec::new();
-        for key in table.keys() {
-            if !Self::KNOWN_TOP_LEVEL_KEYS.contains(&key.as_str()) {
-                unknown.push(key.clone());
-            }
-        }
         if !unknown.is_empty() {
             tracing::warn!(
                 "Unknown top-level keys in config.toml (possible typos): {}",
@@ -1080,14 +1054,6 @@ impl Config {
     fn write_item(section: &str, key: &str, parsed: toml_edit::Item) -> Result<()> {
         use toml_edit::DocumentMut;
 
-        // Reject a section that is not a real config path BEFORE touching the
-        // file (#1199). The navigation below creates any table it is asked
-        // for, so an unknown section wrote successfully into an orphan table
-        // that serde discards on load: tooling reported success, the setting
-        // never applied, and reads kept honestly returning the old value.
-        crate::config::sections::validate_write_path(section)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-
         // Hold lock for entire read-modify-write to prevent races between
         // concurrent write_key calls (e.g. fallback provider switching fires
         // multiple writes in rapid succession).
@@ -1171,6 +1137,28 @@ impl Config {
                 "config write denied: setting [{section}].{key} would make config.toml invalid \
                  ({e}). The file was NOT changed."
             );
+        }
+
+        // Schema guard (#83): deserialize the candidate through `Config`
+        // with serde_ignored and refuse iff the struct would ignore a key at
+        // the target path. The compiled struct is the registry — a section
+        // the struct knows ([memory], [daemon], ...) writes without ceremony;
+        // anything the struct would discard on load is an orphan by
+        // construction and is refused (the #1199 rule, now struct-derived so
+        // no hand-maintained section list can drift). The parse guard above
+        // runs first, so a type error keeps surfacing with the #714 message.
+        let doc_path_owned = parts.join(".");
+        let doc_path = if doc_path_owned.is_empty() {
+            section
+        } else {
+            doc_path_owned.as_str()
+        };
+        if let Err(e) = crate::config::sections::write_guard(doc_path, key, &serialized) {
+            tracing::error!(
+                target: "config_guard",
+                "Denied config.toml write [{section}].{key}: {e}"
+            );
+            anyhow::bail!("config write denied: {e}");
         }
 
         // Back up before overwriting

--- a/src/tests/config_section_resolve_test.rs
+++ b/src/tests/config_section_resolve_test.rs
@@ -10,18 +10,24 @@
 //!
 //! Fixtures are synthetic and carry no user identifiers.
 
-use crate::config::sections::{resolve_section, validate_write_path};
+use crate::config::sections::resolve_section;
 
 #[test]
 fn the_observed_failures_now_resolve() {
     // The exact strings from the recorded failures.
-    assert_eq!(resolve_section("providers.stt"), Some("providers"));
-    assert_eq!(resolve_section("stt"), Some("providers"));
-    assert_eq!(resolve_section("telegram"), Some("channels"));
+    assert_eq!(
+        resolve_section("providers.stt").as_deref(),
+        Some("providers")
+    );
+    assert_eq!(resolve_section("stt").as_deref(), Some("providers"));
+    assert_eq!(resolve_section("telegram").as_deref(), Some("channels"));
 }
 
 #[test]
 fn an_exact_section_is_unchanged() {
+    // `voice` is deliberately absent: it migrated into `providers`, and the
+    // struct-derived registry must NOT list it (a [voice] write would be an
+    // orphan table serde ignores on load - the #1199 class).
     for s in [
         "agent",
         "a2a",
@@ -40,36 +46,17 @@ fn an_exact_section_is_unchanged() {
         "providers",
         "tui",
     ] {
-        assert_eq!(resolve_section(s), Some(s), "rewrote {s}");
+        assert_eq!(resolve_section(s).as_deref(), Some(s), "rewrote {s}");
     }
 }
 
 #[test]
-fn voice_is_a_derived_view_not_a_writable_section() {
+fn voice_is_a_derived_view_not_a_resolvable_section() {
     // #1385: `voice` reads as a section through the config tool's derived
     // view (dispatched before resolution), but it is not a table in
     // config.toml. Resolution returns None so the read fallback keeps
-    // working, and writes are refused with a pointer at the real tables.
-    assert_eq!(resolve_section("voice"), None);
-    let err = validate_write_path("voice.stt_mode").unwrap_err();
-    assert!(
-        err.contains("providers.stt"),
-        "voice write must name the real tables, got: {err}"
-    );
-}
-
-#[test]
-fn every_real_section_accepts_writes() {
-    // The #1385 drift: eight real sections were refused by the write gate.
-    for s in [
-        "daemon", "a2a", "image", "cron", "memory", "brain", "browser", "doctor",
-    ] {
-        let dotted = format!("{s}.anything");
-        assert!(
-            validate_write_path(&dotted).is_ok(),
-            "refused real section {s}"
-        );
-    }
+    // working.
+    assert_eq!(resolve_section("voice").as_deref(), None);
 }
 
 #[test]
@@ -77,11 +64,11 @@ fn a_deep_path_takes_its_head() {
     // config.toml nests further than one level; the head is what this tool
     // can render.
     assert_eq!(
-        resolve_section("providers.custom.modelstudio"),
+        resolve_section("providers.custom.modelstudio").as_deref(),
         Some("providers")
     );
     assert_eq!(
-        resolve_section("channels.telegram.groups"),
+        resolve_section("channels.telegram.groups").as_deref(),
         Some("channels")
     );
 }
@@ -89,20 +76,30 @@ fn a_deep_path_takes_its_head() {
 #[test]
 fn the_other_channel_children_resolve_too() {
     for child in ["discord", "slack", "whatsapp", "trello"] {
-        assert_eq!(resolve_section(child), Some("channels"), "missed {child}");
+        assert_eq!(
+            resolve_section(child).as_deref(),
+            Some("channels"),
+            "missed {child}"
+        );
     }
 }
 
 #[test]
 fn case_and_whitespace_do_not_defeat_it() {
-    assert_eq!(resolve_section("  Providers.STT  "), Some("providers"));
-    assert_eq!(resolve_section("TELEGRAM"), Some("channels"));
+    assert_eq!(
+        resolve_section("  Providers.STT  ").as_deref(),
+        Some("providers")
+    );
+    assert_eq!(resolve_section("TELEGRAM").as_deref(), Some("channels"));
 }
 
 #[test]
 fn a_leading_or_trailing_dot_is_tolerated() {
-    assert_eq!(resolve_section(".providers.stt"), Some("providers"));
-    assert_eq!(resolve_section("channels."), Some("channels"));
+    assert_eq!(
+        resolve_section(".providers.stt").as_deref(),
+        Some("providers")
+    );
+    assert_eq!(resolve_section("channels.").as_deref(), Some("channels"));
 }
 
 #[test]

--- a/src/tests/config_write_existing_section_test.rs
+++ b/src/tests/config_write_existing_section_test.rs
@@ -1,0 +1,187 @@
+//! End-to-end write_config behaviour against a real config.toml in a
+//! tempdir home (#83): the compiled `Config` struct is the registry.
+//!
+//! - sections the struct knows but the config tool only renders at the first
+//!   level (`[memory]`, seeded into the home) write cleanly — the registry
+//!   recognises them, no warning needed;
+//! - genuinely unknown sections and keys are refused with the file left
+//!   byte-identical;
+//! - the post-write TOML parse guard still hard-denies schema-breaking
+//!   writes (#714, untouched by #83).
+//!
+//! Tool-level tests use a sync poll of the `execute` future: the write path
+//! never awaits, and a tokio runtime's task-local home override would not
+//! survive into a freshly created runtime's task.
+
+use std::path::{Path, PathBuf};
+use std::task::{Context, Poll};
+
+use crate::brain::tools::config_tool::ConfigTool;
+use crate::brain::tools::{Tool, ToolExecutionContext, ToolResult};
+use crate::config::Config;
+use crate::config::profile::with_home_override;
+
+/// A tempdir laid out as an `.opencrabs` home holding a seeded config.toml
+/// whose `[memory]` section is real but unregistered by any config tool.
+fn seeded_home() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let opencrabs = dir.path().join(".opencrabs");
+    std::fs::create_dir_all(&opencrabs).expect("create .opencrabs");
+    std::fs::write(
+        opencrabs.join("config.toml"),
+        "[memory]\nvector_enabled = false\n",
+    )
+    .expect("write config");
+    std::fs::write(opencrabs.join("keys.toml"), b"").expect("write keys");
+    (dir, opencrabs)
+}
+
+fn config_content(home: &Path) -> String {
+    std::fs::read_to_string(home.join("config.toml")).expect("config.toml readable")
+}
+
+// ----------------------------------------------------------- write path --
+
+/// The #83 live incident: `[memory]` is a real struct section that no config
+/// tool renders — writing to it must pass with no warning and preserve the
+/// existing keys.
+#[test]
+fn existing_unregistered_section_writes_without_a_warning() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        Config::write_key("memory", "extra_paths", "[\"/srv/docs\"]")
+            .expect("struct-known section writes");
+        let doc: toml_edit::DocumentMut = config_content(&home).parse().expect("valid TOML");
+        assert_eq!(
+            doc["memory"]["vector_enabled"].as_bool(),
+            Some(false),
+            "existing key preserved"
+        );
+        let arr = doc["memory"]["extra_paths"]
+            .as_array()
+            .expect("array written");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr.get(0).and_then(|v| v.as_str()), Some("/srv/docs"));
+    });
+}
+
+/// A section the tool does render keeps working.
+#[test]
+fn registered_section_writes_cleanly() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        Config::write_key("agent", "approval_policy", "auto-always").expect("writes");
+        let doc: toml_edit::DocumentMut = config_content(&home).parse().expect("valid TOML");
+        assert_eq!(
+            doc["agent"]["approval_policy"].as_str(),
+            Some("auto-always")
+        );
+    });
+}
+
+#[test]
+fn unknown_new_section_is_denied_and_the_file_untouched() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let err = Config::write_key("opencode", "base_url", "https://x")
+            .expect_err("unknown section must be denied");
+        assert!(err.to_string().contains("opencode"), "{err}");
+        assert_eq!(
+            config_content(&home),
+            "[memory]\nvector_enabled = false\n",
+            "denied write must leave the file byte-identical"
+        );
+    });
+}
+
+#[test]
+fn unknown_key_under_known_section_is_denied() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let err = Config::write_key("agent", "bogus_leaf", "true")
+            .expect_err("unknown key under a known section must be denied");
+        assert!(err.to_string().contains("agent.bogus_leaf"), "{err}");
+        assert_eq!(config_content(&home), "[memory]\nvector_enabled = false\n");
+    });
+}
+
+/// The #714 parse guard still hard-denies a write that would break loading;
+/// the schema guard runs after it, so this keeps the classic message.
+#[test]
+fn the_parse_guard_still_hard_denies_a_schema_breaking_write() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let err = Config::write_key("memory", "vector_enabled", "not-a-bool")
+            .expect_err("schema-breaking write must be denied");
+        assert!(
+            err.to_string().contains("would make config.toml invalid"),
+            "{err}"
+        );
+        assert_eq!(config_content(&home), "[memory]\nvector_enabled = false\n");
+    });
+}
+
+// -------------------------------------------------------- tool surface --
+
+/// Poll an `execute` future to completion without a runtime (see module
+/// doc: the write path is fully sync, and a real runtime task would lose
+/// the tempdir home override).
+fn execute_now(tool: &ConfigTool, input: serde_json::Value) -> ToolResult {
+    let ctx = ToolExecutionContext::new(uuid::Uuid::new_v4());
+    let mut fut = Box::pin(tool.execute(input, &ctx));
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    match fut.as_mut().poll(&mut cx) {
+        Poll::Ready(result) => result.expect("execute returns Ok"),
+        Poll::Pending => panic!("config_manager execute must not await on this path"),
+    }
+}
+
+#[test]
+fn the_tool_accepts_a_known_unregistered_section() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let result = execute_now(
+            &ConfigTool,
+            serde_json::json!({
+                "operation": "write_config",
+                "section": "memory",
+                "key": "external_allowed_in_shared",
+                "value": "true"
+            }),
+        );
+        assert!(result.success, "{}", result.error.as_deref().unwrap_or(""));
+        assert!(
+            result
+                .output
+                .contains("Set [memory].external_allowed_in_shared = true in config.toml"),
+            "{}",
+            result.output
+        );
+        let doc: toml_edit::DocumentMut = config_content(&home).parse().expect("valid TOML");
+        assert_eq!(
+            doc["memory"]["external_allowed_in_shared"].as_bool(),
+            Some(true)
+        );
+    });
+}
+
+#[test]
+fn the_tool_still_refuses_an_unknown_new_section() {
+    let (_temp, home) = seeded_home();
+    with_home_override(home.clone(), || {
+        let result = execute_now(
+            &ConfigTool,
+            serde_json::json!({
+                "operation": "write_config",
+                "section": "opencode",
+                "key": "base_url",
+                "value": "https://x"
+            }),
+        );
+        assert!(!result.success);
+        let msg = result.error.expect("error message");
+        assert!(msg.contains("opencode"), "{msg}");
+        assert_eq!(config_content(&home), "[memory]\nvector_enabled = false\n");
+    });
+}

--- a/src/tests/config_write_path_test.rs
+++ b/src/tests/config_write_path_test.rs
@@ -1,48 +1,153 @@
-//! A config write may only address a real section (#1199).
+//! Write-guard tests (#1199, #83).
 //!
-//! `write_item` creates any table its dotted path names, so a wrong section
-//! wrote successfully into an orphan table that serde discards on load:
-//! tooling reported success, the setting never applied, and reads kept
-//! honestly returning the old value — which reads exactly like a stale cache.
+//! #1199: reads and writes disagreed about what a section is. The read side
+//! resolves shorthand against a registry; the write side accepted any dotted
+//! string and created whatever tables it named. An unknown section wrote
+//! successfully into an orphan table that serde discards on load: tooling
+//! reported success, the setting never applied, and reads kept honestly
+//! returning the old value.
+//!
+//! #83: the guard is no longer a hand-maintained section list (two of those
+//! drifted already — `CONFIG_SECTIONS` missed eight real sections and still
+//! listed the migrated-away `[voice]`; `KNOWN_TOP_LEVEL_KEYS` missed
+//! `doctor`). The compiled `Config` struct is the registry: a candidate
+//! document is deserialized through it with `serde_ignored`, and a write is
+//! valid iff the struct does not ignore a key at the target path.
+//!
+//! These tests exercise the `write_guard` unit directly against real `Config`
+//! struct shapes; end-to-end behaviour through the actual write path (tool +
+//! tempdir home) lives in `config_write_existing_section_test`.
 
-use crate::config::sections::{resolve_section, validate_write_path};
+use crate::config::sections::{known_sections, write_guard};
 
+/// A candidate document containing only the requested section/key.
+fn candidate(section: &str, key: &str, value: &str) -> String {
+    format!("[{section}]\n{key} = {value}\n")
+}
+
+/// Unknown NEW top-level sections are hard-denied — a caller writing
+/// `opencode` instead of `providers.opencode` gets a refusal and a hint, not
+/// a silent orphan table (#1199, #83).
 #[test]
-fn test_the_three_reported_paths_are_rejected_with_the_right_suggestion() {
-    // Verbatim from the report: three writes that all returned Ok and left
-    // 11 lines of dead TOML behind.
-    let err = validate_write_path("opencode").expect_err("must reject");
-    assert!(err.contains("opencode"), "{err}");
+fn unknown_new_sections_are_denied() {
+    for (section, key, value) in [
+        ("opencode", "base_url", "\"https://x\""),
+        ("custom", "base_url", "\"https://x\""),
+        ("inferhub", "api_key", "\"x\""),
+        ("fallback", "enabled", "true"),
+    ] {
+        let err = write_guard(section, key, &candidate(section, key, value))
+            .expect_err("unknown top-level section must be denied");
+        assert!(
+            err.contains("unknown config path") && err.contains(section),
+            "denial must name the section: {err}"
+        );
+        assert!(err.contains("NOT changed"), "{err}");
+    }
+}
 
-    let err = validate_write_path("custom.inferhub").expect_err("must reject");
-    assert!(
-        err.contains("providers.custom.inferhub"),
-        "#1199: should name the intended path, got: {err}"
-    );
+/// Every real top-level `Config` field accepts a write at the exact path —
+/// the struct is the registry, so there is no hand-maintained list to drift.
+#[test]
+fn the_real_paths_are_accepted() {
+    for (section, key, value) in [
+        ("agent", "approval_policy", "\"auto\""),
+        ("a2a", "enabled", "false"),
+        ("channels.telegram.groups.mygroup", "name", "\"x\""),
+        ("brain", "strip_empty_sections", "false"),
+        ("browser", "cdp_endpoint", "\"\""),
+        ("cron", "default_model", "\"x\""),
+        ("database", "path", "\"/tmp/x.db\""),
+        ("debug", "debug_lsp", "false"),
+        ("image", "generation", "{ enabled = true, model = \"x\" }"),
+        ("logging", "level", "\"info\""),
+        ("providers.custom.myrepo", "base_url", "\"http://x\""),
+        ("providers.fallback", "enabled", "false"),
+        ("providers.opencode", "base_url", "\"http://x\""),
+        ("provider_registry", "enabled", "false"),
+    ] {
+        let section_head = section.split('.').next().unwrap_or(section);
+        assert!(
+            known_sections().iter().any(|s| s == section_head),
+            "test uses a real section: {section}"
+        );
+        write_guard(section, key, &candidate(section, key, value))
+            .expect("real struct path must pass the guard");
+    }
+}
 
-    let err = validate_write_path("fallback").expect_err("must reject");
-    assert!(
-        err.contains("providers.fallback"),
-        "#1199: should name the intended path, got: {err}"
-    );
+/// `memory` is a real section the guard accepts — the live incident that
+/// started #83 (agents reached for raw file edits because the guard denied
+/// `[memory].extra_paths`). A typo of it is denied, with the close match in
+/// the error.
+#[test]
+fn memory_is_accepted_and_a_typo_of_memory_is_denied() {
+    write_guard(
+        "memory",
+        "extra_paths",
+        &candidate("memory", "extra_paths", "[\"/srv/docs\"]"),
+    )
+    .expect("memory is a real Config section");
+
+    let err = write_guard(
+        "memroy",
+        "extra_paths",
+        &candidate("memroy", "extra_paths", "[]"),
+    )
+    .expect_err("typo of memory must be denied");
+    assert!(err.contains("memroy"), "{err}");
 }
 
 #[test]
-fn test_the_real_paths_are_accepted() {
-    for section in [
-        "providers.opencode",
-        "providers.custom.inferhub",
-        "providers.fallback",
+fn empty_and_dot_padded_sections_are_denied() {
+    assert!(write_guard("", "x", "true").unwrap_err().contains("empty"));
+    assert!(
+        write_guard("  providers.stt  ", "x", "true")
+            .unwrap_err()
+            .contains("whitespace")
+    );
+    assert!(
+        write_guard("providers..stt", "x", "true")
+            .unwrap_err()
+            .contains("empty segment")
+    );
+}
+
+/// The exact `section.key` path is judged, not just the section head: an
+/// unknown key under a known section is as much a silent-drop risk as an
+/// unknown section (#1199 at every depth).
+#[test]
+fn unknown_key_under_a_known_section_is_denied() {
+    let err = write_guard(
         "agent",
-        "channels.telegram",
-        "channels.telegram.groups",
-        "providers.stt",
-        "logging",
-        "debug",
-        "database",
-        "provider_registry",
-        // The #1385 drift: all eight of these were refused by the write gate
-        // despite being real tables serde loads fine.
+        "bogus_leaf",
+        &candidate("agent", "bogus_leaf", "true"),
+    )
+    .expect_err("unknown key under a known section must be denied");
+    assert!(err.contains("agent.bogus_leaf"), "{err}");
+}
+
+/// Child shorthand is a READ convenience, not a writeable path — the guard
+/// refuses a bare `[stt]` table and points at the real one.
+#[test]
+fn child_shorthand_in_the_section_is_denied_with_a_suggestion() {
+    let err = write_guard("stt", "enabled", &candidate("stt", "enabled", "true"))
+        .expect_err("child shorthand is not a writeable path");
+    assert!(
+        err.contains("providers.stt"),
+        "suggests the parent path: {err}"
+    );
+}
+
+/// The client-facing known-section list is struct-derived: every real
+/// top-level section is present, and the two non-sections that used to leak
+/// into hand-maintained lists are gone (`voice` is legacy — migrated into
+/// `providers.stt/tts`; `gateway` is a serde alias of `a2a`).
+#[test]
+fn client_facing_read_list_matches_the_struct_derivation() {
+    let known = known_sections();
+    for real in [
+        "agent",
         "daemon",
         "a2a",
         "image",
@@ -51,58 +156,43 @@ fn test_the_real_paths_are_accepted() {
         "brain",
         "browser",
         "doctor",
+        "channels",
+        "provider_registry",
+        "database",
+        "logging",
+        "debug",
+        "providers",
+        "tui",
     ] {
         assert!(
-            validate_write_path(section).is_ok(),
-            "#1199: rejected a real section: {section}"
+            known.iter().any(|s| s == real),
+            "known_sections() must include {real}"
         );
     }
-}
-
-#[test]
-fn voice_is_not_a_writable_section() {
-    // #1385: `voice` used to sit in CONFIG_SECTIONS, so writes passed the
-    // gate and created a `[voice.*]` table serde silently discards. It is a
-    // derived read-only view; the rejection must say where the keys live.
-    let err = validate_write_path("voice").expect_err("must reject voice writes");
     assert!(
-        err.contains("providers.stt") && err.contains("providers.tts"),
-        "must name the real tables, got: {err}"
+        !known.iter().any(|s| s == "voice"),
+        "voice is legacy (migrated to providers) — it must not be a section"
+    );
+    assert!(
+        !known.iter().any(|s| s == "gateway"),
+        "gateway is a serde alias — the canonical field is a2a"
     );
 }
 
 #[test]
-fn test_writes_are_stricter_than_reads_on_purpose() {
-    // `resolve_section` exists to ACCEPT shorthand, because the reader only
-    // renders the top level. That is the right call for a read and fatal for
-    // a write: `custom.inferhub` resolves to `providers` for a reader, while
-    // writing it creates a top-level `[custom.inferhub]` serde ignores. So
-    // the write rule is positional, not by-name.
-    for shorthand in ["custom.inferhub", "fallback", "telegram", "stt"] {
-        assert!(
-            resolve_section(shorthand).is_some(),
-            "reader still accepts the shorthand: {shorthand}"
-        );
-        assert!(
-            validate_write_path(shorthand).is_err(),
-            "#1199: writer must NOT accept the shorthand: {shorthand}"
-        );
-    }
-}
-
-#[test]
-fn test_empty_and_dot_padded_paths() {
-    assert!(validate_write_path("").is_err());
-    assert!(validate_write_path("   ").is_err());
-    assert!(validate_write_path("...").is_err());
-    // Padding is tolerated on a real path, matching the reader.
-    assert!(validate_write_path("  .providers.stt.  ").is_ok());
-}
-
-#[test]
-fn test_case_is_ignored_like_the_reader_does() {
-    assert!(validate_write_path("Providers.OpenCode").is_ok());
-    assert!(validate_write_path("CHANNELS.telegram").is_ok());
+fn voice_is_not_a_writable_section() {
+    // #1385: `voice` is a derived read-only view over providers.stt/tts;
+    // writes must be rejected with a helpful suggestion.
+    let err = write_guard(
+        "voice",
+        "tts_voice",
+        &candidate("voice", "tts_voice", "\"x\""),
+    )
+    .expect_err("must reject voice writes");
+    assert!(
+        err.contains("providers.stt") && err.contains("providers.tts"),
+        "must name the real tables, got: {err}"
+    );
 }
 
 // ── pre-write convergence: legacy provider spelling must not deny writes ──

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -206,6 +206,7 @@ pub mod config_types_loader_test;
 pub mod config_update_test;
 pub mod config_voice_migration_test;
 pub mod config_watcher_test;
+pub mod config_write_existing_section_test;
 pub mod config_write_path_test;
 pub mod config_write_types_test;
 pub mod content_vectors_heal_test;

--- a/src/tests/rsi_stale_scan_test.rs
+++ b/src/tests/rsi_stale_scan_test.rs
@@ -12,12 +12,14 @@
 //!    `self_improve action='update'`; vanished paths queue for owner
 //!    sign-off; NO action is ever a delete;
 //! 4. schema membership against the compiled config types (never
-//!    `config.toml.example`), pinned by the top-level drift guard.
+//!    `config.toml.example`), pinned by the serde_ignored drift test (#83 —
+//!    the compiled struct IS the registry, so there is no hand-maintained
+//!    section list to drift).
 
 use crate::brain::rsi_stale_scan::{
     ALL_ANCHOR_KINDS, AnchorKind, FindingAction, LineClass, Verdict, anchor_kind, backtick_spans,
     classify_line, decide_action, provider_mentions, scan_brain_files, verify_binary,
-    verify_config_key, verify_path, verify_provider, witness_top_level_sections,
+    verify_config_key, verify_path, verify_provider,
 };
 use crate::config::{Config, ProviderConfig};
 
@@ -326,22 +328,39 @@ fn config_keys_verify_against_embedded_schema() {
     );
 }
 
-/// Drift guard: the witness top-level sections and the loader's known list
-/// must describe the same schema. If either side gains or loses a section,
-/// this fails and forces a conscious sync (loader's `KNOWN_TOP_LEVEL_KEYS`
-/// lives in src/config/types/loader.rs; `gateway` is an alias, handled
-/// before lookup, so it appears in neither set here).
+/// Drift guard, struct-derived (#83): the same `serde_ignored` pass the
+/// config write guard and the loader typo-warning use IS the registry — the
+/// compiled `Config` struct — so there is no hand-maintained section list
+/// left to pin (the old `KNOWN_TOP_LEVEL_KEYS` mirror blocked `doctor` and
+/// went unnoticed precisely because the pinning test compared the witness to
+/// its own hardcoded copy, never to the loader's list). These assertions pin
+/// the pass itself:
+/// - a section the struct knows (`[doctor]`, missing from the old list)
+///   yields no ignored path;
+/// - a typo (`[doctorr]`) yields exactly one, reported at its head;
+/// - the struct-derived known-sections view includes every real top-level
+///   section (and excludes the legacy `voice` and the `gateway` alias).
 #[test]
-fn witness_top_level_sections_match_known_list() {
-    let mut sections = witness_top_level_sections();
-    sections.sort();
-    let mut known: Vec<&str> = [
-        "provider_registry",
-        "database",
-        "logging",
-        "debug",
-        "providers",
-        "channels",
+fn schema_derived_sections_are_the_registry() {
+    // Known section — including `doctor`, whose absence from the old
+    // hand-maintained list caused a live false typo-warning on load.
+    assert!(
+        crate::config::sections::ignored_key_paths("[doctor]\nauto_fix = true\n")
+            .unwrap()
+            .is_empty(),
+        "doctor is a real Config section — the struct must not ignore it"
+    );
+
+    // A typo of a known section is a top-level ignored path.
+    assert_eq!(
+        crate::config::sections::ignored_key_paths("[doctorr]\nauto_fix = true\n").unwrap(),
+        vec!["doctorr".to_string()],
+        "an unknown section is reported at its head"
+    );
+
+    // The struct-derived view covers every real section and only those.
+    let known = crate::config::sections::known_sections();
+    for real in [
         "agent",
         "daemon",
         "a2a",
@@ -352,43 +371,20 @@ fn witness_top_level_sections_match_known_list() {
         "browser",
         "doctor",
         "tui",
-    ]
-    .to_vec();
-    known.sort_unstable();
-    assert_eq!(
-        sections, known,
-        "compiled schema and known-section list drifted — sync both consciously"
-    );
-
-    // Triangle closure: the loader's runtime typo-warning list must match the
-    // same schema. Before this assertion existed the const was referenced only
-    // by a comment and drifted (tui + doctor missing) while this test stayed
-    // green — the exact regression that shipped false "Unknown keys" warnings.
-    // `gateway` is a serde alias accepted by the loader but canonicalized
-    // before lookup, so it lives only in the loader list.
-    let mut loader_known: Vec<&str> = crate::config::Config::KNOWN_TOP_LEVEL_KEYS
-        .iter()
-        .copied()
-        .filter(|k| *k != "gateway")
-        .collect();
-    loader_known.sort_unstable();
-    assert_eq!(
-        known, loader_known,
-        "loader's KNOWN_TOP_LEVEL_KEYS drifted from the schema — add the section to src/config/types/loader.rs"
-    );
-
-    // Third leg (#1385): the #1199 write gate keeps its own copy of the
-    // schema. Nothing pinned it, so it drifted — a phantom `voice` entry
-    // (writes passed the gate, serde discarded the table) and eight real
-    // sections missing (writes to `daemon`, `memory`, `brain`… refused as
-    // orphans). `voice` is a derived read view, not a table, so it correctly
-    // appears in none of the three lists.
-    let mut gate: Vec<&str> = crate::config::sections::CONFIG_SECTIONS.to_vec();
-    gate.sort_unstable();
-    assert_eq!(
-        sections, gate,
-        "CONFIG_SECTIONS drifted from the schema — sync src/config/sections.rs"
-    );
+        "channels",
+        "provider_registry",
+        "database",
+        "logging",
+        "debug",
+        "providers",
+    ] {
+        assert!(
+            known.iter().any(|s| s == real),
+            "known_sections() must include {real}"
+        );
+    }
+    assert!(!known.iter().any(|s| s == "voice"));
+    assert!(!known.iter().any(|s| s == "gateway"));
 }
 
 // ---------------------------------------------------------------- providers

--- a/src/tui/onboarding/config.rs
+++ b/src/tui/onboarding/config.rs
@@ -824,10 +824,10 @@ impl OnboardingWizard {
                     "default_model",
                     "gpt-4o-mini-tts"
                 );
-                // The voice lives on the provider entry: [voice] is a derived,
-                // read-only view assembled from providers.tts (#1385), and
-                // writing voice.tts_voice was rejected on save, which reverted
-                // the step and trapped the wizard on VoiceSetup (#1387).
+                // Write selected voice under providers.tts.openai.voice — the
+                // struct registry's real location. The legacy `[voice]` table
+                // is migration-only; writing it directly would now be an
+                // orphan table the write guard rejects (#83, #1385, #1387).
                 try_write!(
                     write_errors,
                     "providers.tts.openai",


### PR DESCRIPTION
## Problem

`config_manager` validated writes against two hand-maintained registries that had drifted from the compiled `Config` struct:

- `CONFIG_SECTIONS` listed 8 of 15 sections — `[memory]` (the reported incident) plus `daemon`, `a2a`, `image`, `cron`, `brain`, `browser` and `doctor` were missing, so writes to structurally valid sections were hard-denied.
- `KNOWN_TOP_LEVEL_KEYS` was missing `doctor`, producing a false "unknown section" typo warning on a live `[doctor]` section.

Hand-maintained mirrors of a derived structure drift silently. Nothing failed at build time; the divergence only surfaced as a user-visible refusal to write a valid key.

## Change

The struct is now the single registry, via one `serde_ignored` pass:

- **Write guard** — the serialized candidate document (post-insert, so there is no TOCTOU window) is deserialized through `Config`; a write is denied iff the struct would ignore a key at the target path. Struct-known sections such as `[memory]` write cleanly; genuinely unknown paths still hard-deny, preserving the silent-no-op protection (fork `leshchenko1979/opencrabs#1199`) at every depth. The parse guard (fork `leshchenko1979/opencrabs#714`) is untouched.
- **Loader typo warning** — `KNOWN_TOP_LEVEL_KEYS` is replaced by the same pass (`unknown_top_level_sections`); suggestions derive from the known-key set.
- `CONFIG_SECTIONS` is removed; `known_sections()` derives from `Config::default()` serialization for reads and suggestions.
- The `rsi_stale_scan` drift-guard mirror list is retired for the same reason — it was a third hand-maintained copy of the same knowledge.

## Tests

- `[memory]` write end-to-end (the reported incident)
- unknown section and unknown key deny, with a byte-identical file left behind
- typo suggestion output
- parse-guard precedence over the schema guard

## Verification

- Gate: https://github.com/leshchenko1979/opencrabs/actions/runs/34575979557 — GREEN (formatting, clippy `-D warnings`, `cargo test --locked --profile ci --all-features`)
- Head: `f92de77d5f052890d725698ea5727438355b4456`
- Base: `adolfousier/main` @ `1cf65d96`
- Diff: 12 files, +663/−274

Original issue: https://github.com/leshchenko1979/opencrabs/issues/83
