### PR TITLE
fix(whatsapp): route whatsapp_send to session chat before owner fallback and resolve LID sender_alt

### DIFF
--- a/src/brain/tools/whatsapp_send.rs
+++ b/src/brain/tools/whatsapp_send.rs
@@ -77,29 +77,42 @@ async fn get_client(
     })
 }
 
-/// Resolve target JID from `phone` param or owner, with allowlist check.
+/// Resolve target JID from `phone` param, originating session, or owner fallback,
+/// with allowlist check.
 #[allow(clippy::result_large_err)]
-async fn resolve_jid(
+pub(crate) async fn resolve_jid(
     input: &Value,
     whatsapp_state: &WhatsAppState,
     config_rx: &tokio::sync::watch::Receiver<Config>,
+    session_id: uuid::Uuid,
 ) -> std::result::Result<(Jid, String), ToolResult> {
-    if let Some(phone) = input.get("phone").and_then(|v| v.as_str()) {
+    if let Some(raw_target) = input.get("phone").and_then(|v| v.as_str()) {
         let allowed = &config_rx.borrow().channels.whatsapp.allowed_phones;
-        let normalized = phone.trim_start_matches('+');
+        let target_clean = raw_target.trim().trim_start_matches('+');
+        let user_part = target_clean
+            .split('@')
+            .next()
+            .unwrap_or(target_clean)
+            .split(':')
+            .next()
+            .unwrap_or(target_clean);
+
         let phone_allowed = allowed.is_empty()
             || allowed
                 .iter()
-                .any(|p| p.trim_start_matches('+') == normalized);
+                .any(|p| p.trim_start_matches('+') == user_part);
         if !phone_allowed {
             return Err(ToolResult::error(format!(
                 "Sending to {} is not permitted. This number is not in the \
                  allowed_users config.",
-                phone
+                raw_target
             )));
         }
-        let digits = phone.trim_start_matches('+');
-        let jid_str = format!("{}@s.whatsapp.net", digits);
+        let jid_str = if target_clean.contains('@') {
+            target_clean.to_string()
+        } else {
+            format!("{}@s.whatsapp.net", user_part)
+        };
         let jid: Jid = jid_str
             .parse()
             .map_err(|e| ToolResult::error(format!("Invalid phone number format: {}", e)))?;
@@ -109,6 +122,16 @@ async fn resolve_jid(
             return Err(ToolResult::error(reason));
         }
         Ok((jid, jid_str))
+    } else if let Some(session_jid_str) = whatsapp_state.session_jid(session_id).await {
+        let jid: Jid = session_jid_str
+            .parse()
+            .map_err(|e| ToolResult::error(format!("Invalid session chat JID: {}", e)))?;
+        if !crate::cron::send_scope::may_send("whatsapp", &session_jid_str) {
+            let reason = crate::cron::send_scope::refusal_for("whatsapp", &session_jid_str);
+            tracing::warn!("whatsapp_send: {reason}");
+            return Err(ToolResult::error(reason));
+        }
+        Ok((jid, session_jid_str))
     } else {
         let jid_str = whatsapp_state.owner_jid().await.ok_or_else(|| {
             ToolResult::error(
@@ -383,7 +406,7 @@ impl Tool for WhatsAppSendTool {
         }
     }
 
-    async fn execute(&self, input: Value, _context: &ToolExecutionContext) -> Result<ToolResult> {
+    async fn execute(&self, input: Value, context: &ToolExecutionContext) -> Result<ToolResult> {
         let action = match input.get("action").and_then(|v| v.as_str()) {
             Some(a) if !a.is_empty() => a.to_string(),
             _ => {
@@ -407,7 +430,7 @@ impl Tool for WhatsAppSendTool {
                     }
                 };
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
 
                 // Convert markdown to WhatsApp format and prepend agent header
                 let message = crate::utils::slack_fmt::markdown_to_mrkdwn(&message);
@@ -485,7 +508,7 @@ impl Tool for WhatsAppSendTool {
             "reply" => {
                 let message = pget!(get_str(&input, "message")).to_string();
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let msg_id = pget!(get_str(&input, "message_id")).to_string();
 
                 let formatted = crate::utils::slack_fmt::markdown_to_mrkdwn(&message);
@@ -582,7 +605,7 @@ impl Tool for WhatsAppSendTool {
             // ── delete ───────────────────────────────────────────────────────
             "delete" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let msg_id = pget!(get_str(&input, "message_id")).to_string();
 
                 match client
@@ -603,7 +626,7 @@ impl Tool for WhatsAppSendTool {
             // ── send_photo ───────────────────────────────────────────────────
             "send_photo" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let path = pget!(get_str(&input, "media_path")).to_string();
                 let caption = input
                     .get("caption")
@@ -640,7 +663,7 @@ impl Tool for WhatsAppSendTool {
             // ── send_document ────────────────────────────────────────────────
             "send_document" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let path = pget!(get_str(&input, "media_path")).to_string();
                 let caption = input
                     .get("caption")
@@ -680,7 +703,7 @@ impl Tool for WhatsAppSendTool {
             // ── send_audio ───────────────────────────────────────────────────
             "send_audio" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let path = pget!(get_str(&input, "media_path")).to_string();
 
                 let (bytes, mime, _filename) = pget!(read_local_media(&path, "audio/ogg").await);
@@ -712,7 +735,7 @@ impl Tool for WhatsAppSendTool {
             // ── send_video ───────────────────────────────────────────────────
             "send_video" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let path = pget!(get_str(&input, "media_path")).to_string();
                 let caption = input
                     .get("caption")
@@ -749,7 +772,7 @@ impl Tool for WhatsAppSendTool {
             // ── send_sticker ─────────────────────────────────────────────────
             "send_sticker" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let path = pget!(get_str(&input, "media_path")).to_string();
 
                 let (bytes, mime, _filename) = pget!(read_local_media(&path, "image/webp").await);
@@ -781,7 +804,7 @@ impl Tool for WhatsAppSendTool {
             // ── send_location ────────────────────────────────────────────────
             "send_location" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let lat = match get_f64(&input, "latitude") {
                     Some(v) => v,
                     None => {
@@ -829,7 +852,7 @@ impl Tool for WhatsAppSendTool {
             // ── send_contact ─────────────────────────────────────────────────
             "send_contact" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let contact_name = pget!(get_str(&input, "contact_name")).to_string();
                 let contact_phone = pget!(get_str(&input, "contact_phone")).to_string();
 
@@ -854,7 +877,7 @@ impl Tool for WhatsAppSendTool {
             // ── react ────────────────────────────────────────────────────────
             "react" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let msg_id = pget!(get_str(&input, "message_id")).to_string();
                 let emoji = input
                     .get("emoji")
@@ -921,7 +944,7 @@ impl Tool for WhatsAppSendTool {
             // ── send_poll ────────────────────────────────────────────────────
             "send_poll" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let question = pget!(get_str(&input, "poll_question")).to_string();
                 let opts: Vec<String> = match input.get("poll_options").and_then(|v| v.as_array()) {
                     Some(arr) => arr
@@ -983,7 +1006,7 @@ impl Tool for WhatsAppSendTool {
             // ── typing ───────────────────────────────────────────────────────
             "typing" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let active = input
                     .get("typing_active")
                     .and_then(|v| v.as_bool())
@@ -1010,7 +1033,7 @@ impl Tool for WhatsAppSendTool {
             // ── mark_read ────────────────────────────────────────────────────
             "mark_read" => {
                 let (jid, jid_str) =
-                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx).await);
+                    pget!(resolve_jid(&input, &self.whatsapp_state, &self.config_rx, context.session_id).await);
                 let msg_id = pget!(get_str(&input, "message_id")).to_string();
 
                 // Build read receipt node manually (send_protocol_receipt is pub(crate))

--- a/src/channels/whatsapp/handler.rs
+++ b/src/channels/whatsapp/handler.rs
@@ -653,7 +653,11 @@ pub(crate) async fn handle_message(
     };
     let session_phone = match (is_owner_self_chat, &owner_number) {
         (true, Some(num)) => num.clone(),
-        _ => phone.clone(),
+        _ => sender_alt_user
+            .as_deref()
+            .filter(|alt| !alt.is_empty())
+            .unwrap_or(&phone)
+            .to_string(),
     };
 
     // Where ALL agent output for this turn is sent. For the owner self-chat the
@@ -706,7 +710,13 @@ pub(crate) async fn handle_message(
     // resolver over allowed_phones + bot_owner.
     let is_owner = is_owner_self_chat
         || owner_number.as_deref() == Some(phone.as_str())
-        || crate::config::owner::is_owner(&wa_cfg.allowed_phones, &wa_cfg.bot_owner, &phone);
+        || sender_alt_user
+            .as_deref()
+            .is_some_and(|alt| owner_number.as_deref() == Some(alt))
+        || crate::config::owner::is_owner(&wa_cfg.allowed_phones, &wa_cfg.bot_owner, &phone)
+        || sender_alt_user.as_deref().is_some_and(|alt| {
+            crate::config::owner::is_owner(&wa_cfg.allowed_phones, &wa_cfg.bot_owner, alt)
+        });
 
     // Sessions are keyed by a stable `[chat:wa-<phone>]` suffix so auto-rename
     // of the visible label still resolves to the same row (issue #121).
@@ -1056,7 +1066,7 @@ pub(crate) async fn handle_message(
     // so photo requests fell back to generic tools or bare paths).
     // Surface the chat JID so the agent can target THIS chat for cron reports
     // without guessing (#533, mirror of upstream #510).
-    let chat_id = info.source.chat.to_string();
+    let chat_id = reply_target.to_string();
     let agent_input = format!(
         "[Channel: WhatsApp (chat_id: {chat_id}) — your text response is automatically sent to this chat. \
          Do NOT call whatsapp_send to deliver your answer. Only use whatsapp_send for: \

--- a/src/tests/brain_tools_whatsapp_send_test.rs
+++ b/src/tests/brain_tools_whatsapp_send_test.rs
@@ -2,7 +2,7 @@
 
 use crate::brain::tools::whatsapp_send::{
     build_vcard, delivered_prefix, get_f64, get_str, mime_from_extension, partial_failure_report,
-    tag_with_header,
+    resolve_jid, tag_with_header,
 };
 use serde_json::json;
 
@@ -379,4 +379,66 @@ fn reply_arm_chunks_with_quote_only_on_lead() {
         arm.contains("persist_outgoing(&jid, &tagged)"),
         "reply success must persist the tagged form"
     );
+}
+
+// ── resolve_jid: session origin vs owner fallback ───────────────────
+
+#[tokio::test]
+async fn resolve_jid_targets_session_chat_when_phone_omitted() {
+    let state = crate::channels::whatsapp::WhatsAppState::new();
+    let session_id = uuid::Uuid::new_v4();
+    state
+        .register_session_jid(session_id, "6285270679623@s.whatsapp.net".to_string())
+        .await;
+    state
+        .set_owner_jid("6282361295343@s.whatsapp.net".to_string())
+        .await;
+
+    let (_tx, rx) = tokio::sync::watch::channel(crate::config::Config::default());
+    let input = json!({});
+
+    let res = resolve_jid(&input, &state, &rx, session_id).await;
+    assert!(res.is_ok(), "resolve_jid failed: {:?}", res);
+    let (jid, jid_str) = res.unwrap();
+    assert_eq!(jid_str, "6285270679623@s.whatsapp.net");
+    assert_eq!(jid.to_string(), "6285270679623@s.whatsapp.net");
+}
+
+#[tokio::test]
+async fn resolve_jid_falls_back_to_owner_when_no_session_chat() {
+    let state = crate::channels::whatsapp::WhatsAppState::new();
+    let unmapped_session = uuid::Uuid::new_v4();
+    state
+        .set_owner_jid("6282361295343@s.whatsapp.net".to_string())
+        .await;
+
+    let (_tx, rx) = tokio::sync::watch::channel(crate::config::Config::default());
+    let input = json!({});
+
+    let res = resolve_jid(&input, &state, &rx, unmapped_session).await;
+    assert!(res.is_ok(), "resolve_jid failed: {:?}", res);
+    let (jid, jid_str) = res.unwrap();
+    assert_eq!(jid_str, "6282361295343@s.whatsapp.net");
+    assert_eq!(jid.to_string(), "6282361295343@s.whatsapp.net");
+}
+
+#[tokio::test]
+async fn resolve_jid_normalizes_raw_target_number() {
+    let state = crate::channels::whatsapp::WhatsAppState::new();
+    let session_id = uuid::Uuid::new_v4();
+    let mut cfg = crate::config::Config::default();
+    cfg.channels.whatsapp.allowed_phones = vec!["6285270679623".to_string()];
+    let (_tx, rx) = tokio::sync::watch::channel(cfg);
+
+    // Test with plus prefix
+    let input_plus = json!({"phone": "+6285270679623"});
+    let res = resolve_jid(&input_plus, &state, &rx, session_id).await;
+    assert!(res.is_ok(), "resolve_jid plus failed: {:?}", res);
+    assert_eq!(res.unwrap().1, "6285270679623@s.whatsapp.net");
+
+    // Test with JID format directly
+    let input_jid = json!({"phone": "6285270679623@s.whatsapp.net"});
+    let res_jid = resolve_jid(&input_jid, &state, &rx, session_id).await;
+    assert!(res_jid.is_ok(), "resolve_jid JID failed: {:?}", res_jid);
+    assert_eq!(res_jid.unwrap().1, "6285270679623@s.whatsapp.net");
 }


### PR DESCRIPTION
## Summary

Fixes an issue where `whatsapp_send` targets the owner's phone number instead of the active chat when called from non-owner chats or secondary numbers, and resolves LID-addressed sessions to their real phone number.

### Root Cause & Trace

1. **Target resolution in `whatsapp_send.rs`**:
   - In `resolve_jid`, when the model omitted the `phone` argument (which is common when sending files, media, or polls within the active chat), the function unconditionally defaulted to `whatsapp_state.owner_jid()`.
   - In Telegram, `telegram_send` first checks `state.session_chat(session_id)` before falling back to `owner_chat_id()`. WhatsApp was missing this session check even though `whatsapp_state.session_jid(session_id)` is registered on every turn (#731).
   - Furthermore, when the model passed a raw target number or an existing JID, `resolve_jid` stripped the number and unconditionally appended `@s.whatsapp.net`, failing on valid full JIDs.

2. **LID session keying & preamble chat ID in `handler.rs`**:
   - Modern WhatsApp 1:1 DMs frequently arrive with LID JIDs (`<lid>@lid`). The handler was keying `session_phone` strictly by `phone` (the raw LID string), creating orphaned sessions named `wa-<LID>` instead of linking to the contact's phone number (`sender_alt`).
   - The turn preamble in `handler.rs` exposed `info.source.chat` (the LID JID) to the LLM. If the model then called `whatsapp_send(phone="<lid>@lid")`, the allowlist check failed because `allowed_phones` lists phone numbers, not opaque LID hashes.
   - Ownership checks now also evaluate `sender_alt` so an allow-listed owner messaging from a secondary client or LID identity is recognized.

### Changes

- **`src/brain/tools/whatsapp_send.rs`**:
  - `resolve_jid` now takes `context.session_id` from `ToolExecutionContext`.
  - Resolution precedence is now: explicit `phone` > `whatsapp_state.session_jid(session_id)` > `whatsapp_state.owner_jid()`.
  - Normalized target parsing preserves full JIDs when provided and maps `+<digits>` cleanly.
- **`src/channels/whatsapp/handler.rs`**:
  - `session_phone` prefers `sender_alt_user` over raw LID `phone` when available.
  - `is_owner` matches against both `phone` and `sender_alt_user`.
  - Preamble `chat_id` is populated from `reply_target` (the deliverable PN JID) rather than the raw un-routable LID.
- **`src/tests/brain_tools_whatsapp_send_test.rs`**:
  - Added unit tests for `resolve_jid` targeting session origin chat, owner fallback when unmapped, and raw input normalization.

### Verification
- Added 3 regression tests covering session origin resolution, owner fallback, and JID normalization.
