### PR TITLE
feat(skills): cursor-style globs frontmatter gate for skills

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -399,6 +399,14 @@ profile_id = ""
 # to reach for `tool_search`.
 # lazy_tools = false
 
+# Skill glob gate (default: true). When a SKILL.md declares a `globs:`
+# frontmatter field, tool calls touching a path matching one of those globs
+# are rejected until the skill body is loaded in the current session context
+# (fresh sessions AND after compaction). The rejection carries the full skill
+# body; the identical retry then succeeds. Per-skill opt-out: delete the
+# skill's `globs` key. Set false to disable the gate entirely.
+# skill_glob_gate = true
+
 # Provider/model for Recursive Self-Improvement (RSI) cycles. The model is
 # paired with the provider, same as subagent_provider/subagent_model.
 # Unset self_improvement_provider → inherit the active provider; unset

--- a/src/brain/agent/service/builder.rs
+++ b/src/brain/agent/service/builder.rs
@@ -466,7 +466,13 @@ impl AgentService {
             last_compaction_elapsed: std::sync::RwLock::new(HashMap::new()),
             session_outgoing_text_ring: std::sync::RwLock::new(HashMap::new()),
             context,
-            tool_registry: Arc::new(ToolRegistry::new()),
+            tool_registry: {
+                let mut registry = ToolRegistry::new();
+                // Skill glob gate master switch (#150) — resolved from
+                // config once at construction.
+                registry.set_skill_gate_enabled(config.agent.skill_glob_gate);
+                Arc::new(registry)
+            },
             max_tool_iterations: 0, // 0 = unlimited (loop detection is the safety net)
             default_system_brain: None,
             brain_rebuild: None,

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -471,6 +471,12 @@ impl AgentService {
             .active_skills_for_session(session_id)
             .into_iter()
             .collect();
+        // Epoch bump (#150) BEFORE the seen-inventory read below is NOT
+        // required and after it is not harmful: `note_compaction` bumps a
+        // per-session epoch counter and clears nothing, so
+        // `seen_for_session` is unaffected either way (decision 5 — a
+        // clearing implementation would empty the stamp's inventory).
+        crate::brain::tools::seen_skills::note_compaction(session_id);
         let seen: std::collections::BTreeSet<String> =
             crate::brain::tools::seen_skills::seen_for_session(session_id)
                 .into_iter()

--- a/src/brain/skills.rs
+++ b/src/brain/skills.rs
@@ -43,6 +43,7 @@
 //! preserved for forward-compat but ignored.
 
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 /// Compile-time table of built-in skills shipped with the binary.
 ///
@@ -109,6 +110,11 @@ pub struct Skill {
     pub description: String,
     /// Prompt body (everything after the closing `---`, trimmed).
     pub body: String,
+    /// Cursor-style glob paths. When non-empty, the skill gate rejects
+    /// tool calls touching a matching path until the skill body has been
+    /// loaded (seen) in the current session context. Opt-in: no `globs`
+    /// key → empty vec → invisible to the gate.
+    pub globs: Vec<String>,
     /// `review_gate: true` in frontmatter: slash invocation of this skill
     /// is the user reaching for the brake on purpose. The agent must
     /// present the skill's output and wait for explicit user approval
@@ -144,17 +150,52 @@ impl Skill {
         let mut fm_name: Option<String> = None;
         let mut fm_description: Option<String> = None;
         let mut fm_review_gate = false;
+        let mut fm_globs: Vec<String> = Vec::new();
+
+        // Open-key state: a top-level `key:` with no inline value opens a
+        // block list; subsequent indented `- item` lines belong to it.
+        // Modeled on directives.rs::field but re-implemented here — those
+        // helpers are private and return the wrong shape.
+        let mut open_key: Option<String> = None;
 
         for line in frontmatter.lines() {
             let trimmed = line.trim();
             if trimmed.is_empty() || trimmed.starts_with('#') {
                 continue;
             }
+
+            // Indented list item under an open block key.
+            let indent = line.len() - line.trim_start().len();
+            if indent > 0 && trimmed.starts_with('-') && open_key.as_deref() == Some("globs") {
+                let item = trimmed[1..].trim().trim_matches('"').trim_matches('\'');
+                if !item.is_empty() {
+                    fm_globs.push(item.to_string());
+                }
+                continue;
+            }
+            if indent > 0 && trimmed.starts_with('-') {
+                continue;
+            }
+            // Indented non-list line (e.g. `globs: x/**` nested under
+            // `metadata:`) — belongs to a nested block, never to the
+            // top-level key set. Skip it and close any open block key:
+            // a nested region means the previous block list is over.
+            if indent > 0 {
+                open_key = None;
+                continue;
+            }
+
+            // Top-level key — closes any open block key.
+            open_key = None;
+
             let Some((key, value)) = trimmed.split_once(':') else {
                 continue;
             };
             let key = key.trim();
-            let value = value.trim().trim_matches('"').trim_matches('\'');
+            let value = value.trim();
+            // Inline value: strip quoting, then optional `[a, b]` flow form.
+            let value = value.trim_matches('"').trim_matches('\'');
+
             match key {
                 "name" => fm_name = Some(value.to_string()),
                 "description" => fm_description = Some(value.to_string()),
@@ -164,7 +205,32 @@ impl Skill {
                         "true" | "yes" | "1" | "on"
                     );
                 }
-                _ => {}
+                "globs" => {
+                    if value.is_empty() {
+                        // Block list form: `globs:` with items on the
+                        // following indented lines.
+                        open_key = Some(key.to_string());
+                    } else if let Some(inner) =
+                        value.strip_prefix('[').and_then(|s| s.strip_suffix(']'))
+                    {
+                        // Inline flow form: `globs: [a, b]`.
+                        for part in inner.split(',') {
+                            let item = part.trim().trim_matches('"').trim_matches('\'');
+                            if !item.is_empty() {
+                                fm_globs.push(item.to_string());
+                            }
+                        }
+                    } else {
+                        // Cursor comma-separated string form: `globs: a, b`.
+                        for part in value.split(',') {
+                            let item = part.trim().trim_matches('"').trim_matches('\'');
+                            if !item.is_empty() {
+                                fm_globs.push(item.to_string());
+                            }
+                        }
+                    }
+                }
+                _ => {} // unknown keys (incl. nested metadata blocks) ignored
             }
         }
 
@@ -178,6 +244,7 @@ impl Skill {
             slash_name,
             description,
             body: body.trim().to_string(),
+            globs: fm_globs,
             review_gate: fm_review_gate,
             source,
         })
@@ -342,4 +409,40 @@ pub fn load_all_skills() -> Vec<Skill> {
 /// `load_all_skills` (user overlay wins).
 pub fn resolve_skill(name: &str) -> Option<Skill> {
     load_all_skills().into_iter().find(|s| s.name == name)
+}
+
+type GlobsCache = std::sync::Mutex<Option<(std::time::Instant, PathBuf, Vec<Skill>)>>;
+static GLOBS_CACHE: OnceLock<GlobsCache> = OnceLock::new();
+
+/// Clear the globs cache (for tests or explicit reload).
+pub fn invalidate_globs_cache() {
+    if let Some(cache) = GLOBS_CACHE.get()
+        && let Ok(mut guard) = cache.lock()
+    {
+        *guard = None;
+    }
+}
+
+/// The skills that declare `globs` — the skill-gate's working set (#150).
+/// Cached for 60s: the gate runs on EVERY tool call, and re-scanning the
+/// skills tree per call would dominate it. A freshly added globs skill
+/// becomes visible within a minute or on restart; failure to read the
+/// cache source is fail-open (empty vec → gate passes everything).
+pub fn skills_with_globs() -> Vec<Skill> {
+    static TTL: std::time::Duration = std::time::Duration::from_secs(60);
+    let cache = GLOBS_CACHE.get_or_init(|| std::sync::Mutex::new(None));
+    let current_home = crate::config::opencrabs_home();
+    let mut guard = cache.lock().expect("skills_with_globs cache poisoned");
+    if let Some((at, home, skills)) = guard.as_ref()
+        && at.elapsed() < TTL
+        && home == &current_home
+    {
+        return skills.clone();
+    }
+    let fresh: Vec<Skill> = load_all_skills()
+        .into_iter()
+        .filter(|s| !s.globs.is_empty())
+        .collect();
+    *guard = Some((std::time::Instant::now(), current_home, fresh.clone()));
+    fresh
 }

--- a/src/brain/tools/mod.rs
+++ b/src/brain/tools/mod.rs
@@ -64,6 +64,7 @@ pub mod load_brain_file;
 pub mod memory_search;
 pub(crate) mod path_lock;
 pub mod plan_gate;
+pub mod skill_gate;
 pub mod plan_tool;
 pub(crate) mod project_runner;
 pub mod provider_vision;

--- a/src/brain/tools/registry.rs
+++ b/src/brain/tools/registry.rs
@@ -86,6 +86,9 @@ pub struct ToolRegistry {
     session_active: RwLock<HashMap<uuid::Uuid, HashMap<String, u64>>>,
     /// Monotonic counter stamping each activation/touch for LRU ordering.
     activation_seq: std::sync::atomic::AtomicU64,
+    /// Skill glob gate master switch (`[agent] skill_glob_gate`, #150).
+    /// Default true; the AgentService wiring sets this from config.
+    skill_gate_enabled: bool,
 }
 
 impl ToolRegistry {
@@ -95,7 +98,14 @@ impl ToolRegistry {
             tools: RwLock::new(HashMap::new()),
             session_active: RwLock::new(HashMap::new()),
             activation_seq: std::sync::atomic::AtomicU64::new(0),
+            skill_gate_enabled: true,
         }
+    }
+
+    /// Set the skill glob gate master switch (#150). Called by the
+    /// AgentService wiring with the `[agent] skill_glob_gate` config value.
+    pub fn set_skill_gate_enabled(&mut self, enabled: bool) {
+        self.skill_gate_enabled = enabled;
     }
 
     /// Mark EXTENDED tools as active for a session (or refresh their recency),
@@ -360,6 +370,50 @@ impl ToolRegistry {
                     return Err(ToolError::ApprovalRequired(reason));
                 }
             }
+        }
+
+        // Skill glob gate (issue #150): a tool call touching a path that
+        // matches a globs-declaring skill the session hasn't loaded is
+        // rejected with the skill's FULL body as the error content (the
+        // plan_gate deny precedent) and `mark_seen` arms the identical
+        // retry. Fires per call inside `execute` — sequential, parallel,
+        // and sub-agent dispatch all pass through here, so there is no
+        // batch-splice logic to get wrong. Fail-open: any internal gate
+        // error is a `Pass` inside `skill_gate::check` itself.
+        let verdict = super::skill_gate::check(
+            context.session_id,
+            name,
+            &input,
+            &context.working_directory,
+            self.skill_gate_enabled,
+        );
+        if let super::skill_gate::GateVerdict::Block {
+            skill,
+            matched_path,
+            body,
+            globs,
+        } = verdict
+        {
+            tracing::info!(
+                "skill_gate: blocked '{}' — path '{}' matches skill '{}' (not loaded in context)",
+                name,
+                matched_path,
+                skill
+            );
+            // Arm the retry BEFORE the agent sees the result: with the
+            // epoch-carrying registry (#150) this upserts the current
+            // epoch, so the identical re-issued call passes.
+            super::seen_skills::mark_seen(context.session_id, &skill);
+            let content = format!(
+                "[SKILL GATE] This call touches '{}' which matches skill '{}' (globs: {}), \
+                 not loaded in the current session context. The full skill body follows. \
+                 Read it, then re-issue the identical call.\n\n---\n\n{}",
+                matched_path,
+                skill,
+                globs.join(", "),
+                body
+            );
+            return Ok(ToolResult::error(content));
         }
 
         // Check if approval is required

--- a/src/brain/tools/seen_skills.rs
+++ b/src/brain/tools/seen_skills.rs
@@ -1,4 +1,4 @@
-//! Session-scoped seen-skill tracking (issue #131).
+//! Session-scoped seen-skill tracking (issue #131, #150).
 //!
 //! Records which skill bodies a session has CONSUMED — by any surface — so
 //! the post-compaction advisory stamp (#125) can list skills the agent
@@ -8,20 +8,34 @@
 //! - `load_brain_file` with a bare skill slug (the #131 canonical form)
 //! - `read_file` on a `skills/<slug>/SKILL.md` path (whole-file reads)
 //!
+//! In-memory registry stores `(session_id, slug) -> epoch` (issue #150).
+//! When context compaction occurs, `note_compaction` bumps the session's epoch.
+//! `seen_since_compaction` checks whether a skill was seen at or after the current epoch.
+//!
 //! This is deliberately SEPARATE from `AgentService::active_skills` (the
 //! #219 slash-invocation registry): that set also drives per-turn body
 //! re-injection into the system prompt, and read-counted skills must not be
 //! re-injected on top of the read already present in conversation history.
 //! The compaction stamp is the UNION of both registries.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 use std::sync::OnceLock;
 use uuid::Uuid;
 
-fn registry() -> &'static std::sync::Mutex<HashSet<(Uuid, String)>> {
-    static REGISTRY: OnceLock<std::sync::Mutex<HashSet<(Uuid, String)>>> = OnceLock::new();
-    REGISTRY.get_or_init(|| std::sync::Mutex::new(HashSet::new()))
+/// In-memory registry: (session, slug) → the compaction epoch at which the
+/// skill body was last loaded into that session's context (issue #150).
+/// Epoch 0 == "loaded before any compaction".
+fn registry() -> &'static std::sync::Mutex<HashMap<(Uuid, String), u64>> {
+    static REGISTRY: OnceLock<std::sync::Mutex<HashMap<(Uuid, String), u64>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+/// Per-session compaction epoch counter (issue #150). `note_compaction`
+/// bumps it; skills seen at an older epoch are no longer "in context".
+fn epochs() -> &'static std::sync::Mutex<HashMap<Uuid, u64>> {
+    static EPOCHS: OnceLock<std::sync::Mutex<HashMap<Uuid, u64>>> = OnceLock::new();
+    EPOCHS.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
 /// Extract the skill slug from a path that points at a skill definition
@@ -43,20 +57,62 @@ pub fn skill_slug_from_path(path: &Path) -> Option<String> {
 }
 
 /// Record that `session_id` consumed skill `slug` (via read or slug-form
-/// load). Idempotent per (session, slug).
+/// load) at the session's CURRENT compaction epoch.
+///
+/// Always upserts (issue #150: updating the epoch ensures that re-reading
+/// a skill after compaction unblocks the skill glob gate).
 pub fn mark_seen(session_id: Uuid, slug: &str) {
+    let epoch = current_epoch(session_id);
     registry()
         .lock()
         .expect("seen_skills registry poisoned")
-        .insert((session_id, slug.to_string()));
+        .insert((session_id, slug.to_string()), epoch);
 }
 
-/// Whether `session_id` has consumed skill `slug` this run.
+/// The session's current compaction epoch (0 before any compaction).
+fn current_epoch(session_id: Uuid) -> u64 {
+    *epochs()
+        .lock()
+        .expect("seen_skills epochs poisoned")
+        .get(&session_id)
+        .unwrap_or(&0)
+}
+
+/// Bump the session's compaction epoch (issue #150): called from the
+/// compaction path. AFTER a compaction, the registry entries keep their
+/// old epoch, so `seen_since_compaction` flips false for every skill
+/// until the body is re-read. Clears NOTHING — the #125 stamp's
+/// seen-inventory (`seen_for_session`) remains intact.
+pub fn note_compaction(session_id: Uuid) {
+    let mut epochs = epochs().lock().expect("seen_skills epochs poisoned");
+    let next = epochs.get(&session_id).copied().unwrap_or(0) + 1;
+    epochs.insert(session_id, next);
+}
+
+/// Whether `session_id`'s context currently holds skill `slug`'s body:
+/// the stored epoch is >= the session's current epoch. Fresh sessions
+/// (no rows) report false — the gate fires on the first matching call.
+pub fn seen_since_compaction(session_id: Uuid, slug: &str) -> bool {
+    let stored = registry()
+        .lock()
+        .expect("seen_skills registry poisoned")
+        .get(&(session_id, slug.to_string()))
+        .copied();
+    if let Some(epoch) = stored {
+        epoch >= current_epoch(session_id)
+    } else {
+        false
+    }
+}
+
+/// Whether `session_id` has consumed skill `slug` this run (any epoch —
+/// legacy stamp inventory semantics; the gate uses
+/// [`seen_since_compaction`]).
 pub fn was_seen(session_id: Uuid, slug: &str) -> bool {
     registry()
         .lock()
         .expect("seen_skills registry poisoned")
-        .contains(&(session_id, slug.to_string()))
+        .contains_key(&(session_id, slug.to_string()))
 }
 
 /// All skills `session_id` has consumed, sorted (deterministic stamp order).
@@ -65,8 +121,113 @@ pub fn seen_for_session(session_id: Uuid) -> Vec<String> {
         .lock()
         .expect("seen_skills registry poisoned")
         .iter()
-        .filter(|(s, _)| *s == session_id)
-        .map(|(_, slug)| slug.clone())
+        .filter(|((sid, _), _)| *sid == session_id)
+        .map(|((_, slug), _)| slug.clone())
         .collect();
     all.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_extraction_from_skill_paths() {
+        assert_eq!(
+            skill_slug_from_path(Path::new(
+                "/root/.opencrabs/profiles/ops/skills/opencrabs-dev/SKILL.md"
+            )),
+            Some("opencrabs-dev".to_string())
+        );
+        assert_eq!(
+            skill_slug_from_path(Path::new("skills/foo/SKILL.md")),
+            Some("foo".to_string())
+        );
+    }
+
+    #[test]
+    fn non_skill_paths_yield_none() {
+        assert_eq!(
+            skill_slug_from_path(Path::new("/home/user/MEMORY.md")),
+            None
+        );
+        assert_eq!(skill_slug_from_path(Path::new("skills/foo/other.md")), None);
+        assert_eq!(
+            skill_slug_from_path(Path::new("not-skills/foo/SKILL.md")),
+            None
+        );
+        assert_eq!(skill_slug_from_path(Path::new("skills/foo/")), None);
+    }
+
+    #[test]
+    fn mark_seen_is_idempotent_and_session_scoped() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        mark_seen(a, "opencrabs-dev");
+        mark_seen(a, "opencrabs-dev");
+        assert!(was_seen(a, "opencrabs-dev"));
+        assert_eq!(seen_for_session(a), vec!["opencrabs-dev".to_string()]);
+        assert!(!was_seen(b, "opencrabs-dev"));
+        assert!(seen_for_session(b).is_empty());
+    }
+
+    #[test]
+    fn seen_list_is_sorted_and_multi() {
+        let a = Uuid::new_v4();
+        mark_seen(a, "zeta");
+        mark_seen(a, "alpha");
+        assert_eq!(
+            seen_for_session(a),
+            vec!["alpha".to_string(), "zeta".to_string()]
+        );
+    }
+
+    // --- issue #150: epoch-carrying registry + skill-gate semantics ---
+
+    #[test]
+    fn fresh_session_reports_not_seen_since_compaction() {
+        let a = Uuid::new_v4();
+        assert!(!seen_since_compaction(a, "anything"));
+    }
+
+    #[test]
+    fn seen_passes_and_compaction_rearms_gate() {
+        let a = Uuid::new_v4();
+        mark_seen(a, "my-skill");
+        assert!(seen_since_compaction(a, "my-skill"));
+        // A compaction bumps the epoch; the stored row keeps the old one.
+        note_compaction(a);
+        assert!(!seen_since_compaction(a, "my-skill"));
+        // Re-reading re-arms at the new epoch.
+        mark_seen(a, "my-skill");
+        assert!(seen_since_compaction(a, "my-skill"));
+    }
+
+    #[test]
+    fn compaction_clears_nothing_stamp_inventory_intact() {
+        let a = Uuid::new_v4();
+        mark_seen(a, "one");
+        mark_seen(a, "two");
+        note_compaction(a);
+        // The #125 stamp's seen-inventory survives.
+        assert_eq!(
+            seen_for_session(a),
+            vec!["one".to_string(), "two".to_string()]
+        );
+        // ...but neither body is "in context" for gate purposes.
+        assert!(!seen_since_compaction(a, "one"));
+        assert!(!seen_since_compaction(a, "two"));
+    }
+
+    #[test]
+    fn sessions_are_independent() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        mark_seen(a, "sk");
+        note_compaction(a);
+        // b never compacted: its row stays current.
+        mark_seen(b, "sk");
+        assert!(seen_since_compaction(b, "sk"));
+        assert!(!seen_since_compaction(a, "sk"));
+    }
 }

--- a/src/brain/tools/skill_gate.rs
+++ b/src/brain/tools/skill_gate.rs
@@ -1,0 +1,491 @@
+//! Skill glob gate (issue #150) — the registry-level sibling of
+//! `plan_gate`.
+//!
+//! Cursor-style opt-in enforcement for skills: a `SKILL.md` that declares
+//! a `globs:` frontmatter field guards its own topic. When the agent
+//! attempts a tool call that references a path matching one of those
+//! globs, and the skill body is NOT loaded (seen) in the current session
+//! context — fresh sessions AND post-compaction (owner decision
+//! 2026-09-10) — the call is rejected. The rejection's content IS the
+//! full skill body (the `plan_gate` deny precedent), so the body lands
+//! in-context the same turn and the identical retry succeeds.
+//!
+//! Laws (design v2, decisions 6–9):
+//! - **Fail-open:** any gate-internal error (pattern compile failure,
+//!   malformed globs, missing skill file, registry error) → `Pass`. The
+//!   gate must never dead-end an agent.
+//! - **Opt-in:** no `globs` key → the skill is invisible to the gate.
+//! - **Exempt recovery tools** must never be gated, or a blocked agent
+//!   cannot self-serve (`load_brain_file`, `read_file`, `slash_command`,
+//!   `session_search`, `tool_search`, `write_opencrabs_file`,
+//!   `execute_code`).
+//! - **Cursor match table:** `*` matches one path segment (never `/`),
+//!   `**` matches recursively — `require_literal_separator: true`.
+//!   Globs match against the normalized ABSOLUTE path; skill authors
+//!   use `**/` prefixes (e.g. `**/skills/opencrabs-dev/**`).
+//! - **Pattern resolution** ([`compile_pattern`]): `~` expands to home;
+//!   a wildcard-led pattern (`**/x`) is unanchored and matched verbatim;
+//!   any other relative pattern anchors at the session cwd. A glob is
+//!   never blanket-prefixed with `cwd` — that silently disarms every
+//!   documented `**/…` form.
+//! - **Cheap + deterministic:** fast-exit when disabled / no loaded
+//!   skill declares globs / tool is exempt.
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use super::seen_skills;
+#[cfg(test)]
+use crate::brain::skills::Skill;
+
+/// Tools the gate never touches — recovery paths a blocked agent must
+/// keep available to read the skill body and re-arm itself.
+const EXEMPT_TOOLS: &[&str] = &[
+    "load_brain_file",
+    "read_file",
+    "slash_command",
+    "session_search",
+    "tool_search",
+    "write_opencrabs_file",
+    "execute_code",
+];
+
+/// Input keys harvested as candidate paths (decision 6). `grep`'s
+/// `pattern` is excluded (regex, not a path); the `glob` tool's
+/// `pattern` is excluded (a glob pattern string is not a path — finding
+/// 24). Bash commands are harvested separately as path-like tokens.
+const PATH_KEYS: &[&str] = &["path", "file_path", "filePath"];
+
+/// Tools whose `pattern`-like keys are NOT harvested even when named in
+/// [`PATH_KEYS`]-adjacent forms. (Kept explicit for the doc contract.)
+const PATTERN_ONLY_TOOLS: &[&str] = &["grep", "glob"];
+
+/// The gate's verdict on one tool call.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GateVerdict {
+    /// The call proceeds (also the verdict for every fail-open path).
+    Pass,
+    /// The call is blocked: the named skill's body rides the rejection.
+    Block {
+        skill: String,
+        matched_path: String,
+        body: String,
+        globs: Vec<String>,
+    },
+}
+
+/// Gate entry point. `enabled` is the `[agent] skill_glob_gate` master
+/// switch; `cwd` is the session's working directory for resolving
+/// relative candidate paths.
+pub fn check(
+    session_id: Uuid,
+    tool_name: &str,
+    input: &Value,
+    cwd: &std::path::Path,
+    enabled: bool,
+) -> GateVerdict {
+    if !enabled || EXEMPT_TOOLS.contains(&tool_name) {
+        return GateVerdict::Pass;
+    }
+    // Fast-exit: no loaded skill declares globs (decision 12 — zero cost).
+    let skills = crate::brain::skills::skills_with_globs();
+    if skills.is_empty() {
+        return GateVerdict::Pass;
+    }
+    let candidates = harvest_candidates(tool_name, input, cwd);
+    if candidates.is_empty() {
+        return GateVerdict::Pass;
+    }
+
+    for skill in &skills {
+        for glob_str in &skill.globs {
+            let pattern = match compile_pattern(glob_str, cwd) {
+                Ok(p) => p,
+                Err(e) => {
+                    // Malformed glob: warn once per (slug, glob) per
+                    // process and skip — fail-open (decision 9).
+                    warn_malformed_glob(&skill.name, glob_str, &e.to_string());
+                    continue;
+                }
+            };
+            let options = glob::MatchOptions {
+                case_sensitive: false,
+                require_literal_separator: true, // Cursor `*` = one segment (B5)
+                require_literal_leading_dot: false,
+            };
+            for candidate in &candidates {
+                if pattern.matches_path_with(candidate, options) {
+                    if seen_skills::seen_since_compaction(session_id, &skill.name) {
+                        return GateVerdict::Pass;
+                    }
+                    return GateVerdict::Block {
+                        skill: skill.name.clone(),
+                        matched_path: candidate.display().to_string(),
+                        body: skill.prompt_body(),
+                        globs: skill.globs.clone(),
+                    };
+                }
+            }
+        }
+    }
+    GateVerdict::Pass
+}
+
+/// Warn-once set for malformed globs (decision 9).
+fn warn_malformed_glob(slug: &str, glob_str: &str, err: &str) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNT: AtomicU64 = AtomicU64::new(0);
+    // Warn at most 8 times per process per signature to bound log noise
+    // without adding a second map.
+    if COUNT.fetch_add(1, Ordering::Relaxed) < 8 {
+        tracing::warn!(
+            "skill_gate: skill '{slug}' has malformed glob '{glob_str}' ({err}) — skipping (fail-open)"
+        );
+    }
+}
+
+/// Harvest candidate absolute paths from the tool input (decision 6).
+fn harvest_candidates(
+    tool_name: &str,
+    input: &Value,
+    cwd: &std::path::Path,
+) -> Vec<std::path::PathBuf> {
+    let mut out: Vec<String> = Vec::new();
+    let obj = match input.as_object() {
+        Some(o) => o,
+        None => return Vec::new(),
+    };
+
+    if !PATTERN_ONLY_TOOLS.contains(&tool_name) {
+        for key in PATH_KEYS {
+            if let Some(Value::String(s)) = obj.get(*key) {
+                out.push(s.clone());
+            }
+        }
+    } else {
+        // grep/glob: the `pattern` key is regex/glob text — never a path —
+        // but their `path` argument IS a real search root and must still be
+        // harvested, otherwise a gated skill under a grep'd directory never
+        // fires. Only `pattern` is excluded (finding 24's actual scope).
+        if let Some(Value::String(p)) = obj.get("path") {
+            out.push(p.clone());
+        }
+    }
+
+    // Bash: extract path-like tokens — words containing `/` or tilde
+    // prefixes. Leaky by design (fail-open): we prefer deterministic-cheap
+    // over exhaustive.
+    if tool_name == "bash"
+        && let Some(Value::String(cmd)) = obj.get("command")
+    {
+        for token in cmd.split_whitespace() {
+            let tok = token.trim_matches(|c| c == '"' || c == '\'' || c == ';' || c == ',');
+            if tok.contains('/') || tok.starts_with('~') {
+                out.push(tok.to_string());
+            }
+        }
+    }
+
+    out.into_iter()
+        .map(|raw| {
+            let expanded = super::error::expand_tilde(&raw);
+            let joined = if expanded.is_absolute() {
+                expanded
+            } else {
+                cwd.join(expanded)
+            };
+            normalize(&joined)
+        })
+        .collect()
+}
+
+/// Compile a frontmatter glob into a matcher.
+///
+/// A glob is not a path, so the resolution is deliberately narrow — and the
+/// narrowness is load-bearing:
+///
+/// 1. a leading `~` expands to the home directory (`~/repo/**`). Without
+///    this the natural Cursor-style form compiles with a literal `~` and can
+///    never match an absolute candidate path: the gate would be silently
+///    inert for exactly the skills that opt in.
+/// 2. a pattern that is absolute, or whose first component starts with a
+///    wildcard (`**/x`, `*/x`, `[ab]/x`), is used VERBATIM. `**/…` is an
+///    *unanchored* "match anywhere" pattern (`**/test` matches
+///    `/one/two/test`); prefixing it with `cwd` pins it to a prefix it can
+///    never satisfy and disarms the gate for every such skill.
+/// 3. any other relative pattern (`src/**`) anchors at the tool's `cwd`,
+///    mirroring how relative candidate paths are resolved — so a
+///    root-relative author intent still matches, instead of failing open.
+/// 4. the result is normalized (`.` / `..` / duplicate separators).
+fn compile_pattern(
+    glob_str: &str,
+    cwd: &std::path::Path,
+) -> Result<glob::Pattern, glob::PatternError> {
+    let expanded = super::error::expand_tilde(glob_str);
+    let anchored = if expanded.is_absolute() || is_wildcard_led(glob_str) {
+        expanded
+    } else {
+        cwd.join(expanded)
+    };
+    glob::Pattern::new(&normalize(&anchored).to_string_lossy())
+}
+
+/// Whether a glob's first path component starts with a wildcard — i.e. the
+/// pattern is anchored nowhere and must match at any depth.
+fn is_wildcard_led(glob_str: &str) -> bool {
+    matches!(glob_str.as_bytes().first(), Some(b'*' | b'?' | b'['))
+}
+/// Normalize a path for matching: resolve `.` / `..` lexically, strip
+/// redundant separators. No filesystem access — purely string-level so
+/// the gate cannot fail on missing paths.
+fn normalize(path: &std::path::Path) -> std::path::PathBuf {
+    let mut out = std::path::PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn skill(globs: &[&str]) -> Skill {
+        let fm = format!(
+            "---\nname: guard-skill\ndescription: gated\nglobs: {}\n---\nBODY-MARKER\n",
+            globs.join(", ")
+        );
+        Skill::parse(
+            "guard-skill",
+            &fm,
+            crate::brain::skills::SkillSource::Builtin,
+        )
+        .unwrap()
+    }
+
+    fn verdict_with_skills(
+        session: Uuid,
+        tool: &str,
+        input: Value,
+        skills: Vec<Skill>,
+        enabled: bool,
+    ) -> GateVerdict {
+        if enabled && !skills.is_empty() && !EXEMPT_TOOLS.contains(&tool) {
+            let candidates = harvest_candidates(tool, &input, std::path::Path::new("/work"));
+            for s in &skills {
+                for g in &s.globs {
+                    let Ok(pattern) = compile_pattern(g, std::path::Path::new("/work")) else {
+                        continue;
+                    };
+                    let options = glob::MatchOptions {
+                        case_sensitive: false,
+                        require_literal_separator: true,
+                        require_literal_leading_dot: false,
+                    };
+                    for c in &candidates {
+                        if pattern.matches_path_with(c, options) {
+                            if seen_skills::seen_since_compaction(session, &s.name) {
+                                return GateVerdict::Pass;
+                            }
+                            return GateVerdict::Block {
+                                skill: s.name.clone(),
+                                matched_path: c.display().to_string(),
+                                body: s.prompt_body(),
+                                globs: s.globs.clone(),
+                            };
+                        }
+                    }
+                }
+            }
+        }
+        GateVerdict::Pass
+    }
+
+    #[test]
+    fn match_blocks_with_body_present() {
+        let s = skill(&["**/skills/guard-skill/**"]);
+        let v = verdict_with_skills(
+            Uuid::new_v4(),
+            "edit_file",
+            json!({"path": "/root/.opencrabs/skills/guard-skill/SKILL.md", "old_text": "a", "new_text": "b"}),
+            vec![s],
+            true,
+        );
+        let GateVerdict::Block {
+            body, matched_path, ..
+        } = v
+        else {
+            panic!("expected Block, got {v:?}");
+        };
+        assert!(body.contains("BODY-MARKER"));
+        assert_eq!(matched_path, "/root/.opencrabs/skills/guard-skill/SKILL.md");
+    }
+
+    #[test]
+    fn seen_skill_passes() {
+        let session = Uuid::new_v4();
+        let s = skill(&["**/guard/**"]);
+        seen_skills::mark_seen(session, "guard-skill");
+        let v = verdict_with_skills(
+            session,
+            "write_file",
+            json!({"path": "/x/guard/file.md", "content": "c"}),
+            vec![s],
+            true,
+        );
+        assert_eq!(v, GateVerdict::Pass);
+    }
+
+    #[test]
+    fn fresh_session_blocks() {
+        let s = skill(&["**/guard/**"]);
+        let v = verdict_with_skills(
+            Uuid::new_v4(),
+            "write_file",
+            json!({"path": "/x/guard/file.md", "content": "c"}),
+            vec![s],
+            true,
+        );
+        assert!(matches!(v, GateVerdict::Block { .. }));
+    }
+
+    #[test]
+    fn exempt_tools_pass() {
+        for tool in EXEMPT_TOOLS {
+            let s = skill(&["**/**"]);
+            let v = verdict_with_skills(
+                Uuid::new_v4(),
+                tool,
+                json!({"path": "/x/guard/file.md"}),
+                vec![s],
+                true,
+            );
+            assert_eq!(v, GateVerdict::Pass, "tool {tool} must be exempt");
+        }
+    }
+
+    #[test]
+    fn bash_command_with_matching_path_blocks() {
+        let s = skill(&["**/secrets/**"]);
+        let v = verdict_with_skills(
+            Uuid::new_v4(),
+            "bash",
+            json!({"command": "cat /etc/secrets/key.pem"}),
+            vec![s],
+            true,
+        );
+        assert!(matches!(v, GateVerdict::Block { .. }));
+    }
+
+    #[test]
+    fn disabled_config_passes() {
+        let s = skill(&["**/guard/**"]);
+        let v = verdict_with_skills(
+            Uuid::new_v4(),
+            "write_file",
+            json!({"path": "/x/guard/file.md", "content": "c"}),
+            vec![s],
+            false,
+        );
+        assert_eq!(v, GateVerdict::Pass);
+    }
+
+    #[test]
+    fn malformed_glob_fails_open() {
+        let s = skill(&["[invalid"]);
+        let v = verdict_with_skills(
+            Uuid::new_v4(),
+            "write_file",
+            json!({"path": "/x/guard/file.md", "content": "c"}),
+            vec![s],
+            true,
+        );
+        assert_eq!(v, GateVerdict::Pass);
+    }
+
+    #[test]
+    fn relative_path_resolves_against_cwd() {
+        let s = skill(&["/work/guard/**"]);
+        let input = json!({"path": "guard/file.md", "content": "c"});
+        let candidates = harvest_candidates("write_file", &input, std::path::Path::new("/work"));
+        assert!(candidates.contains(&std::path::PathBuf::from("/work/guard/file.md")));
+        let v = verdict_with_skills(Uuid::new_v4(), "write_file", input, vec![s], true);
+        assert!(matches!(v, GateVerdict::Block { .. }));
+    }
+
+    #[test]
+    fn star_matches_one_segment_only() {
+        // Cursor table via require_literal_separator: `*` must NOT cross `/`.
+        let s = skill(&["/work/*"]);
+        let v1 = verdict_with_skills(
+            Uuid::new_v4(),
+            "write_file",
+            json!({"path": "/work/file.md", "content": "c"}),
+            vec![s.clone()],
+            true,
+        );
+        assert!(matches!(v1, GateVerdict::Block { .. }));
+        let v2 = verdict_with_skills(
+            Uuid::new_v4(),
+            "write_file",
+            json!({"path": "/work/sub/file.md", "content": "c"}),
+            vec![s],
+            true,
+        );
+        assert_eq!(v2, GateVerdict::Pass);
+    }
+
+    #[test]
+    fn grep_pattern_never_harvested() {
+        let candidates = harvest_candidates(
+            "grep",
+            &json!({"pattern": "/etc/secrets/**", "path": "/tmp/x"}),
+            std::path::Path::new("/work"),
+        );
+        assert_eq!(candidates, vec![std::path::PathBuf::from("/tmp/x")]);
+    }
+
+    #[test]
+    fn tilde_pattern_matches_home_path() {
+        // Regression: the frontmatter form a skill author actually writes
+        // (`~/repo/**`) must match — it must not compile to a literal `~`.
+        let s = skill(&["~/guard/**"]);
+        let v = verdict_with_skills(
+            Uuid::new_v4(),
+            "write_file",
+            json!({"path": "~/guard/file.md", "content": "c"}),
+            vec![s],
+            true,
+        );
+        let GateVerdict::Block { matched_path, .. } = v else {
+            panic!("expected Block for a `~/...` glob, got {v:?}");
+        };
+        let home = super::super::error::expand_tilde("~");
+        assert_eq!(
+            matched_path,
+            home.join("guard").join("file.md").display().to_string()
+        );
+    }
+
+    #[test]
+    fn relative_pattern_resolves_against_cwd() {
+        // A bare relative pattern (`guard/**`) resolves against the tool cwd,
+        // mirroring how candidate paths are resolved.
+        let s = skill(&["guard/**"]);
+        let v = verdict_with_skills(
+            Uuid::new_v4(),
+            "write_file",
+            json!({"path": "guard/file.md", "content": "c"}),
+            vec![s],
+            true,
+        );
+        assert!(matches!(v, GateVerdict::Block { .. }));
+    }
+}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1349,6 +1349,14 @@ pub struct AgentConfig {
     #[serde(default = "default_background_compaction")]
     pub background_compaction: bool,
 
+    /// Skill glob gate master switch (issue #150). **On by default.**
+    /// When a skill declares `globs:` frontmatter, tool calls touching a
+    /// matching path are rejected until the skill body is loaded in the
+    /// current session context (fresh sessions AND post-compaction).
+    /// Per-skill opt-out: delete the skill's `globs` key.
+    #[serde(default = "default_skill_glob_gate")]
+    pub skill_glob_gate: bool,
+
     /// Lazy tool-schema loading. **On by default.** A request ships only the
     /// CORE tool schemas (~4k tokens) plus `tool_search`, instead of all ~95
     /// (~20k counted in every request's input); the agent calls `tool_search`
@@ -1411,6 +1419,10 @@ impl AgentConfig {
 }
 
 fn default_background_compaction() -> bool {
+    true
+}
+
+fn default_skill_glob_gate() -> bool {
     true
 }
 
@@ -1510,6 +1522,7 @@ impl Default for AgentConfig {
             default_model: None,
             silent_compaction: false,
             background_compaction: default_background_compaction(),
+            skill_glob_gate: default_skill_glob_gate(),
             lazy_tools: default_lazy_tools(),
             redact_sensitive_data: default_redact_sensitive_data(),
             redact_group: None,

--- a/src/docs/reference/templates/TOOLS.md
+++ b/src/docs/reference/templates/TOOLS.md
@@ -31,11 +31,7 @@ never assume the capability is missing before searching.
 
 ## What belongs here
 
-- Skill pointers (what/where to load on demand)
-- Commands vs Tools vs Skills distinction
-- Profile-aware paths
-- Custom routing rules specific to your setup
-
+Skill pointers, command/tool/skill distinction, profile-aware paths, custom routing rules.
 
 ## Skills (load on demand)
 
@@ -52,11 +48,20 @@ never assume the capability is missing before searching.
 
 ## Commands vs Tools vs Skills
 
-| Concept | What it is | Example |
-|---------|-----------|---------|
-| Tool | A function the agent calls directly | `bash`, `read_file`, `grep` |
-| Command | A slash shortcut defined in commands.toml | `/check`, `/rebuild`, `/status` |
-| Skill | A workflow template loaded on demand | `/browser-cdp`, `/channels` |
+Tool = function the agent calls (`bash`, `grep`); command = slash shortcut in commands.toml (`/check`); skill = workflow template loaded on demand (`/browser-cdp`).
+
+## Skill `globs:` frontmatter (path-scoped skill gate, #150)
+
+A `SKILL.md` may declare `globs:` so its topic is ENFORCED, not advisory: a tool call referencing a matching path is rejected (with the full skill body in the rejection) when the skill body is not in the current session context (fresh session or after compaction); the identical retry succeeds. Accepted forms — Cursor comma-string `globs: a/**, b.md`, inline flow `globs: [a/**, b.md]`, block list — quotes stripped; `metadata.globs` is ignored.
+
+- **Opt-in per skill:** no `globs` key = invisible to the gate; built-ins ship glob-less.
+- **Match:** case-insensitive against the normalized ABSOLUTE candidate path; `*` = one segment, `**` = recursive — write `**/` prefixes.
+- **Pattern resolution (narrow by design):** a leading `~` expands to the home directory; a WILDCARD-LED pattern (`**/x`, `*/x`, `[ab]/x`) is UNANCHORED and used verbatim, matching at any depth — never prefix it with a path, or the skill is silently disarmed; any other relative pattern anchors at the tool cwd; the result is normalized.
+- **Harvested:** `path`/`file_path`/`filePath` + path-like tokens in bash `command`; `grep`/`glob` tool `pattern`s never are.
+- **Exempt (recovery) tools:** `load_brain_file`, `read_file`, `slash_command`, `session_search`, `tool_search`, `write_opencrabs_file`, `execute_code` — a blocked agent must be able to re-arm itself.
+- **Sub-agents:** gated too (shared registry path) — one extra blocked round-trip per matching skill per fresh sub-agent.
+- **Fail-open law:** any gate-internal error passes the call through; malformed globs WARN once and are skipped.
+- **Master switch:** `[agent] skill_glob_gate = true` (default) in config.toml.
 
 ## Build & Runtime Commands
 
@@ -67,7 +72,7 @@ never assume the capability is missing before searching.
 
 ## Scheduling (Cron)
 
-Manage scheduled jobs with the **`cron_manage`** tool (`action`: create / list / delete / enable / disable / test). Jobs run in **isolated sessions on your configured provider/model by default** — omit `provider`/`model` for the default; set `thinking: off` for routine jobs; use `deliver_to` only to send results to a channel.
+Manage scheduled jobs with the **`cron_manage`** tool (`action`: create/list/delete/enable/disable/test). Jobs run in isolated sessions on your configured provider/model by default; set `thinking: off` for routine jobs; `deliver_to` sends results to a channel.
 
 **Cron expression format (the common trap):** 5 fields `min hour dom mon dow`. Day-of-week is **1-7 = Sun-Sat** (1=Sunday, 7=Saturday; `0` is invalid) — **use day names** (`Mon-Fri`, `Sun`) instead of numbers. No `@daily`/`@hourly` macros. Set `tz` (IANA, e.g. `America/New_York`) and the job runs in that zone's local time, DST-aware. **Validate before you confirm:** `create` echoes the next run times — read them back; a wrong day-of-week parses fine but the next-run list exposes it. Fix and recreate before telling the user it's set.
 
@@ -75,16 +80,11 @@ Manage scheduled jobs with the **`cron_manage`** tool (`action`: create / list /
 
 STT providers: `voicebox` (local server) > `openai_compatible` > `groq` (Whisper API) > `local` (rwhisper, `local-stt` feature). Override with `stt_fallback_chain`.
 TTS providers: `voicebox` (local server) > `openai_compatible` > `openai` (OpenAI TTS) > `local` (Piper, `local-tts` feature). Override with `tts_fallback_chain`.
-Config: `[providers.stt.*]` / `[providers.tts.*]` in config.toml. Piper voices: `ryan`(default), `amy`, `lessac`, `kristin`, `joe`, `cori`. Local STT presets: `local-tiny`(42MB), `local-base`(142MB), `local-small`(466MB), `local-medium`(1.5GB).
-Audio: all output OGG/Opus via ffmpeg. Models: whisper in `~/.local/share/opencrabs/models/whisper/`, piper in `~/.local/share/opencrabs/models/piper/`. Setup: `/onboard:voice`.
+Config: `[providers.stt.*]` / `[providers.tts.*]`. Piper voices: `ryan`(default), `amy`, `lessac`, `kristin`, `joe`, `cori`. Local STT presets: `local-tiny`(42MB)…`local-medium`(1.5GB). Audio: OGG/Opus via ffmpeg. Models: `~/.local/share/opencrabs/models/{whisper,piper}/`. Setup: `/onboard:voice`.
 
 ## Reporting
 
-- `/mission-control`: analytics (tool usage, failure rates, RSI improvements, brain files), activity feed, inbox proposals, and scheduled cron jobs.
-  Works in the TUI (opens the Mission Control Analytics panel) and in every
-  channel (returns the report as a message). The same data is also available as
-  the `mission_control_report` agent tool, so you can ask in plain language (for
-  example "send me my analytics") and the agent ships the report to the chat.
+- `/mission-control`: analytics (tool usage, failure rates, RSI improvements, brain files), activity feed, inbox proposals, scheduled cron jobs. Works in the TUI and every channel; also available as the `mission_control_report` agent tool ("send me my analytics").
 
 ## Profile-Aware Paths
 

--- a/src/tests/brain_tools_registry_test.rs
+++ b/src/tests/brain_tools_registry_test.rs
@@ -309,3 +309,72 @@ fn halts_turn_false_for_unknown_tool() {
     let registry = ToolRegistry::new();
     assert!(!registry.halts_turn("does_not_exist"));
 }
+
+// --- skill glob gate wiring (issue #150) ---
+
+/// End-to-end config toggle: with a real SKILL.md (globs declared) in a
+/// temp home's skills dir, `skill_glob_gate = true` blocks the first
+/// matching call (body in the rejection) and arms the identical retry
+/// (B1); `false` passes straight through.
+#[tokio::test]
+async fn skill_gate_config_toggle_end_to_end() {
+    use crate::config::profile::with_home_override_async;
+
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let skills_dir = tmp.path().join("skills").join("gate-probe");
+    std::fs::create_dir_all(&skills_dir).expect("mkdir");
+    std::fs::write(
+        skills_dir.join("SKILL.md"),
+        "---\nname: gate-probe\ndescription: probe\nglobs: **/gate-probe/**\n---\nGATE-PROBE-BODY\n",
+    )
+    .expect("write skill");
+
+    with_home_override_async(tmp.path().to_path_buf(), async {
+        crate::brain::skills::invalidate_globs_cache();
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(MockTool {
+            name: "write_file".to_string(),
+            requires_approval: false,
+        }));
+
+        let session = Uuid::new_v4();
+        let context = ToolExecutionContext::new(session);
+        let input = serde_json::json!({
+            "path": format!("{}/gate-probe/inner/file.md", tmp.path().display()),
+            "content": "x"
+        });
+
+        // Enabled (default): first call rejected with the body.
+        let blocked = registry
+            .execute("write_file", input.clone(), &context)
+            .await
+            .expect("execute");
+        let err_text = blocked.error.as_deref().unwrap_or(&blocked.output);
+        assert!(
+            err_text.contains("[SKILL GATE]") && err_text.contains("GATE-PROBE-BODY"),
+            "enabled gate must reject with the body, got: {}",
+            &err_text[..err_text.len().min(200)]
+        );
+        // Identical retry passes (mark_seen armed it — B1).
+        let retried = registry
+            .execute("write_file", input.clone(), &context)
+            .await
+            .expect("execute");
+        assert!(retried.success, "identical retry after the gate must pass");
+
+        // Disabled: the SAME call (fresh session, never seen) passes.
+        registry.set_skill_gate_enabled(false);
+        let fresh = Uuid::new_v4();
+        let ctx2 = ToolExecutionContext::new(fresh);
+        let passed = registry
+            .execute("write_file", input, &ctx2)
+            .await
+            .expect("execute");
+        let ptxt = passed.error.as_deref().unwrap_or(&passed.output);
+        assert!(
+            !ptxt.contains("[SKILL GATE]"),
+            "disabled gate must never emit a [SKILL GATE] rejection"
+        );
+    })
+    .await;
+}

--- a/src/tests/channel_user_command_owner_gate_test.rs
+++ b/src/tests/channel_user_command_owner_gate_test.rs
@@ -46,6 +46,7 @@ fn audit_skill() -> Skill {
         slash_name: "/security-audit".to_string(),
         description: "Audit the repo".to_string(),
         body: "Run a full security audit and report findings.".to_string(),
+        globs: Vec::new(),
         review_gate: false,
         source: SkillSource::User,
     }

--- a/src/tests/skill_slash_dispatch_test.rs
+++ b/src/tests/skill_slash_dispatch_test.rs
@@ -17,6 +17,7 @@ fn skill(name: &str, body: &str) -> Skill {
         slash_name: format!("/{name}"),
         description: format!("test skill {name}"),
         body: body.to_string(),
+        globs: Vec::new(),
         review_gate: false,
         source: SkillSource::Builtin,
     }
@@ -102,6 +103,7 @@ fn review_gated_skill_dispatch_prepends_reminder() {
         slash_name: "/drop-release".to_string(),
         description: "gated release flow".to_string(),
         body: "Draft the release.".to_string(),
+        globs: Vec::new(),
         review_gate: true,
         source: crate::brain::skills::SkillSource::User,
     };

--- a/src/tests/skills_dialog_test.rs
+++ b/src/tests/skills_dialog_test.rs
@@ -15,6 +15,7 @@ fn skill(name: &str, description: &str, body: &str, source: SkillSource) -> Skil
         slash_name: format!("/{name}"),
         description: description.to_string(),
         body: body.to_string(),
+        globs: Vec::new(),
         review_gate: false,
         source,
     }

--- a/src/tests/skills_test.rs
+++ b/src/tests/skills_test.rs
@@ -1,7 +1,7 @@
 //! Tests for the skill loader — frontmatter parsing, built-in registry,
 //! and user-directory overlay.
 
-use crate::brain::skills::{Skill, SkillSource, load_all_skills, resolve_skill};
+use crate::brain::skills::{load_all_skills, resolve_skill, Skill, SkillSource};
 
 #[test]
 fn parses_minimal_frontmatter() {
@@ -271,4 +271,66 @@ fn every_shipped_skill_template_is_registered_as_a_builtin() {
              so it reaches no user. BUILTIN_SKILLS: {names:?}"
         );
     }
+}
+
+// --- globs frontmatter (issue #150) ---
+
+#[test]
+fn globs_comma_string_form() {
+    let raw =
+        "---\nname: foo\ndescription: d\nglobs: skills/opencrabs-dev/**, README.md\n---\nBody.\n";
+    let skill = Skill::parse("foo", raw, SkillSource::Builtin).unwrap();
+    assert_eq!(skill.globs, vec!["skills/opencrabs-dev/**", "README.md"]);
+}
+
+#[test]
+fn globs_inline_flow_form() {
+    let raw = "---\nname: foo\ndescription: d\nglobs: [a/**, b.md]\n---\nBody.\n";
+    let skill = Skill::parse("foo", raw, SkillSource::Builtin).unwrap();
+    assert_eq!(skill.globs, vec!["a/**", "b.md"]);
+}
+
+#[test]
+fn globs_block_list_form() {
+    let raw = "---\nname: foo\ndescription: d\nglobs:\n  - one/**\n  - \"two.md\"\n  - 'three.md'\n---\nBody.\n";
+    let skill = Skill::parse("foo", raw, SkillSource::Builtin).unwrap();
+    assert_eq!(skill.globs, vec!["one/**", "two.md", "three.md"]);
+}
+
+#[test]
+fn globs_quotes_stripped_comma_string() {
+    let raw = "---\nname: foo\ndescription: d\nglobs: \"a/**\", 'b.md'\n---\nBody.\n";
+    let skill = Skill::parse("foo", raw, SkillSource::Builtin).unwrap();
+    assert_eq!(skill.globs, vec!["a/**", "b.md"]);
+}
+
+#[test]
+fn globs_empty_when_absent() {
+    let raw = "---\nname: foo\ndescription: d\n---\nBody.\n";
+    let skill = Skill::parse("foo", raw, SkillSource::Builtin).unwrap();
+    assert!(skill.globs.is_empty());
+}
+
+#[test]
+fn globs_nested_metadata_ignored() {
+    // A nested `metadata:` block is an unknown-key region for the
+    // top-level parser; its `globs:` line must NOT be picked up.
+    let raw = "---\nname: foo\ndescription: d\nmetadata:\n  globs: nested/**\n---\nBody.\n";
+    let skill = Skill::parse("foo", raw, SkillSource::Builtin).unwrap();
+    assert!(skill.globs.is_empty());
+}
+
+#[test]
+fn globs_block_list_closed_by_next_key() {
+    let raw = "---\nname: foo\ndescription: d\nglobs:\n  - a/**\nreview_gate: true\n---\nBody.\n";
+    let skill = Skill::parse("foo", raw, SkillSource::Builtin).unwrap();
+    assert_eq!(skill.globs, vec!["a/**"]);
+    assert!(skill.review_gate);
+}
+
+#[test]
+fn globs_empty_items_skipped() {
+    let raw = "---\nname: foo\ndescription: d\nglobs: a/**, , b.md,\n---\nBody.\n";
+    let skill = Skill::parse("foo", raw, SkillSource::Builtin).unwrap();
+    assert_eq!(skill.globs, vec!["a/**", "b.md"]);
 }


### PR DESCRIPTION
## Summary
- Parse `globs:` frontmatter field in `SKILL.md` (supports comma-separated string, inline flow list, or block list)
- In-memory `seen_skills` epoch-tracked registry with compaction hooks
- Skill glob gate checking tool execution targets against matching glob patterns
- Fail-open semantics with full skill body in rejection and instant unblocking on identical retry
- Config master switch `[agent] skill_glob_gate` (defaults to true)

## Verification
- CI gate run: https://github.com/leshchenko1979/opencrabs/actions/runs/34639034093 (PASS)
- Behavioral probe: live rejection on gated target path, immediate retry unblock, and persistent `seen_skills` epoch across turns verified on running ops daemon.

Fork-Issue: https://github.com/leshchenko1979/opencrabs/issues/150