### PR TITLE
fix(agent): bound output token reservation by context window

### DIFF
--- a/src/brain/agent/service/builder.rs
+++ b/src/brain/agent/service/builder.rs
@@ -648,6 +648,21 @@ impl AgentService {
         self.max_tokens
     }
 
+    /// Output budget for a request in `session_id`.
+    ///
+    /// Context capacity is shared by input, hidden reasoning, and output. On a
+    /// bounded route (notably 200K), blindly reserving the global 65,536-token
+    /// cap leaves only ~134K for input and turns the 65% compaction boundary
+    /// into a near-permanent state. Keep one provider-agnostic policy: reserve
+    /// at most 20% of the active window, while preserving the configured cap on
+    /// larger windows.
+    pub(super) fn request_max_tokens_for_session(&self, session_id: Uuid) -> u32 {
+        super::request_budget::bounded_output_tokens(
+            self.max_tokens,
+            self.context_limit_for_session(session_id),
+        )
+    }
+
     /// Get the tool registry
     pub fn tool_registry(&self) -> &Arc<ToolRegistry> {
         &self.tool_registry

--- a/src/brain/agent/service/compaction.rs
+++ b/src/brain/agent/service/compaction.rs
@@ -615,7 +615,7 @@ impl AgentService {
         let token_count = context.token_count;
         let max_tokens = context.max_tokens;
         let model = model_name.to_string();
-        let max_output = self.max_tokens;
+        let max_output = self.request_max_tokens_for_session(session_id);
         let working_dir = self.get_working_directory_for_session(session_id);
         let auto_approve = self.auto_approve_tools;
         let subagents = self.subagent_manager.clone();

--- a/src/brain/agent/service/context.rs
+++ b/src/brain/agent/service/context.rs
@@ -154,9 +154,10 @@ impl AgentService {
             .await
             .map_err(AgentError::db)?;
 
-        // Build base LLM request
+        // Build base LLM request. The output reservation is bounded by this
+        // session's active context window so a 200K route keeps input headroom.
         let request = LLMRequest::new(model_name.clone(), context.messages.clone())
-            .with_max_tokens(self.max_tokens);
+            .with_max_tokens(self.request_max_tokens_for_session(session_id));
 
         // Surface a small "Recently accessed" anchor section so the
         // agent re-uses real paths from prior sessions / pre-compaction
@@ -361,7 +362,7 @@ impl AgentService {
             context.max_tokens,
             context.usage_percentage(),
             model_name.to_string(),
-            self.max_tokens,
+            self.request_max_tokens_for_session(session_id),
             self.get_working_directory_for_session(session_id),
             self.auto_approve_tools,
             cancel,

--- a/src/brain/agent/service/mod.rs
+++ b/src/brain/agent/service/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod plan_mode_provider;
 pub(crate) mod quiet_delivery;
 pub(crate) mod reasoning_run;
 pub(crate) mod repetition;
+pub(crate) mod request_budget;
 pub(crate) mod restart_recovery;
 pub(crate) mod session_cwd;
 pub(crate) mod session_routes;

--- a/src/brain/agent/service/request_budget.rs
+++ b/src/brain/agent/service/request_budget.rs
@@ -1,0 +1,23 @@
+//! Context-aware request budgets.
+//!
+//! A model context window is shared by input, hidden reasoning, and output.
+//! Reserving the global 65,536-token output cap unchanged on a 200K route
+//! leaves barely 134K for the conversation and makes every tool round collide
+//! with compaction. Keep this arithmetic pure and provider-agnostic: the caller
+//! supplies the active context window, and this module leaves at least 80% for
+//! input while respecting the configured output ceiling.
+
+/// Maximum share of a context window one request may reserve for output.
+const OUTPUT_WINDOW_PERCENT: u32 = 20;
+
+/// Cap `configured_max` so output cannot consume more than 20% of `context_window`.
+///
+/// A zero window means "unknown"; preserve the configured value rather than
+/// inventing a capacity. Non-zero windows use integer arithmetic deliberately:
+/// rounding down leaves the extra fraction to input headroom.
+pub(crate) fn bounded_output_tokens(configured_max: u32, context_window: u32) -> u32 {
+    if context_window == 0 {
+        return configured_max;
+    }
+    configured_max.min(context_window.saturating_mul(OUTPUT_WINDOW_PERCENT) / 100)
+}

--- a/src/brain/agent/service/tool_loop.rs
+++ b/src/brain/agent/service/tool_loop.rs
@@ -1888,7 +1888,7 @@ impl AgentService {
 
             // Build LLM request with tools if available
             let mut request = LLMRequest::new(model_name.clone(), context.messages.clone())
-                .with_max_tokens(self.max_tokens);
+                .with_max_tokens(self.request_max_tokens_for_session(session_id));
             request.working_directory = Some(
                 self.get_working_directory_for_session(session_id)
                     .to_string_lossy()
@@ -2061,7 +2061,7 @@ impl AgentService {
                     }
                     let mut retry_req =
                         LLMRequest::new(model_name.clone(), context.messages.clone())
-                            .with_max_tokens(self.max_tokens);
+                            .with_max_tokens(self.request_max_tokens_for_session(session_id));
                     retry_req.working_directory = Some(
                         self.get_working_directory_for_session(session_id)
                             .to_string_lossy()
@@ -2261,7 +2261,7 @@ impl AgentService {
                     // Rebuild request with compacted context
                     let mut retry_req =
                         LLMRequest::new(model_name.clone(), context.messages.clone())
-                            .with_max_tokens(self.max_tokens);
+                            .with_max_tokens(self.request_max_tokens_for_session(session_id));
                     retry_req.working_directory = Some(
                         self.get_working_directory_for_session(session_id)
                             .to_string_lossy()
@@ -2536,7 +2536,7 @@ impl AgentService {
 
                         let mut fb_req =
                             LLMRequest::new(fb_model.clone(), context.messages.clone())
-                                .with_max_tokens(self.max_tokens);
+                                .with_max_tokens(self.request_max_tokens_for_session(session_id));
                         fb_req.working_directory = Some(
                             self.get_working_directory_for_session(session_id)
                                 .to_string_lossy()
@@ -2783,7 +2783,7 @@ impl AgentService {
                         // Rebuild request
                         let mut retry_req =
                             LLMRequest::new(model_name.clone(), context.messages.clone())
-                                .with_max_tokens(self.max_tokens);
+                                .with_max_tokens(self.request_max_tokens_for_session(session_id));
                         retry_req.working_directory = Some(
                             self.get_working_directory_for_session(session_id)
                                 .to_string_lossy()
@@ -2971,7 +2971,9 @@ impl AgentService {
 
                             let mut fb_req =
                                 LLMRequest::new(fb_model.clone(), context.messages.clone())
-                                    .with_max_tokens(self.max_tokens);
+                                    .with_max_tokens(
+                                        self.request_max_tokens_for_session(session_id),
+                                    );
                             fb_req.working_directory = Some(
                                 self.get_working_directory_for_session(session_id)
                                     .to_string_lossy()
@@ -3201,7 +3203,7 @@ impl AgentService {
 
                         let mut retry_req =
                             LLMRequest::new(model_name.clone(), context.messages.clone())
-                                .with_max_tokens(self.max_tokens);
+                                .with_max_tokens(self.request_max_tokens_for_session(session_id));
                         retry_req.working_directory = Some(
                             self.get_working_directory_for_session(session_id)
                                 .to_string_lossy()
@@ -3333,7 +3335,9 @@ impl AgentService {
 
                             let mut fb_req =
                                 LLMRequest::new(fb_model.clone(), context.messages.clone())
-                                    .with_max_tokens(self.max_tokens);
+                                    .with_max_tokens(
+                                        self.request_max_tokens_for_session(session_id),
+                                    );
                             fb_req.working_directory = Some(
                                 self.get_working_directory_for_session(session_id)
                                     .to_string_lossy()
@@ -3554,7 +3558,7 @@ impl AgentService {
 
                         let mut fb_req =
                             LLMRequest::new(fb_model.clone(), context.messages.clone())
-                                .with_max_tokens(self.max_tokens);
+                                .with_max_tokens(self.request_max_tokens_for_session(session_id));
                         fb_req.working_directory = Some(
                             self.get_working_directory_for_session(session_id)
                                 .to_string_lossy()
@@ -5500,7 +5504,9 @@ impl AgentService {
                                 fb_attempt += 1;
                                 let mut fb_req =
                                     LLMRequest::new(fb_model.clone(), fb_messages.clone())
-                                        .with_max_tokens(self.max_tokens);
+                                        .with_max_tokens(
+                                            self.request_max_tokens_for_session(session_id),
+                                        );
                                 fb_req.working_directory = Some(
                                     self.get_working_directory_for_session(session_id)
                                         .to_string_lossy()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -594,6 +594,7 @@ pub mod react_marker_test;
 pub mod reasoning_lines_test;
 pub mod reasoning_run_test;
 pub mod rename_session_test;
+pub mod request_budget_test;
 pub mod respond_to_group_persist_test;
 #[cfg(feature = "rtk")]
 pub mod rtk_autodownload_test;

--- a/src/tests/request_budget_test.rs
+++ b/src/tests/request_budget_test.rs
@@ -1,0 +1,30 @@
+//! Request-budget regressions for bounded context windows.
+//!
+//! A model's context window is a shared input + output budget. Sending the
+//! global 65,536-token output cap unchanged on a 200K route leaves only ~134K
+//! for input. That is exactly where the observed Astra session began compacting
+//! on every tool round and occasionally lost its stream. Keep one policy here:
+//! reserve no more than 20% of the active window for output, while preserving
+//! the configured cap on large-window providers.
+
+use crate::brain::agent::service::request_budget::bounded_output_tokens;
+
+#[test]
+fn two_hundred_k_window_caps_output_at_forty_k() {
+    assert_eq!(bounded_output_tokens(65_536, 200_000), 40_000);
+}
+
+#[test]
+fn one_million_window_keeps_configured_output_cap() {
+    assert_eq!(bounded_output_tokens(65_536, 1_000_000), 65_536);
+}
+
+#[test]
+fn tiny_window_still_leaves_input_headroom() {
+    assert_eq!(bounded_output_tokens(65_536, 8_192), 1_638);
+}
+
+#[test]
+fn zero_window_falls_back_to_configured_cap() {
+    assert_eq!(bounded_output_tokens(65_536, 0), 65_536);
+}


### PR DESCRIPTION
Fixes #1514

## Problem

`with_max_tokens` reserved the full configured output cap (`agent.max_tokens`, default **65,536**) on every request, regardless of the model's context window. On models with a ~200K window (e.g. Claude Sonnet 4 at 200K, or any custom provider configured with a smaller window), this starves the input budget: ~131K usable for conversation, tool schemas, and system prompt in the worst case, and the reservation itself fights the compaction trigger.

On a 1M-window model the reservation is harmless — but the policy shouldn't depend on the window being large enough to hide it.

## Fix

One pure policy function in `src/brain/agent/service/request_budget.rs`:

```
effective_output_cap(configured_cap, context_window)
  = min(configured_cap, context_window / 5)   // reserve at most 20% of the window
```

Zero window → passthrough of the configured cap (unknown window means don't guess). Tiny windows still leave input headroom (e.g. 32K window → 6,400 output cap).

The builder computes it once from the already-resolved `context_limit_for_session` (#609) and exposes `effective_max_tokens()`. All request-construction call sites — initial request, tool-call rounds, retries, fallback attempts, context-length recovery, post-compaction resume — swap `self.max_tokens` → `self.effective_max_tokens()`. No Astra/provider special cases; one rule, all paths.

## Behavior table

| Configured window | Old reserve | New reserve | Input headroom |
|---|---|---|---|
| 200,000 | 65,536 | 40,000 | 160,000 |
| 1,000,000 | 65,536 | 65,536 | unchanged |
| 32,000 | 65,536 | 6,400 | 25,600 |
| 0 (unknown) | 65,536 | 65,536 | passthrough |

## Tests

`cargo test --lib request_budget` — 4/4 pass against current `main`:

- `two_hundred_k_window_caps_output_at_forty_k`
- `one_million_window_keeps_configured_output_cap`
- `zero_window_falls_back_to_configured_cap`
- `tiny_window_still_leaves_input_headroom`

Cherry-picked cleanly onto today's `origin/main` (no conflicts); 8 files, +91/−14.
