### PR TITLE
feat(brain): temporal grounding via turn ingress dual-time markers and user timezone resolution

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -450,6 +450,12 @@ debug_logs = false
 # Set to 0 to disable. Hot-reloads with no restart.
 thinking_loop_timeout_secs = 600
 
+# Cadence (in seconds) for injecting periodic wall-clock notices during
+# long-running tool execution turns. Keeps autonomous multi-step loops
+# grounded without stale time drift or prompt-cache busting. Default: 900 (15 min).
+# Set to 0 to disable intra-turn periodic markers while retaining turn-ingress time.
+time_marker_interval_secs = 900
+
 [image.generation]
 enabled = false
 model = "gemini-3.1-flash-image-preview"   # Gemini image-gen model ("Nano Banana")

--- a/src/brain/agent/service/builder.rs
+++ b/src/brain/agent/service/builder.rs
@@ -736,6 +736,13 @@ impl AgentService {
         self.brain_rebuild.clone()
     }
 
+    /// The root workspace path for brain files, if a brain rebuild handle is wired.
+    pub fn brain_workspace_path(&self) -> Option<std::path::PathBuf> {
+        self.brain_rebuild
+            .as_ref()
+            .map(|r| r.inner.loader.workspace_path().to_path_buf())
+    }
+
     /// The system brain to send THIS turn. Rebuilds from disk when a brain
     /// file changed (#213); otherwise returns the cached/static brain. This is
     /// the single source of truth for the prompt — `default_system_brain` is

--- a/src/brain/agent/service/context.rs
+++ b/src/brain/agent/service/context.rs
@@ -27,11 +27,34 @@ impl AgentService {
     /// only the reminder, and the two blocks were otherwise identical. Whether
     /// memory surfaced therefore depended on which code path a session took,
     /// which is not a property of the memory.
-    pub(super) async fn augment_user_message(session_id: Uuid, user_message: &str) -> String {
-        let mut out = match Self::active_plan_reminder(session_id).await {
-            Some(reminder) => format!("{user_message}\n\n{reminder}"),
-            None => user_message.to_string(),
+    /// Augment the user message for LLM context:
+    /// 1. Temporal grounding: inject [Current time: YYYY-MM-DD HH:MM:SS UTC (user: ...)] (#153).
+    /// 2. Active plan reminder.
+    /// 3. Memory recall.
+    pub(super) async fn augment_user_message(
+        session_id: Uuid,
+        user_message: &str,
+        brain_dir: Option<&std::path::Path>,
+    ) -> String {
+        // Temporal grounding (#153): inject context-only time marker at turn start.
+        let now = chrono::Utc::now();
+        let tz_info = brain_dir
+            .and_then(|dir| crate::brain::timezone::GLOBAL_TZ_CACHE.resolve_from_brain_dir(dir));
+        let time_marker = match tz_info {
+            Some(ref info) => format!("[Current time: {}]", info.format_dual_time(&now)),
+            None => format!(
+                "[Current time: {}]",
+                crate::brain::timezone::format_utc_time(&now)
+            ),
         };
+
+        let mut out = format!("{time_marker}\n\n{user_message}");
+
+        if let Some(reminder) = Self::active_plan_reminder(session_id).await {
+            out.push_str("\n\n");
+            out.push_str(&reminder);
+        }
+
         // Ride relevant memory along with the message (#799). MEMORY.md was
         // written constantly and read almost never; #800 made reading cheap,
         // but a cheap read still has to be chosen, and the model cannot decide
@@ -139,7 +162,9 @@ impl AgentService {
         // recency window in a long conversation and the model forgets it was
         // mid-plan (discussion #177). Regenerated each turn from the plan file;
         // the DB only ever stores the clean user message, so it never piles up.
-        let context_user_message = Self::augment_user_message(session_id, &user_message).await;
+        let brain_dir = self.brain_workspace_path();
+        let context_user_message =
+            Self::augment_user_message(session_id, &user_message, brain_dir.as_deref()).await;
         let user_msg = Message::user(context_user_message);
         context.add_message(user_msg);
 
@@ -1249,4 +1274,36 @@ pub(crate) fn format_plan_reminder(plan: &crate::tui::plan::PlanDocument) -> Opt
         }
     }
     Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn augment_user_message_injects_time_marker() {
+        let dir = TempDir::new().unwrap();
+        let user_md = dir.path().join("USER.md");
+        fs::write(&user_md, "Timezone: UTC+3 (MSK)\n").unwrap();
+
+        let session_id = Uuid::new_v4();
+        let augmented =
+            AgentService::augment_user_message(session_id, "hello world", Some(dir.path())).await;
+        assert!(augmented.contains("[Current time:"));
+        assert!(augmented.contains("UTC"));
+        assert!(augmented.contains("MSK"));
+        assert!(augmented.ends_with("hello world"));
+    }
+
+    #[tokio::test]
+    async fn augment_user_message_falls_back_to_utc() {
+        let session_id = Uuid::new_v4();
+        let augmented = AgentService::augment_user_message(session_id, "test message", None).await;
+        assert!(augmented.contains("[Current time:"));
+        assert!(augmented.contains("UTC"));
+        assert!(!augmented.contains("(user:"));
+        assert!(augmented.ends_with("test message"));
+    }
 }

--- a/src/brain/agent/service/context.rs
+++ b/src/brain/agent/service/context.rs
@@ -31,7 +31,7 @@ impl AgentService {
     /// 1. Temporal grounding: inject [Current time: YYYY-MM-DD HH:MM:SS UTC (user: ...)] (#153).
     /// 2. Active plan reminder.
     /// 3. Memory recall.
-    pub(super) async fn augment_user_message(
+    pub(crate) async fn augment_user_message(
         session_id: Uuid,
         user_message: &str,
         brain_dir: Option<&std::path::Path>,

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -19,6 +19,34 @@ use uuid::Uuid;
 /// times consecutively successfully, the 4th it sticks".
 const STICKY_FALLBACK_THRESHOLD: u32 = 4;
 
+/// Default interval in seconds between mid-turn intra-loop time markers (#153).
+pub const DEFAULT_TIME_MARKER_INTERVAL_SECS: u64 = 900;
+
+/// Check whether the intra-turn elapsed time warrants injecting a new time notice (#153).
+/// Returns `Some((notice_string, now))` if the interval has passed, or `None`.
+pub(crate) fn check_intra_turn_time_marker(
+    last_marker: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+    interval_secs: u64,
+    brain_dir: Option<&std::path::Path>,
+) -> Option<(String, chrono::DateTime<chrono::Utc>)> {
+    if interval_secs == 0 {
+        return None;
+    }
+    let elapsed = (now - last_marker).num_seconds();
+    if elapsed >= interval_secs as i64 {
+        let tz_info = brain_dir
+            .and_then(|dir| crate::brain::timezone::GLOBAL_TZ_CACHE.resolve_from_brain_dir(dir));
+        let time_str = match tz_info {
+            Some(ref info) => info.format_dual_time(&now),
+            None => crate::brain::timezone::format_utc_time(&now),
+        };
+        Some((format!("[System: Current time: {time_str}]"), now))
+    } else {
+        None
+    }
+}
+
 /// True when a provider's reported `input_tokens` is implausibly larger than
 /// the real content size (system + messages + tool schemas) — the signature of
 /// an OVER-REPORTING endpoint. The zhipu "coding" endpoint was observed adding
@@ -1508,6 +1536,11 @@ impl AgentService {
         // approval waits are part of that answer. Monotonic, so it is immune
         // to clock adjustments mid-turn.
         let turn_started_at = std::time::Instant::now();
+        // Last time marker timestamp for intra-turn periodic time notice (#153).
+        let mut last_time_marker = chrono::Utc::now();
+        let time_marker_interval_secs = crate::config::Config::current()
+            .agent
+            .time_marker_interval_secs;
         let mut total_input_tokens = 0u32;
         let mut total_output_tokens = 0u32;
         let mut total_cache_creation = 0u32;
@@ -7317,6 +7350,20 @@ impl AgentService {
             }
             if has_progress_override && let Some(ref cb) = self.progress_callback {
                 cb(session_id, ProgressEvent::TokenCount(context.token_count));
+            }
+
+            // Intra-turn periodic time marker (#153): inject current wall-clock
+            // notice strictly AFTER tool results and repeat verdict, but BEFORE
+            // compaction checks or next assistant generation, if >= interval elapsed.
+            if let Some((notice, updated_time)) = check_intra_turn_time_marker(
+                last_time_marker,
+                chrono::Utc::now(),
+                time_marker_interval_secs,
+                brain_dir.as_deref(),
+            ) {
+                tracing::info!("Injecting mid-turn time notice into context: {notice}");
+                context.add_message(Message::user(notice));
+                last_time_marker = updated_time;
             }
 
             // Enforce 65% budget after tool results. Skip ONLY when the CLI

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -1210,7 +1210,9 @@ impl AgentService {
         // still stores the clean `user_message` below (persistence uses it
         // directly), so the reminder is context-only and never piles up (#571
         // follow-up).
-        let context_user_message = Self::augment_user_message(session_id, &user_message).await;
+        let brain_dir = self.brain_workspace_path();
+        let context_user_message =
+            Self::augment_user_message(session_id, &user_message, brain_dir.as_deref()).await;
         let user_msg = Self::build_user_message(&context_user_message);
         context.add_message(user_msg);
 

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -33,6 +33,7 @@ pub mod rsi_sync;
 pub mod section_rank;
 pub mod self_update;
 pub mod skills;
+pub mod timezone;
 pub mod tokenizer;
 pub mod toml_merge;
 pub mod tools;

--- a/src/brain/prompt_builder.rs
+++ b/src/brain/prompt_builder.rs
@@ -3,7 +3,7 @@
 //! Reads workspace markdown files and assembles the system brain dynamically
 //! each turn, so edits to brain files take effect immediately.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Core brain files — always injected (user context).
 ///

--- a/src/brain/prompt_builder.rs
+++ b/src/brain/prompt_builder.rs
@@ -289,6 +289,11 @@ impl BrainLoader {
         Self { workspace_path }
     }
 
+    /// The root workspace path for brain files.
+    pub fn workspace_path(&self) -> &Path {
+        &self.workspace_path
+    }
+
     /// Latest modification time across the brain markdown files at the
     /// workspace root (SOUL.md, USER.md, AGENTS.md, MEMORY.md, …) — the
     /// files that feed the system brain. Cheap: stats `*.md` dir entries,

--- a/src/brain/prompt_builder.rs
+++ b/src/brain/prompt_builder.rs
@@ -697,8 +697,8 @@ pub const RUNTIME_INFO_HEADER: &str = "--- Runtime Info ---";
 /// Returns `(stable_prefix, Some(runtime_block))` when the block is present,
 /// else `(brain, None)`. The suffix runs from [`RUNTIME_INFO_HEADER`] to the
 /// FIRST blank line after it — which, by construction of [`push_runtime_info`],
-/// falls right after the `Current date & time` line (the volatile PER-SESSION
-/// lines: model / provider / working directory / home / date-time). The blank
+/// falls right after the `Current date` line (the volatile PER-SESSION
+/// lines: model / provider / working directory / home / date). The blank
 /// line is emitted by `push_known_paths`'s leading newline, so everything from
 /// `Known paths` onward — the profile home and compiled features, which are
 /// per-INSTANCE constant, not per-session — stays in the CACHED prefix. That is
@@ -870,13 +870,14 @@ fn push_runtime_info(prompt: &mut String, runtime_info: Option<&RuntimeInfo>) {
         env!("CARGO_PKG_VERSION")
     ));
     prompt.push_str(&format!("OS: {}\n", std::env::consts::OS));
-    // Full timestamp (date AND time). #657 dropped time-of-day to keep the
-    // cached prefix stable, but #658 moved this whole block into the UNCACHED
-    // runtime suffix, so a per-second value no longer invalidates the cache —
-    // restore time-of-day awareness (#681).
+    // Date-only timestamp (YYYY-MM-DD (UTC)). Per #693, the system prompt is
+    // sent as a single string (system_suffix = None) across all providers to
+    // keep tool-calling reliable. Placing second-granular time here busts prefix
+    // caching across turns. Moving live time-of-day awareness to message-tail
+    // markers (#153) allows the system prompt to stay byte-stable for 24 hours.
     prompt.push_str(&format!(
-        "Current date & time: {} UTC\n",
-        chrono::Utc::now().format("%Y-%m-%d %H:%M:%S")
+        "Current date: {} (UTC)\n",
+        chrono::Utc::now().format("%Y-%m-%d")
     ));
     push_known_paths(prompt);
     push_compiled_features(prompt);

--- a/src/brain/timezone.rs
+++ b/src/brain/timezone.rs
@@ -8,9 +8,10 @@
 
 use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
+use once_cell::sync::Lazy;
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::path::Path;
+use std::sync::Mutex;
 use std::time::SystemTime;
 
 /// Resolved timezone info with display label.
@@ -285,10 +286,8 @@ impl UserTimezoneCache {
     }
 }
 
-lazy_static::lazy_static! {
-    /// Process-wide singleton cache for user timezone.
-    pub static ref GLOBAL_TZ_CACHE: UserTimezoneCache = UserTimezoneCache::new();
-}
+/// Process-wide singleton cache for user timezone.
+pub static GLOBAL_TZ_CACHE: Lazy<UserTimezoneCache> = Lazy::new(UserTimezoneCache::new);
 
 #[cfg(test)]
 mod tests {

--- a/src/brain/timezone.rs
+++ b/src/brain/timezone.rs
@@ -50,10 +50,7 @@ pub fn format_utc_time(dt: &DateTime<Utc>) -> String {
 /// - `Timezone: America/New_York`
 pub fn parse_timezone_heuristic(text: &str) -> Option<TzInfo> {
     for line in text.lines() {
-        let line_clean = line
-            .trim()
-            .trim_start_matches(|c| c == '-' || c == '*' || c == '#')
-            .trim();
+        let line_clean = line.trim().trim_start_matches(['-', '*', '#']).trim();
         let lower = line_clean.to_lowercase();
 
         let is_tz_line = lower.starts_with("timezone:")
@@ -165,7 +162,7 @@ fn parse_utc_offset_or_iana(s: &str) -> Option<Tz> {
     let hours_str = sign_and_num.1.split(':').next()?.trim();
     let hours: i32 = hours_str.parse().ok()?;
 
-    if hours > 14 || hours < 0 {
+    if !(0..=14).contains(&hours) {
         return None;
     }
 
@@ -241,10 +238,11 @@ impl UserTimezoneCache {
 
         {
             let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-            if let Some(ref entry) = *guard {
-                if entry.mtime == current_mtime && entry.file_len == current_len {
-                    return entry.resolved.clone();
-                }
+            if let Some(ref entry) = *guard
+                && entry.mtime == current_mtime
+                && entry.file_len == current_len
+            {
+                return entry.resolved.clone();
             }
         }
 
@@ -352,7 +350,7 @@ Timezone: Europe/Paris
     #[test]
     fn test_caching_and_invalidation() {
         let mut tmp = NamedTempFile::new().unwrap();
-        write!(tmp, "Timezone: UTC+2 (EET)\n").unwrap();
+        writeln!(tmp, "Timezone: UTC+2 (EET)").unwrap();
         tmp.flush().unwrap();
 
         let cache = UserTimezoneCache::new();
@@ -366,7 +364,7 @@ Timezone: Europe/Paris
             .truncate(true)
             .open(tmp.path())
             .unwrap();
-        write!(file, "Timezone: UTC+7 (NOVT)\n").unwrap();
+        writeln!(file, "Timezone: UTC+7 (NOVT)").unwrap();
         file.flush().unwrap();
 
         let res2 = cache.resolve_from_file(tmp.path()).expect("second resolve");

--- a/src/brain/timezone.rs
+++ b/src/brain/timezone.rs
@@ -1,0 +1,389 @@
+//! User timezone resolution and caching (#153).
+//!
+//! Provides temporal grounding for agents by parsing user-preferred timezones
+//! from `USER.md` (e.g. `Timezone: UTC+3 (MSK)` or `Europe/Paris`) and caching
+//! the resolved [`chrono_tz::Tz`]. Keyed on `USER.md` mtime and content hash
+//! to avoid disk/LLM overhead on subsequent turns while invalidating automatically
+//! when `USER.md` is modified.
+
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+/// Resolved timezone info with display label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TzInfo {
+    pub tz: Tz,
+    pub label: Option<String>,
+}
+
+impl TzInfo {
+    pub fn new(tz: Tz, label: Option<String>) -> Self {
+        Self { tz, label }
+    }
+
+    /// Format a UTC timestamp into dual UTC + local representation:
+    /// `YYYY-MM-DD HH:MM:SS UTC (user: HH:MM:SS TZ)`
+    pub fn format_dual_time(&self, dt: &DateTime<Utc>) -> String {
+        let utc_str = dt.format("%Y-%m-%d %H:%M:%S UTC");
+        let local_dt = dt.with_timezone(&self.tz);
+        let tz_label = self.label.as_deref().unwrap_or_else(|| self.tz.name());
+        let local_str = local_dt.format("%H:%M:%S");
+        format!("{utc_str} (user: {local_str} {tz_label})")
+    }
+}
+
+/// Format UTC-only time marker string.
+pub fn format_utc_time(dt: &DateTime<Utc>) -> String {
+    format!("{} UTC", dt.format("%Y-%m-%d %H:%M:%S"))
+}
+
+/// Tier 1: Fast synchronous parser for timezone declarations in text (USER.md).
+/// Matches common formats:
+/// - `Timezone: UTC+3 (MSK)` / `Timezone: UTC-5 (EST)`
+/// - `Timezone: Europe/Moscow`
+/// - `Часовой пояс: UTC+3 (MSK)` / `Часовой пояс: Москва (UTC+3)`
+/// - `Timezone: America/New_York`
+pub fn parse_timezone_heuristic(text: &str) -> Option<TzInfo> {
+    for line in text.lines() {
+        let line_clean = line
+            .trim()
+            .trim_start_matches(|c| c == '-' || c == '*' || c == '#')
+            .trim();
+        let lower = line_clean.to_lowercase();
+
+        let is_tz_line = lower.starts_with("timezone:")
+            || lower.starts_with("timezone :")
+            || lower.starts_with("часовой пояс:")
+            || lower.starts_with("часовой пояс :");
+
+        if !is_tz_line
+            && !line_clean.starts_with("**Timezone:**")
+            && !line_clean.starts_with("**Часовой пояс:**")
+        {
+            continue;
+        }
+
+        // Extract the value after colon
+        let Some((_, val_part)) = line_clean.split_once(':') else {
+            continue;
+        };
+        let val = val_part
+            .trim()
+            .trim_matches(|c| c == '*' || c == '`' || c == '"' || c == '\'')
+            .trim();
+
+        if let Some(info) = parse_tz_value(val) {
+            return Some(info);
+        }
+    }
+
+    // Secondary scan: check if any standalone line contains an explicit IANA or UTC offset pattern
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.contains("Europe/") || trimmed.contains("America/") || trimmed.contains("Asia/")
+        {
+            for word in trimmed.split_whitespace() {
+                let clean_word = word.trim_matches(|c| {
+                    c == '(' || c == ')' || c == '[' || c == ']' || c == '`' || c == ',' || c == '.'
+                });
+                if let Ok(tz) = clean_word.parse::<Tz>() {
+                    return Some(TzInfo::new(tz, None));
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Parse a timezone value string into TzInfo.
+fn parse_tz_value(val: &str) -> Option<TzInfo> {
+    // Check for "UTC+3 (MSK)" or "UTC-5 (EST)"
+    if let Some((utc_part, rest)) = val.split_once('(') {
+        let label = rest.trim_end_matches(')').trim().to_string();
+        let tz_candidate = utc_part.trim();
+        if let Some(tz) = parse_utc_offset_or_iana(tz_candidate) {
+            return Some(TzInfo::new(
+                tz,
+                if label.is_empty() { None } else { Some(label) },
+            ));
+        }
+        // Maybe format is "Москва (UTC+3)"
+        let inner = rest.trim_end_matches(')').trim();
+        if let Some(tz) = parse_utc_offset_or_iana(inner) {
+            let outer_label = utc_part.trim().to_string();
+            return Some(TzInfo::new(
+                tz,
+                if outer_label.is_empty() {
+                    None
+                } else {
+                    Some(outer_label)
+                },
+            ));
+        }
+    }
+
+    // Direct IANA parse, e.g. "Europe/Paris"
+    if let Ok(tz) = val.parse::<Tz>() {
+        return Some(TzInfo::new(tz, None));
+    }
+
+    // Direct UTC offset parse, e.g. "UTC+3" or "+03:00"
+    if let Some(tz) = parse_utc_offset_or_iana(val) {
+        return Some(TzInfo::new(tz, None));
+    }
+
+    None
+}
+
+/// Parse UTC offset (e.g. "UTC+3", "UTC-5", "UTC+03:00", "+03") or direct IANA string.
+fn parse_utc_offset_or_iana(s: &str) -> Option<Tz> {
+    let s = s.trim();
+    if let Ok(tz) = s.parse::<Tz>() {
+        return Some(tz);
+    }
+
+    let upper = s.to_uppercase();
+    let offset_str = upper
+        .strip_prefix("UTC")
+        .or_else(|| upper.strip_prefix("GMT"))
+        .unwrap_or(&upper)
+        .trim();
+
+    // Map common fixed offsets to Etc/GMT offsets.
+    // Note: In POSIX/IANA Etc/GMT zones, the sign is inverted (Etc/GMT-3 is UTC+3).
+    let sign_and_num = offset_str
+        .strip_prefix('+')
+        .map(|num| (1, num))
+        .or_else(|| offset_str.strip_prefix('-').map(|num| (-1, num)))?;
+
+    let hours_str = sign_and_num.1.split(':').next()?.trim();
+    let hours: i32 = hours_str.parse().ok()?;
+
+    if hours > 14 || hours < 0 {
+        return None;
+    }
+
+    let total_offset = sign_and_num.0 * hours;
+    etc_gmt_for_offset(total_offset)
+}
+
+/// Convert standard UTC hour offset (e.g. +3 for MSK) to chrono_tz::Tz.
+fn etc_gmt_for_offset(offset: i32) -> Option<Tz> {
+    // POSIX Etc/GMT signs are inverted: UTC+3 is Etc/GMT-3, UTC-5 is Etc/GMT+5.
+    match offset {
+        0 => Some(Tz::UTC),
+        1 => Some(Tz::Etc__GMTMinus1),
+        2 => Some(Tz::Etc__GMTMinus2),
+        3 => Some(Tz::Etc__GMTMinus3),
+        4 => Some(Tz::Etc__GMTMinus4),
+        5 => Some(Tz::Etc__GMTMinus5),
+        6 => Some(Tz::Etc__GMTMinus6),
+        7 => Some(Tz::Etc__GMTMinus7),
+        8 => Some(Tz::Etc__GMTMinus8),
+        9 => Some(Tz::Etc__GMTMinus9),
+        10 => Some(Tz::Etc__GMTMinus10),
+        11 => Some(Tz::Etc__GMTMinus11),
+        12 => Some(Tz::Etc__GMTMinus12),
+        -1 => Some(Tz::Etc__GMTPlus1),
+        -2 => Some(Tz::Etc__GMTPlus2),
+        -3 => Some(Tz::Etc__GMTPlus3),
+        -4 => Some(Tz::Etc__GMTPlus4),
+        -5 => Some(Tz::Etc__GMTPlus5),
+        -6 => Some(Tz::Etc__GMTPlus6),
+        -7 => Some(Tz::Etc__GMTPlus7),
+        -8 => Some(Tz::Etc__GMTPlus8),
+        -9 => Some(Tz::Etc__GMTPlus9),
+        -10 => Some(Tz::Etc__GMTPlus10),
+        -11 => Some(Tz::Etc__GMTPlus11),
+        -12 => Some(Tz::Etc__GMTPlus12),
+        _ => None,
+    }
+}
+
+/// In-memory cache holding resolved user timezone, keyed by file mtime and size.
+#[derive(Debug, Default)]
+pub struct UserTimezoneCache {
+    inner: Mutex<Option<CachedEntry>>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedEntry {
+    mtime: Option<SystemTime>,
+    file_len: u64,
+    resolved: Option<TzInfo>,
+}
+
+impl UserTimezoneCache {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(None),
+        }
+    }
+
+    /// Resolve timezone from `USER.md` in the given brain directory.
+    /// If cached and `USER.md` mtime/size unchanged, returns cached without disk read.
+    pub fn resolve_from_brain_dir(&self, brain_dir: &Path) -> Option<TzInfo> {
+        let user_md_path = brain_dir.join("USER.md");
+        self.resolve_from_file(&user_md_path)
+    }
+
+    /// Resolve timezone from a specific `USER.md` file path.
+    pub fn resolve_from_file(&self, path: &Path) -> Option<TzInfo> {
+        let meta = fs::metadata(path).ok();
+        let current_mtime = meta.as_ref().and_then(|m| m.modified().ok());
+        let current_len = meta.as_ref().map(|m| m.len()).unwrap_or(0);
+
+        {
+            let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(ref entry) = *guard {
+                if entry.mtime == current_mtime && entry.file_len == current_len {
+                    return entry.resolved.clone();
+                }
+            }
+        }
+
+        // Needs re-read or initial read
+        let resolved = if let Ok(content) = fs::read_to_string(path) {
+            parse_timezone_heuristic(&content)
+        } else {
+            None
+        };
+
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(CachedEntry {
+            mtime: current_mtime,
+            file_len: current_len,
+            resolved: resolved.clone(),
+        });
+
+        resolved
+    }
+
+    /// Update or seed the cache explicitly (e.g. after Tier-2 LLM extraction).
+    pub fn set_explicit(&self, path: &Path, resolved: Option<TzInfo>) {
+        let meta = fs::metadata(path).ok();
+        let current_mtime = meta.as_ref().and_then(|m| m.modified().ok());
+        let current_len = meta.as_ref().map(|m| m.len()).unwrap_or(0);
+
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(CachedEntry {
+            mtime: current_mtime,
+            file_len: current_len,
+            resolved,
+        });
+    }
+
+    /// Invalidate cache manually (e.g. on test teardown or explicit notification).
+    pub fn invalidate(&self) {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = None;
+    }
+}
+
+lazy_static::lazy_static! {
+    /// Process-wide singleton cache for user timezone.
+    pub static ref GLOBAL_TZ_CACHE: UserTimezoneCache = UserTimezoneCache::new();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn parse_standard_english_timezone() {
+        let user_md = "\
+# USER
+- **Name:** Alexey
+- **Timezone:** UTC+3 (MSK)
+";
+        let info = parse_timezone_heuristic(user_md).expect("should parse");
+        assert_eq!(info.label.as_deref(), Some("MSK"));
+        let dt = Utc.with_ymd_and_hms(2026, 9, 10, 12, 0, 0).unwrap();
+        let formatted = info.format_dual_time(&dt);
+        assert_eq!(formatted, "2026-09-10 12:00:00 UTC (user: 15:00:00 MSK)");
+    }
+
+    #[test]
+    fn parse_russian_timezone_format() {
+        let user_md = "\
+# Профиль
+- **Часовой пояс:** Москва (UTC+3)
+";
+        let info = parse_timezone_heuristic(user_md).expect("should parse");
+        assert_eq!(info.label.as_deref(), Some("Москва"));
+        let dt = Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap();
+        let formatted = info.format_dual_time(&dt);
+        assert_eq!(formatted, "2026-01-15 10:00:00 UTC (user: 13:00:00 Москва)");
+    }
+
+    #[test]
+    fn parse_iana_timezone_with_dst_transitions() {
+        let user_md = "\
+# USER
+Timezone: Europe/Paris
+";
+        let info = parse_timezone_heuristic(user_md).expect("should parse");
+        assert_eq!(info.tz, Tz::Europe__Paris);
+
+        // Summer: Paris is UTC+2 (CEST)
+        let summer_dt = Utc.with_ymd_and_hms(2026, 7, 1, 12, 0, 0).unwrap();
+        let summer_fmt = info.format_dual_time(&summer_dt);
+        assert_eq!(
+            summer_fmt,
+            "2026-07-01 12:00:00 UTC (user: 14:00:00 Europe/Paris)"
+        );
+
+        // Winter: Paris is UTC+1 (CET)
+        let winter_dt = Utc.with_ymd_and_hms(2026, 12, 1, 12, 0, 0).unwrap();
+        let winter_fmt = info.format_dual_time(&winter_dt);
+        assert_eq!(
+            winter_fmt,
+            "2026-12-01 12:00:00 UTC (user: 13:00:00 Europe/Paris)"
+        );
+    }
+
+    #[test]
+    fn test_caching_and_invalidation() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write!(tmp, "Timezone: UTC+2 (EET)\n").unwrap();
+        tmp.flush().unwrap();
+
+        let cache = UserTimezoneCache::new();
+        let res1 = cache.resolve_from_file(tmp.path()).expect("first resolve");
+        assert_eq!(res1.label.as_deref(), Some("EET"));
+
+        // Rewrite file with new timezone
+        std::thread::sleep(std::time::Duration::from_millis(15));
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(tmp.path())
+            .unwrap();
+        write!(file, "Timezone: UTC+7 (NOVT)\n").unwrap();
+        file.flush().unwrap();
+
+        let res2 = cache.resolve_from_file(tmp.path()).expect("second resolve");
+        assert_eq!(res2.label.as_deref(), Some("NOVT"));
+    }
+
+    #[test]
+    fn test_negative_caching_on_no_match() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write!(tmp, "# Just notes\nNo timezone mentioned here.\n").unwrap();
+        tmp.flush().unwrap();
+
+        let cache = UserTimezoneCache::new();
+        assert!(cache.resolve_from_file(tmp.path()).is_none());
+
+        // Second call hits cache returning None without re-reading
+        assert!(cache.resolve_from_file(tmp.path()).is_none());
+    }
+}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1436,7 +1436,7 @@ fn default_thinking_loop_timeout_secs() -> u64 {
 }
 
 fn default_time_marker_interval_secs() -> u64 {
-    900
+    crate::brain::agent::service::tool_loop::DEFAULT_TIME_MARKER_INTERVAL_SECS
 }
 
 fn default_approval_policy() -> String {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1394,6 +1394,11 @@ pub struct AgentConfig {
     /// Set to 0 to disable.
     #[serde(default = "default_thinking_loop_timeout_secs")]
     pub thinking_loop_timeout_secs: u64,
+
+    /// Interval in seconds for injecting mid-turn time notices in long-running
+    /// tool execution loops (#153). Default: 900 (15 min). Set to 0 to disable.
+    #[serde(default = "default_time_marker_interval_secs")]
+    pub time_marker_interval_secs: u64,
 }
 
 impl AgentConfig {
@@ -1428,6 +1433,10 @@ fn default_debug_logs() -> bool {
 
 fn default_thinking_loop_timeout_secs() -> u64 {
     600
+}
+
+fn default_time_marker_interval_secs() -> u64 {
+    900
 }
 
 fn default_approval_policy() -> String {
@@ -1516,6 +1525,7 @@ impl Default for AgentConfig {
             redact_dm: None,
             debug_logs: default_debug_logs(),
             thinking_loop_timeout_secs: default_thinking_loop_timeout_secs(),
+            time_marker_interval_secs: default_time_marker_interval_secs(),
         }
     }
 }

--- a/src/tests/config_types_loader_test.rs
+++ b/src/tests/config_types_loader_test.rs
@@ -330,6 +330,26 @@ default_provider = "anthropic"
 }
 
 #[test]
+fn test_agent_config_time_marker_interval_secs() {
+    let agent = AgentConfig::default();
+    assert_eq!(agent.time_marker_interval_secs, 900);
+
+    let toml_content = r#"
+[agent]
+time_marker_interval_secs = 1200
+    "#;
+    let config: Config = toml::from_str(toml_content).unwrap();
+    assert_eq!(config.agent.time_marker_interval_secs, 1200);
+
+    let toml_disabled = r#"
+[agent]
+time_marker_interval_secs = 0
+    "#;
+    let config_disabled: Config = toml::from_str(toml_disabled).unwrap();
+    assert_eq!(config_disabled.agent.time_marker_interval_secs, 0);
+}
+
+#[test]
 fn test_agent_config_save_with_default_provider() {
     let temp_file = NamedTempFile::new().unwrap();
     let mut config = Config::default();

--- a/src/tests/datetime_awareness_test.rs
+++ b/src/tests/datetime_awareness_test.rs
@@ -1,0 +1,72 @@
+//! Integration tests for #153 datetime awareness:
+//! 1. Sub-agent tool loop inheritance and temporal grounding
+//! 2. Post-compaction context temporal continuation
+
+use crate::brain::agent::service::AgentService;
+use crate::brain::agent::service::tool_loop::check_intra_turn_time_marker;
+use std::fs;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn subagent_or_worker_turn_ingress_carries_time_marker() {
+    let dir = TempDir::new().unwrap();
+    let user_md = dir.path().join("USER.md");
+    fs::write(&user_md, "Timezone: Europe/Paris\n").unwrap();
+
+    let session_id = Uuid::new_v4();
+    let prompt = "Examine repo health and run diagnostics";
+    let augmented = AgentService::augment_user_message(session_id, prompt, Some(dir.path())).await;
+
+    // Must prepend the temporal marker with dual or UTC time
+    assert!(augmented.starts_with("[Current time: "));
+    assert!(augmented.contains("UTC"));
+    assert!(augmented.contains("user:"));
+    assert!(augmented.ends_with(prompt));
+}
+
+#[test]
+fn intra_turn_evaluator_handles_subagent_and_compaction_cadence() {
+    // When a long task runs across multiple tool iterations or post-compaction:
+    let start = chrono::Utc::now();
+    let interval = 900u64; // 15 minutes
+
+    // Just after compaction or early in turn (< 15 min): no marker injected
+    assert!(
+        check_intra_turn_time_marker(
+            start,
+            start + chrono::Duration::seconds(300),
+            interval,
+            None
+        )
+        .is_none()
+    );
+
+    // Crossing the 15-minute boundary: marker is generated with fresh wall-clock
+    let after_15m = start + chrono::Duration::seconds(901);
+    let marker = check_intra_turn_time_marker(start, after_15m, interval, None);
+    assert!(marker.is_some());
+    let (notice, updated) = marker.unwrap();
+    assert_eq!(updated, after_15m);
+    assert!(notice.starts_with("[System: Current time: "));
+    assert!(notice.contains("UTC"));
+
+    // Subsequent iteration immediately after marker (< 15 min from updated): no marker
+    assert!(
+        check_intra_turn_time_marker(
+            updated,
+            updated + chrono::Duration::seconds(60),
+            interval,
+            None
+        )
+        .is_none()
+    );
+
+    // Next 15m cycle: fires again
+    let next_cycle = updated + chrono::Duration::seconds(905);
+    let marker2 = check_intra_turn_time_marker(updated, next_cycle, interval, None);
+    assert!(marker2.is_some());
+    let (notice2, updated2) = marker2.unwrap();
+    assert_eq!(updated2, next_cycle);
+    assert!(notice2.starts_with("[System: Current time: "));
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -234,6 +234,7 @@ pub mod custom_provider_live_fetch_regression_test;
 pub mod custom_provider_rename_keys_toml_test;
 pub mod custom_provider_section_resolver_test;
 pub mod daily_backup_rotation_test;
+pub mod datetime_awareness_test;
 pub mod db_database_test;
 pub mod db_migration_33_heal_test;
 pub mod db_models_test;

--- a/src/tests/prompt_cache_stability_test.rs
+++ b/src/tests/prompt_cache_stability_test.rs
@@ -1,15 +1,18 @@
-//! Prompt-cache stability of the system brain (#657, #658, #681).
+//! Prompt-cache stability of the system brain (#657, #658, #681, #693, #153).
 //!
 //! The cached prefix must stay byte-stable across turns so the provider prompt
 //! cache hits. #657 first achieved this by making Runtime Info date-only, but
 //! #658 moved the whole Runtime Info block into the UNCACHED suffix (providers
-//! stamp cache_control on the stable prefix only). Once the block is uncached, a
-//! per-second timestamp no longer touches the cached prefix — so #681 restored
-//! the full `Current date & time` line for time-of-day awareness.
+//! stamp cache_control on the stable prefix only). However, #693 disabled the
+//! split because the array-shaped 2-part system broke tool calling, sending the
+//! entire system prompt as a single string.
 //!
-//! These tests lock the real invariant: the CACHED PREFIX (what
-//! `split_runtime_suffix` leaves behind) is byte-stable even though the suffix
-//! carries a second-granular timestamp, and the split boundary keeps per-session
+//! Under #153, Runtime Info carries `Current date: YYYY-MM-DD (UTC)` (date-only),
+//! while live wall-clock awareness is injected into message-tail markers. This keeps
+//! the system prompt byte-stable for 24h while preserving temporal grounding.
+//!
+//! These tests lock the real invariant: both CACHED PREFIX and suffix are byte-stable
+//! across builds within the same UTC day, and the split boundary keeps per-session
 //! lines in the suffix while per-instance constants (Known paths, compiled
 //! features) stay cached.
 
@@ -42,16 +45,16 @@ fn contains_seconds_time(s: &str) -> bool {
 }
 
 #[test]
-fn runtime_info_now_carries_full_timestamp() {
-    // #681: time-of-day restored. The block must render a full date+time line
-    // (seconds present) since it rides uncached.
+fn runtime_info_carries_date_only() {
+    // #153: system prompt carries date-only. The block must render a YYYY-MM-DD
+    // line without volatile time-of-day (seconds absent).
     for brain in [
         loader().1.build_system_brain(Some(&runtime_info())),
         loader().1.build_core_brain(Some(&runtime_info())),
     ] {
         assert!(
-            brain.contains("Current date & time:"),
-            "expected a full date+time line, got:\n{}",
+            brain.contains("Current date:"),
+            "expected date-only line, got:\n{}",
             brain
                 .lines()
                 .filter(|l| l.contains("date") || l.contains("Runtime"))
@@ -59,42 +62,48 @@ fn runtime_info_now_carries_full_timestamp() {
                 .join("\n")
         );
         assert!(
-            contains_seconds_time(&brain),
-            "the restored timestamp must include HH:MM:SS"
+            !brain.contains("Current date & time:"),
+            "system prompt should not contain volatile time-of-day"
+        );
+        assert!(
+            !contains_seconds_time(&brain),
+            "system prompt must not include HH:MM:SS"
         );
     }
 }
 
 #[test]
-fn cached_prefix_is_byte_stable_despite_second_granular_time() {
-    // The real cache guarantee post-#658: the timestamp lives in the UNCACHED
-    // suffix, so the cached PREFIX is byte-identical across builds even when the
-    // clock ticks between them. (Two full brains may differ by a second; their
-    // prefixes must not.)
+fn cached_prefix_and_suffix_are_byte_stable_with_date_only() {
+    // Under date-only timestamps, both prefix and suffix are byte-identical
+    // across builds within the same day.
     let (_dir, loader) = loader();
     let a = loader.build_system_brain(Some(&runtime_info()));
     let b = loader.build_system_brain(Some(&runtime_info()));
     let (prefix_a, suffix_a) = split_runtime_suffix(&a);
-    let (prefix_b, _suffix_b) = split_runtime_suffix(&b);
+    let (prefix_b, suffix_b) = split_runtime_suffix(&b);
     assert_eq!(
         prefix_a, prefix_b,
         "the cached prefix must be byte-stable across builds (#658)"
     );
-    // The volatile timestamp belongs to the suffix, never the prefix.
+    assert_eq!(
+        suffix_a, suffix_b,
+        "the suffix must be byte-stable across builds on the same date (#153)"
+    );
+    // Neither prefix nor suffix should carry seconds.
     assert!(
         !contains_seconds_time(&prefix_a),
-        "a per-second timestamp leaked into the CACHED prefix (#658/#681)"
+        "seconds timestamp leaked into CACHED prefix"
     );
     assert!(
-        contains_seconds_time(suffix_a.as_deref().unwrap_or("")),
-        "the timestamp must ride in the uncached suffix"
+        !contains_seconds_time(suffix_a.as_deref().unwrap_or("")),
+        "seconds timestamp leaked into suffix"
     );
 }
 
 #[test]
 fn split_boundary_keeps_session_lines_in_suffix_and_constants_cached() {
     // #681 GAP 3: lock the split boundary. Per-SESSION lines (model, provider,
-    // working directory, date-time) ride in the uncached suffix; per-INSTANCE
+    // working directory, date) ride in the uncached suffix; per-INSTANCE
     // constants (Known paths, compiled features) stay in the cached prefix.
     let (_dir, loader) = loader();
     let brain = loader.build_system_brain(Some(&runtime_info()));
@@ -105,7 +114,7 @@ fn split_boundary_keeps_session_lines_in_suffix_and_constants_cached() {
         "Model: test-model",
         "Provider: test-provider",
         "Working directory:",
-        "Current date & time:",
+        "Current date:",
     ] {
         assert!(
             suffix.contains(volatile),

--- a/src/tests/tool_loop_helpers_test.rs
+++ b/src/tests/tool_loop_helpers_test.rs
@@ -22,9 +22,9 @@
 //! `src/tests/`) keeps the test surface flat.
 
 use crate::brain::agent::service::tool_loop::{
-    RepeatLoopAction, build_tool_result_content, extract_path_for_recent_buffer,
-    is_duplicate_iteration_text, is_implausible_token_report, is_user_correction,
-    repeat_loop_action, strip_ansi_output,
+    DEFAULT_TIME_MARKER_INTERVAL_SECS, RepeatLoopAction, build_tool_result_content,
+    check_intra_turn_time_marker, extract_path_for_recent_buffer, is_duplicate_iteration_text,
+    is_implausible_token_report, is_user_correction, repeat_loop_action, strip_ansi_output,
 };
 use serde_json::json;
 use std::path::PathBuf;
@@ -585,4 +585,56 @@ fn duplicate_text_catches_a_substring_of_longer_accumulated_text() {
         accumulated,
         "All 112 passed, 0 failed."
     ));
+}
+
+// ── check_intra_turn_time_marker ────────────────────────────────────
+
+#[test]
+fn intra_turn_time_marker_defaults_and_suppression() {
+    assert_eq!(DEFAULT_TIME_MARKER_INTERVAL_SECS, 900);
+
+    let start = chrono::Utc::now();
+    // 0 interval disables the check entirely
+    assert!(
+        check_intra_turn_time_marker(start, start + chrono::Duration::seconds(1800), 0, None)
+            .is_none()
+    );
+
+    // Less than interval elapsed -> None
+    let under = start + chrono::Duration::seconds(899);
+    assert!(check_intra_turn_time_marker(start, under, 900, None).is_none());
+}
+
+#[test]
+fn intra_turn_time_marker_fires_at_or_above_interval_with_utc_fallback() {
+    let start = chrono::Utc::now();
+    let exact = start + chrono::Duration::seconds(900);
+    let res = check_intra_turn_time_marker(start, exact, 900, None);
+    assert!(res.is_some());
+    let (notice, updated_time) = res.unwrap();
+    assert_eq!(updated_time, exact);
+    assert!(notice.starts_with("[System: Current time: "));
+    assert!(notice.contains("UTC"));
+    assert!(!notice.contains("(user:"));
+    assert!(notice.ends_with(']'));
+}
+
+#[test]
+fn intra_turn_time_marker_resolves_user_timezone_from_brain() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let dir = TempDir::new().unwrap();
+    let user_md = dir.path().join("USER.md");
+    fs::write(&user_md, "Timezone: UTC+3 (MSK)\n").unwrap();
+
+    let start = chrono::Utc::now();
+    let elapsed = start + chrono::Duration::seconds(1200);
+    let res = check_intra_turn_time_marker(start, elapsed, 900, Some(dir.path()));
+    assert!(res.is_some());
+    let (notice, _) = res.unwrap();
+    assert!(notice.starts_with("[System: Current time: "));
+    assert!(notice.contains("UTC"));
+    assert!(notice.contains("MSK"));
+    assert!(notice.ends_with(']'));
 }


### PR DESCRIPTION
## Summary
- Temporal grounding via turn-ingress dual-time marker (`[Current time: YYYY-MM-DD HH:MM:SS UTC (user: HH:MM:SS TZ)]`)
- Demote system prompt date to date-only for cache stability
- User timezone resolution and caching with DST support from `USER.md`
- Configurable time notice interval (`agent.time_marker_interval_secs`, defaults to 900s)

## Verification
- CI gate run: https://github.com/leshchenko1979/opencrabs/actions/runs/34639850803 (PASS)
- Behavioral probe: live dual-time marker injected on turn ingress across agent sessions.

Fork-Issue: https://github.com/leshchenko1979/opencrabs/issues/153