### PR TITLE
fix(cron): per-job cron sessions to prevent concurrent context and provider bleed

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -493,7 +493,7 @@ impl CronScheduler {
                                     job.name,
                                     crate::config::opencrabs_home()
                                 );
-                                match resolve_or_create_cron_session(&ctx).await {
+                                match resolve_or_create_cron_session(&ctx, &job).await {
                                     Ok(cron_sid) => {
                                         execute_job(
                                             &job,
@@ -510,7 +510,7 @@ impl CronScheduler {
                             })
                             .await
                         } else {
-                            match resolve_or_create_cron_session(&ctx).await {
+                            match resolve_or_create_cron_session(&ctx, &job).await {
                                 Ok(cron_sid) => {
                                     execute_job(
                                         &job,
@@ -578,12 +578,51 @@ impl CronScheduler {
     }
 }
 
-/// Find an existing "Cron" session or create one. All cron jobs share this
-/// session for logging/debugging, but each run inserts a compaction marker
-/// after completion so the next run starts with empty context (no history
-/// contamination between jobs).
-async fn resolve_or_create_cron_session(ctx: &ServiceContext) -> anyhow::Result<Uuid> {
-    const CRON_SESSION_NAME: &str = "Cron";
+/// The stable per-job title suffix used as the session lookup key. Derived
+/// from the job's UUID — unique per job row, rename-safe (LIKE-unsafe
+/// characters are impossible in a UUID), and shared by the resolution path
+/// and tests via this single definition.
+pub(crate) fn cron_session_title_suffix(job: &CronJob) -> String {
+    format!("[cron-job:{}]", job.id)
+}
+
+/// Resolve the session a cron job runs in — ONE SESSION PER JOB (#149).
+///
+/// Legacy behavior (pre-#149) resolved a single shared "Cron" session for
+/// every job. That design cross-pollinates whenever jobs overlap in time,
+/// which the 60s tick makes routine, not exceptional:
+///
+/// 1. **History**: a run inserts its `[CONTEXT COMPACTION]` marker only at
+///    the END of the turn, and context loads from the LAST marker in the
+///    session (`messages_from_last_compaction`). A job B starting while job
+///    A is mid-flight reads A's prompt + partial tool activity as its own
+///    context. Two concurrent turns also interleave writes into one history.
+/// 2. **Provider/model**: `execute_job` swaps the per-session provider keyed
+///    to the session id — with one shared id, a concurrent job's swap
+///    overwrites the running job's provider mid-turn (last writer wins).
+///
+/// Sessions are resolved by a stable TITLE suffix carrying the job id
+/// (`Cron: <job_name> [cron-job:<uuid>]`), mirroring the channel-handler pattern
+/// (`[chat:N]` suffix) so a user rename of the readable part still resolves
+/// to the same session row while different jobs never share one.
+///
+/// Cross-RUN contamination within a single job is still bounded by the
+/// end-of-run compaction marker: the job's own next fire starts from an
+/// empty context (deliberate — cron prompts are self-contained).
+///
+/// There is no per-run single-flight guard here: overlapping fires of the
+/// same job each get a session that ONLY that job writes, so the two
+/// pollution vectors above cannot cross jobs; self-overlap remains visible
+/// in `cron_job_runs` and is addressed separately if it proves harmful.
+pub(crate) async fn resolve_or_create_cron_session(
+    ctx: &ServiceContext,
+    job: &CronJob,
+) -> anyhow::Result<Uuid> {
+    // Stable lookup key: survives renames of the readable part, unique per
+    // job id (a UUID — LIKE-escape characters cannot occur).
+    let suffix = cron_session_title_suffix(job);
+    let title = format!("Cron: {} {}", job.name, suffix);
+
     use crate::db::repository::SessionListOptions;
     let session_svc = SessionService::new(ctx.clone());
     let sessions = session_svc
@@ -597,7 +636,7 @@ async fn resolve_or_create_cron_session(ctx: &ServiceContext) -> anyhow::Result<
         .await?;
     if let Some(existing) = sessions
         .iter()
-        .find(|s| s.title.as_deref().is_some_and(|n| n == CRON_SESSION_NAME))
+        .find(|s| s.title.as_deref().is_some_and(|n| n.ends_with(&suffix)))
     {
         return Ok(existing.id);
     }
@@ -605,7 +644,7 @@ async fn resolve_or_create_cron_session(ctx: &ServiceContext) -> anyhow::Result<
     let provider = config.cron.default_provider.clone();
     let model = config.cron.default_model.clone();
     let session = session_svc
-        .create_session_with_provider(Some(CRON_SESSION_NAME.to_string()), provider, model, None)
+        .create_session_with_provider(Some(title), provider, model, None)
         .await?;
     Ok(session.id)
 }

--- a/src/tests/cron_session_isolation_test.rs
+++ b/src/tests/cron_session_isolation_test.rs
@@ -1,0 +1,167 @@
+//! Tests for #149: cron jobs must NOT share one session.
+//!
+//! Pre-#149 every job ran in a single shared "Cron" session. That design
+//! cross-pollinates whenever jobs overlap in time (routine under the 60s
+//! tick): context loads from the LAST compaction marker, and a job starting
+//! mid-flight of another reads that job's prompt/tool activity as its own
+//! context; the per-session provider swap is likewise keyed to the shared id
+//! and a concurrent job's swap overwrites the running job's provider.
+//!
+//! The fix resolves ONE SESSION PER JOB via a stable title suffix
+//! `[cron-job:<job-uuid>]`. These tests cover the resolution contract: two
+//! different jobs resolve to different sessions; the same job resolves to
+//! the SAME session across fires (its history + provider swaps stay
+//! self-consistent); and a rename of the readable title part does not
+//! orphan the session (the suffix is the lookup key).
+
+use crate::config::profile::with_home_override_async;
+use crate::cron::scheduler::cron_session_title_suffix;
+use crate::db::{Database, models::CronJob};
+use crate::services::{ServiceContext, SessionService};
+use uuid::Uuid;
+
+async fn test_ctx() -> ServiceContext {
+    let db = Database::connect_in_memory().await.unwrap();
+    db.run_migrations().await.unwrap();
+    ServiceContext::new(db.pool().clone())
+}
+
+fn make_job(name: &str) -> CronJob {
+    CronJob::new(
+        name.to_string(),
+        "0 9 * * *".to_string(),
+        "UTC".to_string(),
+        "do things".to_string(),
+        None,
+        None,
+        "off".to_string(),
+        true,
+        None,
+        None,
+    )
+}
+
+/// Two DIFFERENT jobs must resolve to DIFFERENT sessions — the core #149
+/// guarantee. No shared "Cron" session exists anymore.
+#[tokio::test]
+async fn different_jobs_get_different_sessions() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = dir.path().join(".opencrabs");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    with_home_override_async(home, async {
+        let ctx = test_ctx().await;
+        let job_a = make_job("job-a");
+        let job_b = make_job("job-b");
+
+        let sid_a = crate::cron::scheduler::resolve_or_create_cron_session(&ctx, &job_a)
+            .await
+            .expect("resolve session for job-a");
+        let sid_b = crate::cron::scheduler::resolve_or_create_cron_session(&ctx, &job_b)
+            .await
+            .expect("resolve session for job-b");
+
+        assert_ne!(
+            sid_a, sid_b,
+            "two different jobs resolved the SAME session — #149 cross-pollination is back"
+        );
+    })
+    .await;
+}
+
+/// The SAME job must resolve to the SAME session across fires, so its own
+/// history stays coherent and its end-of-run compaction marker bounds its
+/// own next fire's context.
+#[tokio::test]
+async fn same_job_reuses_its_session() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = dir.path().join(".opencrabs");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    with_home_override_async(home, async {
+        let ctx = test_ctx().await;
+        let job = make_job("recurring-job");
+
+        let first = crate::cron::scheduler::resolve_or_create_cron_session(&ctx, &job)
+            .await
+            .expect("first resolve");
+        let second = crate::cron::scheduler::resolve_or_create_cron_session(&ctx, &job)
+            .await
+            .expect("second resolve");
+
+        assert_eq!(first, second, "same job must reuse its own session");
+    })
+    .await;
+}
+
+/// The lookup key is the `[cron-job:<uuid>]` suffix, not the readable title:
+/// renaming the title part must not orphan the job's session (mirrors the
+/// channel-handler `[chat:N]` rename-safety pattern).
+#[tokio::test]
+async fn renamed_session_still_resolves_by_suffix() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = dir.path().join(".opencrabs");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    with_home_override_async(home, async {
+        let ctx = test_ctx().await;
+        let job = make_job("renamed-job");
+
+        let original = crate::cron::scheduler::resolve_or_create_cron_session(&ctx, &job)
+            .await
+            .expect("initial resolve");
+
+        // Simulate a user rename: same session row, new readable title,
+        // suffix preserved.
+        let session_svc = SessionService::new(ctx.clone());
+        let mut session = session_svc
+            .get_session(original)
+            .await
+            .expect("get session")
+            .expect("session exists");
+        session.title = Some(format!(
+            "Renamed by user {}",
+            cron_session_title_suffix(&job)
+        ));
+        session_svc
+            .update_session(&session)
+            .await
+            .expect("rename session");
+
+        let resolved = crate::cron::scheduler::resolve_or_create_cron_session(&ctx, &job)
+            .await
+            .expect("resolve after rename");
+        assert_eq!(
+            resolved, original,
+            "renaming the title part must not orphan the job's session"
+        );
+    })
+    .await;
+}
+
+/// The suffix is derived from the job's ID, not its name — two jobs with the
+/// SAME name (possible in the jobs table) still get separate sessions.
+#[tokio::test]
+async fn same_name_different_ids_get_different_sessions() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = dir.path().join(".opencrabs");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    with_home_override_async(home, async {
+        let ctx = test_ctx().await;
+        let job_a = make_job("twin");
+        let mut job_b = make_job("twin");
+        job_b.id = Uuid::new_v4();
+
+        assert_ne!(job_a.id, job_b.id, "test setup: ids must differ");
+        let sid_a = crate::cron::scheduler::resolve_or_create_cron_session(&ctx, &job_a)
+            .await
+            .expect("resolve twin-a");
+        let sid_b = crate::cron::scheduler::resolve_or_create_cron_session(&ctx, &job_b)
+            .await
+            .expect("resolve twin-b");
+
+        assert_ne!(sid_a, sid_b, "same-name jobs must not share a session");
+    })
+    .await;
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -223,6 +223,7 @@ pub mod cron_profile_isolation_test;
 pub mod cron_schedule_util_test;
 pub mod cron_scheduler_lock_test;
 pub mod cron_send_scope_test;
+pub mod cron_session_isolation_test;
 pub mod cron_session_target_test;
 pub mod cron_test;
 pub mod cron_tool_registry_test;


### PR DESCRIPTION
### Summary

Every cron job resolved ONE shared "Cron" session, so overlapping fires (routine under the 60s tick) polluted each other two ways:
1. **History bleed**: a run writes its `[CONTEXT COMPACTION]` marker only at the END of the turn and context loads from the LAST marker, so a job starting mid-flight reads the other's prompt and partial tool activity.
2. **Provider/model overwrite**: `execute_job` swaps the provider keyed to the session id, so with one shared id a concurrent job's swap overwrites the running job's provider mid-turn.

### Solution

Resolve one session per job with a stable title suffix carrying the job UUID (`Cron: <name> [cron-job:<uuid>]`), mirroring the `[chat:N]` channel pattern so renaming the human-readable part still resolves to the same database row.

Includes 4 regression tests in `src/tests/cron_session_isolation_test.rs`:
- Distinct sessions per job ID
- Session reuse for subsequent runs of the same job
- Suffix matching across title renames
- Complete separation between jobs sharing the same title string

### Verification & CI Gate

- Pre-flight PR gate: https://github.com/leshchenko1979/opencrabs/actions/runs/34623786259 (`PR-lane gates (158a8e4ae0a62ff332d1577ab960f5d8a1b8e5b2)`) — completed success (fmt, clippy, 8255 tests passed, 0 failed).
- Fork-deployed smoke verified: session creation, isolation, and persistent storage validated on live daemon.

Original issue: https://github.com/leshchenko1979/opencrabs/issues/149